### PR TITLE
Make GOOS=js GOARCH=wasm a possible build target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `filewriter` now has a wasm target, which though noop makes wasm a possible build target.
 - `blockservice` now has `ContextWithSession` and `EmbedSessionInContext` functions, which allows to embed a session in a context. Future calls to `BlockGetter.GetBlock`, `BlockGetter.GetBlocks` and `NewSession` will use the session in the context.
 - `blockservice.NewWritethrough` deprecated function has been removed, instead you can do `blockservice.New(..., ..., WriteThrough())` like previously.
 - `gateway`: a new header configuration middleware has been added to replace the existing header configuration, which can be used more generically.

--- a/files/filewriter_unix.go
+++ b/files/filewriter_unix.go
@@ -1,4 +1,5 @@
-//go:build darwin || linux || netbsd || openbsd || freebsd || dragonfly || js || wasip1
+//go:build darwin || linux || netbsd || openbsd || freebsd || dragonfly || (js && !wasm) || wasip1
+// +build darwin linux netbsd openbsd freebsd dragonfly js,!wasm wasip1
 
 package files
 

--- a/files/filewriter_unix_test.go
+++ b/files/filewriter_unix_test.go
@@ -1,4 +1,6 @@
-//go:build darwin || linux || netbsd || openbsd || freebsd || dragonfly || js || wasip1
+//go:build darwin || linux || netbsd || openbsd || freebsd || dragonfly || (js && !wasm) || wasip1
+// +build darwin linux netbsd openbsd freebsd dragonfly js,!wasm wasip1
+
 
 package files
 

--- a/files/filewriter_wasm.go
+++ b/files/filewriter_wasm.go
@@ -1,0 +1,27 @@
+//go:build js && wasm
+// +build js,wasm
+
+package files
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// In a WebAssembly context, direct file system operations like in Unix are not possible.
+// Therefore, these functions could be adapted to work with in-memory storage or
+// interfacing with JavaScript for file operations.
+
+func createNewFile(path string) (*os.File, error) {
+	// Since direct file creation isn't possible, you might want to simulate it or
+	// interface with JavaScript. For now, this will return an error.
+	return nil, errors.New("createNewFile is not supported in WebAssembly environments")
+}
+
+func isValidFilename(filename string) bool {
+	// Filename validation might still be relevant in a WASM context.
+	// You can keep the logic same or adapt it based on your application's needs.
+	invalidChars := `/` + "\x00"
+	return !strings.ContainsAny(filename, invalidChars)
+}

--- a/files/filewriter_wasm.go
+++ b/files/filewriter_wasm.go
@@ -1,0 +1,20 @@
+//go:build js && wasm
+// +build js,wasm
+
+package files
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+func createNewFile(path string) (*os.File, error) {
+	return nil, errors.New("createNewFile is not supported in WebAssembly environments")
+}
+
+func isValidFilename(filename string) bool {
+	// Filename validation might still be relevant in a WASM context.
+	invalidChars := `/` + "\x00"
+	return !strings.ContainsAny(filename, invalidChars)
+}

--- a/files/filewriter_wasm_test.go
+++ b/files/filewriter_wasm_test.go
@@ -1,0 +1,30 @@
+//go:build js && wasm
+// +build js,wasm
+
+package files
+
+import (
+    "testing"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestIsValidFilenameWASM(t *testing.T) {
+    // Since file creation isn't supported in WASM, this test only focuses on filename validation.
+
+    testCases := []struct {
+        name     string
+        valid    bool
+    }{
+        {"validfilename", true},
+        {"/invalid/filename", false},
+        {"", false},
+        {".", false},
+        {"..", false},
+    }
+
+    for _, tc := range testCases {
+        t.Run(tc.name, func(t *testing.T) {
+            assert.Equal(t, tc.valid, isValidFilename(tc.name))
+        })
+    }
+}


### PR DESCRIPTION
As writing files is not really applicable in WebAssembly create a noop filewriter to make compilation possible.