### PR TITLE
Fix PeerManager mutex bottleneck

### DIFF
--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -64,7 +64,7 @@ type MessageNetwork interface {
 // MessageQueue implements queue of want messages to send to peers.
 type MessageQueue struct {
 	ctx          context.Context
-	shutdown     func()
+	shutdown     context.CancelFunc
 	p            peer.ID
 	network      MessageNetwork
 	dhTimeoutMgr DontHaveTimeoutManager
@@ -475,8 +475,8 @@ func (mq *MessageQueue) Startup() {
 
 // Shutdown stops the processing of messages for a message queue.
 func (mq *MessageQueue) Shutdown() {
-	mq.requests.Shutdown()
 	mq.shutdown()
+	mq.requests.Shutdown()
 }
 
 func (mq *MessageQueue) onShutdown() {

--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -333,14 +333,6 @@ func newMessageQueue(
 	}
 }
 
-func (mq *MessageQueue) Sync() <-chan struct{} {
-	done := make(chan struct{})
-	mq.requests.In() <- func() {
-		close(done)
-	}
-	return done
-}
-
 // Add want-haves that are part of a broadcast to all connected peers
 func (mq *MessageQueue) AddBroadcastWantHaves(wantHaves []cid.Cid) {
 	if len(wantHaves) == 0 {

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 const collectTimeout = 2500 * time.Millisecond
+const eventTimeout = 5 * time.Second
 
 type fakeMessageNetwork struct {
 	connectError       error
@@ -162,7 +163,7 @@ func expectEvent(t *testing.T, events <-chan messageEvent, expectedEvent message
 		if evt != expectedEvent {
 			t.Fatal("message not queued")
 		}
-	case <-time.After(3 * time.Second):
+	case <-time.After(eventTimeout):
 		t.Fatal("timed out waiting for event")
 	}
 }
@@ -691,6 +692,7 @@ func TestResponseReceived(t *testing.T) {
 
 	// Add some wants
 	messageQueue.AddWants(cids[:5], nil)
+	clock.Add(maxSendMessageDelay)
 	clock.Add(maxSendMessageDelay)
 	expectEvent(t, events, messageQueued)
 	<-messagesSent

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -436,10 +436,16 @@ func TestWantlistRebroadcast(t *testing.T) {
 	// Add some broadcast want-haves
 	messageQueue.Startup()
 	defer messageQueue.Shutdown()
+
 	messageQueue.AddBroadcastWantHaves(bcstwh)
 	clock.Add(maxSendMessageDelay)
 	expectEvent(t, events, messageQueued)
-	message := <-messagesSent
+	var message []bsmsg.Entry
+	select {
+	case message = <-messagesSent:
+	case <-time.After(2 * maxSendMessageDelay):
+		t.Fatal("timed out waiting for messages sent")
+	}
 	expectEvent(t, events, messageFinishedSending)
 
 	// All broadcast want-haves should have been sent
@@ -448,7 +454,11 @@ func TestWantlistRebroadcast(t *testing.T) {
 	}
 
 	messageQueue.RebroadcastNow()
-	message = <-messagesSent
+	select {
+	case message = <-messagesSent:
+	case <-time.After(2 * maxSendMessageDelay):
+		t.Fatal("timed out waiting for messages sent")
+	}
 	expectEvent(t, events, messageFinishedSending)
 
 	// All the want-haves should have been rebroadcast
@@ -461,7 +471,11 @@ func TestWantlistRebroadcast(t *testing.T) {
 	clock.Add(maxSendMessageDelay)
 	expectEvent(t, events, messageQueued)
 	clock.Add(10 * time.Millisecond)
-	message = <-messagesSent
+	select {
+	case message = <-messagesSent:
+	case <-time.After(2 * maxSendMessageDelay):
+		t.Fatal("timed out waiting for messages sent")
+	}
 	expectEvent(t, events, messageFinishedSending)
 
 	// All new wants should have been sent
@@ -476,7 +490,11 @@ func TestWantlistRebroadcast(t *testing.T) {
 	}
 
 	messageQueue.RebroadcastNow()
-	message = <-messagesSent
+	select {
+	case message = <-messagesSent:
+	case <-time.After(2 * maxSendMessageDelay):
+		t.Fatal("timed out waiting for messages sent")
+	}
 	expectEvent(t, events, messageFinishedSending)
 
 	// Both original and new wants should have been rebroadcast
@@ -491,7 +509,11 @@ func TestWantlistRebroadcast(t *testing.T) {
 	clock.Add(maxSendMessageDelay)
 	expectEvent(t, events, messageQueued)
 	clock.Add(10 * time.Millisecond)
-	message = <-messagesSent
+	select {
+	case message = <-messagesSent:
+	case <-time.After(2 * maxSendMessageDelay):
+		t.Fatal("timed out waiting for messages sent")
+	}
 	expectEvent(t, events, messageFinishedSending)
 
 	select {
@@ -511,7 +533,11 @@ func TestWantlistRebroadcast(t *testing.T) {
 	}
 
 	messageQueue.RebroadcastNow()
-	message = <-messagesSent
+	select {
+	case message = <-messagesSent:
+	case <-time.After(2 * maxSendMessageDelay):
+		t.Fatal("timed out waiting for messages sent")
+	}
 	expectEvent(t, events, messageFinishedSending)
 
 	if len(message) != totalWants-len(cancels) {

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -175,6 +175,7 @@ func TestStartupAndShutdown(t *testing.T) {
 	bcstwh := random.Cids(10)
 
 	messageQueue.Startup()
+	defer messageQueue.Shutdown()
 	messageQueue.AddBroadcastWantHaves(bcstwh)
 	messages := collectMessages(ctx, t, messagesSent, collectTimeout)
 	if len(messages) != 1 {
@@ -318,6 +319,7 @@ func TestSendingMessagesPriority(t *testing.T) {
 }
 
 func TestCancelOverridesPendingWants(t *testing.T) {
+	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -377,13 +379,12 @@ func TestWantOverridesPendingCancels(t *testing.T) {
 	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
 	peerID := random.Peers(1)[0]
 	messageQueue := New(ctx, peerID, fakenet, mockTimeoutCb)
+	messageQueue.Startup()
+	defer messageQueue.Shutdown()
 
 	cids := random.Cids(3)
 	wantBlocks := cids[:1]
 	wantHaves := cids[1:]
-
-	messageQueue.Startup()
-	defer messageQueue.Shutdown()
 
 	// Add 1 want-block and 2 want-haves
 	messageQueue.AddWants(wantBlocks, wantHaves)
@@ -417,7 +418,7 @@ func TestWantOverridesPendingCancels(t *testing.T) {
 }
 
 func TestWantlistRebroadcast(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -737,7 +738,6 @@ func TestResponseReceivedAppliesForFirstResponseOnly(t *testing.T) {
 }
 
 func TestResponseReceivedDiscardsOutliers(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	messagesSent := make(chan []bsmsg.Entry)
 	resetChan := make(chan struct{}, 1)
@@ -819,6 +819,7 @@ func BenchmarkMessageQueue(b *testing.B) {
 
 		messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, clock.New(), nil)
 		messageQueue.Startup()
+		defer messageQueue.Shutdown()
 
 		go func() {
 			for {

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -133,9 +133,9 @@ func (pm *PeerManager) ResponseReceived(p peer.ID, ks []cid.Cid) {
 // the peer.
 func (pm *PeerManager) BroadcastWantHaves(ctx context.Context, wantHaves []cid.Cid) {
 	pm.pqLk.Lock()
-	defer pm.pqLk.Unlock()
-
-	pm.pwm.broadcastWantHaves(wantHaves)
+	wg := pm.pwm.broadcastWantHaves(wantHaves)
+	pm.pqLk.Unlock()
+	wg.Wait()
 }
 
 // SendWants sends the given want-blocks and want-haves to the given peer.

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -116,9 +116,9 @@ func (pm *PeerManager) Disconnected(p peer.ID) {
 // Note that this is just used to calculate latency.
 func (pm *PeerManager) ResponseReceived(p peer.ID, ks []cid.Cid) {
 	pm.pqLk.RLock()
-	pq, ok := pm.peerQueues[p]
-	pm.pqLk.RUnlock()
+	defer pm.pqLk.RUnlock()
 
+	pq, ok := pm.peerQueues[p]
 	if ok {
 		pq.ResponseReceived(ks)
 	}

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -95,17 +95,15 @@ func (pm *PeerManager) Connected(p peer.ID) {
 // Disconnected is called to remove a peer from the pool.
 func (pm *PeerManager) Disconnected(p peer.ID) {
 	pm.pqLk.Lock()
+	defer pm.pqLk.Unlock()
 
 	pq, ok := pm.peerQueues[p]
 	if !ok {
-		pm.pqLk.Unlock()
 		return
 	}
 	// Clean up the peer
 	delete(pm.peerQueues, p)
 	pm.pwm.removePeer(p)
-
-	pm.pqLk.Unlock()
 
 	// Inform the sessions that the peer has disconnected
 	pm.signalAvailability(p, false)

--- a/bitswap/client/internal/peermanager/peermanager.go
+++ b/bitswap/client/internal/peermanager/peermanager.go
@@ -95,15 +95,17 @@ func (pm *PeerManager) Connected(p peer.ID) {
 // Disconnected is called to remove a peer from the pool.
 func (pm *PeerManager) Disconnected(p peer.ID) {
 	pm.pqLk.Lock()
-	defer pm.pqLk.Unlock()
 
 	pq, ok := pm.peerQueues[p]
 	if !ok {
+		pm.pqLk.Unlock()
 		return
 	}
 	// Clean up the peer
 	delete(pm.peerQueues, p)
 	pm.pwm.removePeer(p)
+
+	pm.pqLk.Unlock()
 
 	// Inform the sessions that the peer has disconnected
 	pm.signalAvailability(p, false)

--- a/bitswap/client/internal/peermanager/peermanager_test.go
+++ b/bitswap/client/internal/peermanager/peermanager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,22 +21,29 @@ type msg struct {
 }
 
 type mockPeerQueue struct {
-	p    peer.ID
-	msgs chan msg
+	p      peer.ID
+	msgs   chan msg
+	wllock sync.Mutex
 }
 
 func (fp *mockPeerQueue) Startup()  {}
 func (fp *mockPeerQueue) Shutdown() {}
 
 func (fp *mockPeerQueue) AddBroadcastWantHaves(whs []cid.Cid) {
+	fp.wllock.Lock()
+	defer fp.wllock.Unlock()
 	fp.msgs <- msg{fp.p, nil, whs, nil}
 }
 
 func (fp *mockPeerQueue) AddWants(wbs []cid.Cid, whs []cid.Cid) {
+	fp.wllock.Lock()
+	defer fp.wllock.Unlock()
 	fp.msgs <- msg{fp.p, wbs, whs, nil}
 }
 
 func (fp *mockPeerQueue) AddCancels(cs []cid.Cid) {
+	fp.wllock.Lock()
+	defer fp.wllock.Unlock()
 	fp.msgs <- msg{fp.p, nil, nil, cs}
 }
 

--- a/bitswap/client/internal/peermanager/peerwantmanager.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager.go
@@ -276,7 +276,8 @@ func (pwm *peerWantManager) sendCancels(cancelKs []cid.Cid) *sync.WaitGroup {
 	// Send cancels to a particular peer
 	send := func(pws *peerWant) {
 		// Start from the broadcast cancels
-		toCancel := broadcastCancels
+		toCancel := make([]cid.Cid, len(broadcastCancels))
+		copy(toCancel, broadcastCancels)
 
 		// For each key to be cancelled
 		for _, c := range cancelKs {

--- a/bitswap/client/internal/peermanager/peerwantmanager_test.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager_test.go
@@ -83,7 +83,8 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 	}
 
 	// Broadcast 2 cids to 2 peers
-	pwm.broadcastWantHaves(cids)
+	wg := pwm.broadcastWantHaves(cids)
+	wg.Wait()
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 2, "Expected 2 want-haves")
@@ -92,7 +93,8 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 
 	// Broadcasting same cids should have no effect
 	clearSent(peerQueues)
-	pwm.broadcastWantHaves(cids)
+	wg = pwm.broadcastWantHaves(cids)
+	wg.Wait()
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 0, "Expected 0 want-haves")
@@ -100,7 +102,8 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 
 	// Broadcast 2 other cids
 	clearSent(peerQueues)
-	pwm.broadcastWantHaves(cids2)
+	wg = pwm.broadcastWantHaves(cids2)
+	wg.Wait()
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 2, "Expected 2 want-haves")
@@ -109,7 +112,8 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 
 	// Broadcast mix of old and new cids
 	clearSent(peerQueues)
-	pwm.broadcastWantHaves(append(cids, cids3...))
+	wg = pwm.broadcastWantHaves(append(cids, cids3...))
+	wg.Wait()
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 2, "Expected 2 want-haves")
@@ -125,7 +129,8 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 	p1 := peers[1]
 	pwm.sendWants(p0, wantBlocks, []cid.Cid{})
 
-	pwm.broadcastWantHaves(cids4)
+	wg = pwm.broadcastWantHaves(cids4)
+	wg.Wait()
 	pq0 := peerQueues[p0].(*mockPQ)
 	// only broadcast 2 / 4 want-haves
 	require.Len(t, pq0.bcst, 2, "Expected 2 want-haves")
@@ -148,7 +153,8 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 	require.ElementsMatch(t, pq2.bcst, allCids, "Expected all cids to be broadcast")
 
 	clearSent(peerQueues)
-	pwm.broadcastWantHaves(allCids)
+	wg = pwm.broadcastWantHaves(allCids)
+	wg.Wait()
 	require.Empty(t, pq2.bcst, "did not expect to have CIDs to broadcast")
 }
 

--- a/bitswap/client/internal/peermanager/peerwantmanager_test.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager_test.go
@@ -88,14 +88,12 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 	for _, p := range peers[:2] {
 		pq := &mockPQ{}
 		peerQueues[p] = pq
-		wg := pwm.addPeer(pq, p)
-		wg.Wait()
+		pwm.addPeer(pq, p)
 		require.Empty(t, pq.bcst, "expected no broadcast wants")
 	}
 
 	// Broadcast 2 cids to 2 peers
-	wg := pwm.broadcastWantHaves(cids)
-	wg.Wait()
+	pwm.broadcastWantHaves(cids)
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 2, "Expected 2 want-haves")
@@ -104,8 +102,7 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 
 	// Broadcasting same cids should have no effect
 	clearSent(peerQueues)
-	wg = pwm.broadcastWantHaves(cids)
-	wg.Wait()
+	pwm.broadcastWantHaves(cids)
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 0, "Expected 0 want-haves")
@@ -113,8 +110,7 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 
 	// Broadcast 2 other cids
 	clearSent(peerQueues)
-	wg = pwm.broadcastWantHaves(cids2)
-	wg.Wait()
+	pwm.broadcastWantHaves(cids2)
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 2, "Expected 2 want-haves")
@@ -123,8 +119,7 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 
 	// Broadcast mix of old and new cids
 	clearSent(peerQueues)
-	wg = pwm.broadcastWantHaves(append(cids, cids3...))
-	wg.Wait()
+	pwm.broadcastWantHaves(append(cids, cids3...))
 	for _, pqi := range peerQueues {
 		pq := pqi.(*mockPQ)
 		require.Len(t, pq.bcst, 2, "Expected 2 want-haves")
@@ -138,11 +133,9 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 	wantBlocks := []cid.Cid{cids4[0], cids4[2]}
 	p0 := peers[0]
 	p1 := peers[1]
-	wg = pwm.sendWants(p0, wantBlocks, []cid.Cid{})
-	wg.Wait()
+	pwm.sendWants(p0, wantBlocks, []cid.Cid{})
 
-	wg = pwm.broadcastWantHaves(cids4)
-	wg.Wait()
+	pwm.broadcastWantHaves(cids4)
 	pq0 := peerQueues[p0].(*mockPQ)
 	// only broadcast 2 / 4 want-haves
 	require.Len(t, pq0.bcst, 2, "Expected 2 want-haves")
@@ -161,13 +154,11 @@ func TestPWMBroadcastWantHaves(t *testing.T) {
 	peer2 := peers[2]
 	pq2 := &mockPQ{}
 	peerQueues[peer2] = pq2
-	wg = pwm.addPeer(pq2, peer2)
-	wg.Wait()
+	pwm.addPeer(pq2, peer2)
 	require.ElementsMatch(t, pq2.bcst, allCids, "Expected all cids to be broadcast")
 
 	clearSent(peerQueues)
-	wg = pwm.broadcastWantHaves(allCids)
-	wg.Wait()
+	pwm.broadcastWantHaves(allCids)
 	require.Empty(t, pq2.bcst, "did not expect to have CIDs to broadcast")
 }
 
@@ -191,8 +182,7 @@ func TestPWMSendWants(t *testing.T) {
 
 	// Send 2 want-blocks and 2 want-haves to p0
 	clearSent(peerQueues)
-	wg := pwm.sendWants(p0, cids, cids2)
-	wg.Wait()
+	pwm.sendWants(p0, cids, cids2)
 	require.ElementsMatch(t, pq0.wbs, cids, "Expected 2 want-blocks")
 	require.ElementsMatch(t, pq0.whs, cids2, "Expected 2 want-haves")
 
@@ -202,8 +192,7 @@ func TestPWMSendWants(t *testing.T) {
 	clearSent(peerQueues)
 	cids3 := random.Cids(2)
 	cids4 := random.Cids(2)
-	wg = pwm.sendWants(p0, append(cids3, cids[0]), append(cids4, cids2[0]))
-	wg.Wait()
+	pwm.sendWants(p0, append(cids3, cids[0]), append(cids4, cids2[0]))
 	require.ElementsMatch(t, pq0.wbs, cids3, "Expected 2 want-blocks")
 	require.ElementsMatch(t, pq0.whs, cids4, "Expected 2 want-haves")
 
@@ -211,8 +200,7 @@ func TestPWMSendWants(t *testing.T) {
 	clearSent(peerQueues)
 	cids5 := random.Cids(1)
 	newWantBlockOldWantHave := append(cids5, cids2[0])
-	wg = pwm.sendWants(p0, newWantBlockOldWantHave, []cid.Cid{})
-	wg.Wait()
+	pwm.sendWants(p0, newWantBlockOldWantHave, []cid.Cid{})
 	// If a want was sent as a want-have, it should be ok to now send it as a
 	// want-block
 	require.ElementsMatch(t, pq0.wbs, newWantBlockOldWantHave, "Expected 2 want-blocks")
@@ -222,16 +210,14 @@ func TestPWMSendWants(t *testing.T) {
 	clearSent(peerQueues)
 	cids6 := random.Cids(1)
 	newWantHaveOldWantBlock := append(cids6, cids[0])
-	wg = pwm.sendWants(p0, []cid.Cid{}, newWantHaveOldWantBlock)
-	wg.Wait()
+	pwm.sendWants(p0, []cid.Cid{}, newWantHaveOldWantBlock)
 	// If a want was previously sent as a want-block, it should not be
 	// possible to now send it as a want-have
 	require.ElementsMatch(t, pq0.whs, cids6, "Expected 1 want-have")
 	require.Empty(t, pq0.wbs, "Expected 0 want-blocks")
 
 	// Send 2 want-blocks and 2 want-haves to p1
-	wg = pwm.sendWants(p1, cids, cids2)
-	wg.Wait()
+	pwm.sendWants(p1, cids, cids2)
 	require.ElementsMatch(t, pq1.wbs, cids, "Expected 2 want-blocks")
 	require.ElementsMatch(t, pq1.whs, cids2, "Expected 2 want-haves")
 }
@@ -254,27 +240,23 @@ func TestPWMSendCancels(t *testing.T) {
 	for _, p := range peers[:2] {
 		pq := &mockPQ{}
 		peerQueues[p] = pq
-		wg := pwm.addPeer(pq, p)
-		wg.Wait()
+		pwm.addPeer(pq, p)
 	}
 	pq0 := peerQueues[p0].(*mockPQ)
 	pq1 := peerQueues[p1].(*mockPQ)
 
 	// Send 2 want-blocks and 2 want-haves to p0
-	wg := pwm.sendWants(p0, wb1, wh1)
-	wg.Wait()
+	pwm.sendWants(p0, wb1, wh1)
 	// Send 3 want-blocks and 3 want-haves to p1
 	// (1 overlapping want-block / want-have with p0)
-	wg = pwm.sendWants(p1, append(wb2, wb1[1]), append(wh2, wh1[1]))
-	wg.Wait()
+	pwm.sendWants(p1, append(wb2, wb1[1]), append(wh2, wh1[1]))
 
 	require.ElementsMatch(t, pwm.getWantBlocks(), allwb, "Expected 4 cids to be wanted")
 	require.ElementsMatch(t, pwm.getWantHaves(), allwh, "Expected 4 cids to be wanted")
 
 	// Cancel 1 want-block and 1 want-have that were sent to p0
 	clearSent(peerQueues)
-	wg = pwm.sendCancels([]cid.Cid{wb1[0], wh1[0]})
-	wg.Wait()
+	pwm.sendCancels([]cid.Cid{wb1[0], wh1[0]})
 	// Should cancel the want-block and want-have
 	require.Empty(t, pq1.cancels, "Expected no cancels sent to p1")
 	require.ElementsMatch(t, pq0.cancels, []cid.Cid{wb1[0], wh1[0]}, "Expected 2 cids to be cancelled")
@@ -284,8 +266,7 @@ func TestPWMSendCancels(t *testing.T) {
 	// Cancel everything
 	clearSent(peerQueues)
 	allCids := append(allwb, allwh...)
-	wg = pwm.sendCancels(allCids)
-	wg.Wait()
+	pwm.sendCancels(allCids)
 	// Should cancel the remaining want-blocks and want-haves for p0
 	require.ElementsMatch(t, pq0.cancels, []cid.Cid{wb1[1], wh1[1]}, "Expected un-cancelled cids to be cancelled")
 
@@ -312,34 +293,29 @@ func TestStats(t *testing.T) {
 	peerQueues := make(map[peer.ID]PeerQueue)
 	pq := &mockPQ{}
 	peerQueues[p0] = pq
-	wg := pwm.addPeer(pq, p0)
-	wg.Wait()
+	pwm.addPeer(pq, p0)
 
 	// Send 2 want-blocks and 2 want-haves to p0
-	wg = pwm.sendWants(p0, cids, cids2)
-	wg.Wait()
+	pwm.sendWants(p0, cids, cids2)
 
 	require.Equal(t, 4, g.count, "Expected 4 wants")
 	require.Equal(t, 2, wbg.count, "Expected 2 want-blocks")
 
 	// Send 1 old want-block and 2 new want-blocks to p0
 	cids3 := random.Cids(2)
-	wg = pwm.sendWants(p0, append(cids3, cids[0]), []cid.Cid{})
-	wg.Wait()
+	pwm.sendWants(p0, append(cids3, cids[0]), []cid.Cid{})
 
 	require.Equal(t, 6, g.count, "Expected 6 wants")
 	require.Equal(t, 4, wbg.count, "Expected 4 want-blocks")
 
 	// Broadcast 1 old want-have and 2 new want-haves
 	cids4 := random.Cids(2)
-	wg = pwm.broadcastWantHaves(append(cids4, cids2[0]))
-	wg.Wait()
+	pwm.broadcastWantHaves(append(cids4, cids2[0]))
 	require.Equal(t, 8, g.count, "Expected 8 wants")
 	require.Equal(t, 4, wbg.count, "Expected 4 want-blocks")
 
 	// Add a second peer
-	wg = pwm.addPeer(pq, p1)
-	wg.Wait()
+	pwm.addPeer(pq, p1)
 
 	require.Equal(t, 8, g.count, "Expected 8 wants")
 	require.Equal(t, 4, wbg.count, "Expected 4 want-blocks")
@@ -347,8 +323,7 @@ func TestStats(t *testing.T) {
 	// Cancel 1 want-block that was sent to p0
 	// and 1 want-block that was not sent
 	cids5 := random.Cids(1)
-	wg = pwm.sendCancels(append(cids5, cids[0]))
-	wg.Wait()
+	pwm.sendCancels(append(cids5, cids[0]))
 
 	require.Equal(t, 7, g.count, "Expected 7 wants")
 	require.Equal(t, 3, wbg.count, "Expected 3 want-blocks")
@@ -368,8 +343,7 @@ func TestStats(t *testing.T) {
 	require.Zero(t, wbg.count, "Expected 0 want-blocks")
 
 	// Cancel one remaining broadcast want-have
-	wg = pwm.sendCancels(cids2[:1])
-	wg.Wait()
+	pwm.sendCancels(cids2[:1])
 	require.Equal(t, 2, g.count, "Expected 2 wants")
 	require.Zero(t, wbg.count, "Expected 0 want-blocks")
 }
@@ -385,26 +359,21 @@ func TestStatsOverlappingWantBlockWantHave(t *testing.T) {
 	cids := random.Cids(2)
 	cids2 := random.Cids(2)
 
-	wg := pwm.addPeer(&mockPQ{}, p0)
-	wg.Wait()
-	wg = pwm.addPeer(&mockPQ{}, p1)
-	wg.Wait()
+	pwm.addPeer(&mockPQ{}, p0)
+	pwm.addPeer(&mockPQ{}, p1)
 
 	// Send 2 want-blocks and 2 want-haves to p0
-	wg = pwm.sendWants(p0, cids, cids2)
-	wg.Wait()
+	pwm.sendWants(p0, cids, cids2)
 
 	// Send opposite:
 	// 2 want-haves and 2 want-blocks to p1
-	wg = pwm.sendWants(p1, cids2, cids)
-	wg.Wait()
+	pwm.sendWants(p1, cids2, cids)
 
 	require.Equal(t, 4, g.count, "Expected 4 wants")
 	require.Equal(t, 4, wbg.count, "Expected 4 want-blocks")
 
 	// Cancel 1 of each group of cids
-	wg = pwm.sendCancels([]cid.Cid{cids[0], cids2[0]})
-	wg.Wait()
+	pwm.sendCancels([]cid.Cid{cids[0], cids2[0]})
 
 	require.Equal(t, 2, g.count, "Expected 2 wants")
 	require.Equal(t, 2, wbg.count, "Expected 2 want-blocks")
@@ -421,19 +390,15 @@ func TestStatsRemovePeerOverlappingWantBlockWantHave(t *testing.T) {
 	cids := random.Cids(2)
 	cids2 := random.Cids(2)
 
-	wg := pwm.addPeer(&mockPQ{}, p0)
-	wg.Wait()
-	wg = pwm.addPeer(&mockPQ{}, p1)
-	wg.Wait()
+	pwm.addPeer(&mockPQ{}, p0)
+	pwm.addPeer(&mockPQ{}, p1)
 
 	// Send 2 want-blocks and 2 want-haves to p0
-	wg = pwm.sendWants(p0, cids, cids2)
-	wg.Wait()
+	pwm.sendWants(p0, cids, cids2)
 
 	// Send opposite:
 	// 2 want-haves and 2 want-blocks to p1
-	wg = pwm.sendWants(p1, cids2, cids)
-	wg.Wait()
+	pwm.sendWants(p1, cids2, cids)
 
 	require.Equal(t, 4, g.count, "Expected 4 wants")
 	require.Equal(t, 4, wbg.count, "Expected 4 want-blocks")

--- a/bitswap/client/internal/peermanager/peerwantmanager_test.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager_test.go
@@ -31,6 +31,8 @@ type mockPQ struct {
 }
 
 func (mpq *mockPQ) clear() {
+	mpq.wllock.Lock()
+	defer mpq.wllock.Unlock()
 	mpq.bcst = nil
 	mpq.wbs = nil
 	mpq.whs = nil

--- a/bitswap/client/internal/peermanager/peerwantmanager_test.go
+++ b/bitswap/client/internal/peermanager/peerwantmanager_test.go
@@ -223,7 +223,6 @@ func TestPWMSendWants(t *testing.T) {
 }
 
 func TestPWMSendCancels(t *testing.T) {
-	t.Skip()
 	pwm := newPeerWantManager(&gauge{}, &gauge{})
 
 	peers := random.Peers(2)


### PR DESCRIPTION
Do not try to acquire a MessageQueue mutex while holding the PeerManager mutex. A MessageQueue mutex may already be held for message processing and waiting for these will delay releasing the global PeerManager mutex. Instead, enqueue calls to MessageQueue and let an asynchronous goroutine execute the calls so that the PeerManager lock can be released sooner, without having to wait for the MessageQueue operations.

In short, this decouples the PeerManager from the per-peer MessageQueue mutexes.

Kubo PR: https://github.com/ipfs/kubo/pull/10749

