### PR TITLE
blockstore/blockservice: change option to `WriteThrough(enabled bool)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+* 🛠 `blockstore` and `blockservice`'s `WriteThrough()` option now takes an "enabled" parameter: `WriteThrough(enabled bool)`.
+
 ### Removed
 
 ### Fixed

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -85,10 +85,10 @@ type blockService struct {
 type Option func(*blockService)
 
 // WriteThrough disable cache checks for writes and make them go straight to
-// the blockstore.
-func WriteThrough() Option {
+// the blockstore, when enabled.
+func WriteThrough(enabled bool) Option {
 	return func(bs *blockService) {
-		bs.checkFirst = false
+		bs.checkFirst = !enabled
 	}
 }
 

--- a/blockservice/blockservice_test.go
+++ b/blockservice/blockservice_test.go
@@ -29,7 +29,7 @@ func TestWriteThroughWorks(t *testing.T) {
 	}
 	exchbstore := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	exch := offline.Exchange(exchbstore)
-	bserv := New(bstore, exch, WriteThrough())
+	bserv := New(bstore, exch, WriteThrough(true))
 
 	block := random.BlocksOfSize(1, blockSize)[0]
 
@@ -63,7 +63,7 @@ func TestExchangeWrite(t *testing.T) {
 		offline.Exchange(exchbstore),
 		0,
 	}
-	bserv := New(bstore, exch, WriteThrough())
+	bserv := New(bstore, exch, WriteThrough(true))
 
 	for name, fetcher := range map[string]BlockGetter{
 		"blockservice": bserv,
@@ -137,7 +137,7 @@ func TestLazySessionInitialization(t *testing.T) {
 	session := offline.Exchange(bstore2)
 	exch := offline.Exchange(bstore3)
 	sessionExch := &fakeSessionExchange{Interface: exch, session: session}
-	bservSessEx := New(bstore, sessionExch, WriteThrough())
+	bservSessEx := New(bstore, sessionExch, WriteThrough(true))
 	blks := random.BlocksOfSize(2, blockSize)
 
 	block := blks[0]
@@ -234,7 +234,7 @@ func TestNilExchange(t *testing.T) {
 	block := random.BlocksOfSize(1, blockSize)[0]
 
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
-	bserv := New(bs, nil, WriteThrough())
+	bserv := New(bs, nil, WriteThrough(true))
 	sess := NewSession(ctx, bserv)
 	_, err := sess.GetBlock(ctx, block.Cid())
 	if !ipld.IsNotFound(err) {

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -122,11 +122,11 @@ type Option struct {
 }
 
 // WriteThrough skips checking if the blockstore already has a block before
-// writing it.
-func WriteThrough() Option {
+// writing it, when enabled.
+func WriteThrough(enabled bool) Option {
 	return Option{
 		func(bs *blockstore) {
-			bs.writeThrough = true
+			bs.writeThrough = enabled
 		},
 	}
 }

--- a/exchange/providing/providing_test.go
+++ b/exchange/providing/providing_test.go
@@ -30,7 +30,7 @@ func TestExchange(t *testing.T) {
 	provExchange := New(i.Exchange, prov)
 	// write-through so that we notify when re-adding block
 	bs := blockservice.New(i.Blockstore, provExchange,
-		blockservice.WriteThrough())
+		blockservice.WriteThrough(true))
 	block := random.BlocksOfSize(1, 10)[0]
 	// put it on the blockstore of the first instance
 	err = i.Blockstore.Put(ctx, block)


### PR DESCRIPTION
This allows passing in a boolean to indicate if we want to use the option or not, which provides better ergonomics for initialization.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
