### PR TITLE
Limit bitswap sessions

### DIFF
--- a/bitswap/benchmarks_test.go
+++ b/bitswap/benchmarks_test.go
@@ -499,7 +499,10 @@ func onePeerPerBlock(b *testing.B, provs []testinstance.Instance, blks []blocks.
 }
 
 func oneAtATime(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
+	ses, err := bs.NewSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
 	for _, c := range ks {
 		_, err := ses.GetBlock(context.Background(), c)
 		if err != nil {
@@ -511,7 +514,10 @@ func oneAtATime(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
 
 // fetch data in batches, 10 at a time
 func batchFetchBy10(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
+	ses, err := bs.NewSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
 	for i := 0; i < len(ks); i += 10 {
 		out, err := ses.GetBlocks(context.Background(), ks[i:i+10])
 		if err != nil {
@@ -524,7 +530,10 @@ func batchFetchBy10(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
 
 // fetch each block at the same time concurrently
 func fetchAllConcurrent(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
+	ses, err := bs.NewSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	var wg sync.WaitGroup
 	for _, c := range ks {
@@ -541,7 +550,10 @@ func fetchAllConcurrent(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
 }
 
 func batchFetchAll(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
+	ses, err := bs.NewSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
 	out, err := ses.GetBlocks(context.Background(), ks)
 	if err != nil {
 		b.Fatal(err)
@@ -552,8 +564,11 @@ func batchFetchAll(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
 
 // simulates the fetch pattern of trying to sync a unixfs file graph as fast as possible
 func unixfsFileFetch(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
-	_, err := ses.GetBlock(context.Background(), ks[0])
+	ses, err := bs.NewSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	_, err = ses.GetBlock(context.Background(), ks[0])
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -574,8 +589,11 @@ func unixfsFileFetch(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
 }
 
 func unixfsFileFetchLarge(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
-	ses := bs.NewSession(context.Background())
-	_, err := ses.GetBlock(context.Background(), ks[0])
+	ses, err := bs.NewSession(context.Background())
+	if err != nil {
+		b.Fatal(err)
+	}
+	_, err = ses.GetBlock(context.Background(), ks[0])
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -32,7 +32,7 @@ type bitswap interface {
 	GetWantlist() []cid.Cid
 	IsOnline() bool
 	LedgerForPeer(p peer.ID) *server.Receipt
-	NewSession(ctx context.Context) exchange.Fetcher
+	NewSession(ctx context.Context) (exchange.Fetcher, error)
 	NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) error
 	PeerConnected(p peer.ID)
 	PeerDisconnected(p peer.ID)

--- a/bitswap/bitswap_test.go
+++ b/bitswap/bitswap_test.go
@@ -138,7 +138,10 @@ func TestDoesNotProvideWhenConfiguredNotTo(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Millisecond)
 	defer cancel()
 
-	ns := wantsBlock.Exchange.NewSession(ctx)
+	ns, err := wantsBlock.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	received, err := ns.GetBlock(ctx, block.Cid())
 	if received != nil {

--- a/bitswap/client/bitswap_with_sessions_test.go
+++ b/bitswap/client/bitswap_with_sessions_test.go
@@ -68,7 +68,10 @@ func TestBasicSessions(t *testing.T) {
 	}
 
 	// Create a session on Peer A
-	sesa := a.Exchange.NewSession(ctx)
+	sesa, err := a.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Get the block
 	blkout, err := sesa.GetBlock(ctx, block.Cid())
@@ -149,7 +152,10 @@ func TestCustomProviderQueryManager(t *testing.T) {
 	}
 
 	// Create a session on Peer A
-	sesa := a.Exchange.NewSession(ctx)
+	sesa, err := a.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Get the block
 	blkout, err := sesa.GetBlock(ctx, block.Cid())
@@ -194,7 +200,10 @@ func TestSessionBetweenPeers(t *testing.T) {
 	}
 
 	// Create a session on Peer B
-	ses := inst[1].Exchange.NewSession(ctx)
+	ses, err := inst[1].Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if _, err := ses.GetBlock(ctx, cids[0]); err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +265,11 @@ func TestSessionSplitFetch(t *testing.T) {
 	}
 
 	// Create a session on the remaining peer and fetch all the blocks 10 at a time
-	ses := inst[10].Exchange.NewSession(ctx).(*session.Session)
+	exch, err := inst[10].Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ses := exch.(*session.Session)
 	ses.SetBaseTickDelay(time.Millisecond * 10)
 
 	for i := 0; i < 10; i++ {
@@ -301,7 +314,11 @@ func TestFetchNotConnected(t *testing.T) {
 	// Note: Peer A and Peer B are not initially connected, so this tests
 	// that Peer B will search for and find Peer A
 	thisNode := ig.Next()
-	ses := thisNode.Exchange.NewSession(ctx).(*session.Session)
+	exch, err := thisNode.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ses := exch.(*session.Session)
 	ses.SetBaseTickDelay(time.Millisecond * 10)
 	ch, err := ses.GetBlocks(ctx, cids)
 	if err != nil {
@@ -346,7 +363,11 @@ func TestFetchAfterDisconnect(t *testing.T) {
 	}
 
 	// Request all blocks with Peer B
-	ses := peerB.Exchange.NewSession(ctx).(*session.Session)
+	exch, err := peerB.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ses := exch.(*session.Session)
 	ses.SetBaseTickDelay(time.Millisecond * 10)
 
 	ch, err := ses.GetBlocks(ctx, cids)
@@ -410,7 +431,10 @@ func TestInterestCacheOverflow(t *testing.T) {
 	a := inst[0]
 	b := inst[1]
 
-	ses := a.Exchange.NewSession(ctx)
+	ses, err := a.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	zeroch, err := ses.GetBlocks(ctx, []cid.Cid{blks[0].Cid()})
 	if err != nil {
 		t.Fatal(err)
@@ -459,7 +483,10 @@ func TestPutAfterSessionCacheEvict(t *testing.T) {
 
 	a := inst[0]
 
-	ses := a.Exchange.NewSession(ctx)
+	ses, err := a.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	var allcids []cid.Cid
 	for _, blk := range blks[1:] {
@@ -499,7 +526,10 @@ func TestMultipleSessions(t *testing.T) {
 	b := inst[1]
 
 	ctx1, cancel1 := context.WithCancel(ctx)
-	ses := a.Exchange.NewSession(ctx1)
+	ses, err := a.Exchange.NewSession(ctx1)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	blkch, err := ses.GetBlocks(ctx, []cid.Cid{blk.Cid()})
 	if err != nil {
@@ -507,7 +537,10 @@ func TestMultipleSessions(t *testing.T) {
 	}
 	cancel1()
 
-	ses2 := a.Exchange.NewSession(ctx)
+	ses2, err := a.Exchange.NewSession(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 	blkch2, err := ses2.GetBlocks(ctx, []cid.Cid{blk.Cid()})
 	if err != nil {
 		t.Fatal(err)
@@ -544,9 +577,12 @@ func TestWantlistClearsOnCancel(t *testing.T) {
 	a := inst[0]
 
 	ctx1, cancel1 := context.WithCancel(ctx)
-	ses := a.Exchange.NewSession(ctx1)
+	ses, err := a.Exchange.NewSession(ctx1)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	_, err := ses.GetBlocks(ctx, cids)
+	_, err = ses.GetBlocks(ctx, cids)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/bitswap/client/internal/sessionmanager/sessionmanager_test.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager_test.go
@@ -121,7 +121,7 @@ func TestReceiveFrom(t *testing.T) {
 	sim := bssim.New()
 	bpm := bsbpm.New()
 	pm := &fakePeerManager{}
-	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "")
+	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "", 0)
 
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
@@ -174,7 +174,7 @@ func TestReceiveBlocksWhenManagerShutdown(t *testing.T) {
 	sim := bssim.New()
 	bpm := bsbpm.New()
 	pm := &fakePeerManager{}
-	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "")
+	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "", 0)
 
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
@@ -216,7 +216,7 @@ func TestReceiveBlocksWhenSessionContextCancelled(t *testing.T) {
 	sim := bssim.New()
 	bpm := bsbpm.New()
 	pm := &fakePeerManager{}
-	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "")
+	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "", 0)
 
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
@@ -260,9 +260,10 @@ func TestSessionLimit(t *testing.T) {
 	sim := bssim.New()
 	bpm := bsbpm.New()
 	pm := &fakePeerManager{}
-	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "")
 
-	sessionsLimit = 5
+	sessionsLimit := 5
+	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "", sessionsLimit)
+
 	for i := 0; i < sessionsLimit+1; i++ {
 		ses, err := sm.NewSession(ctx, time.Second, delay.Fixed(time.Minute))
 		if i == sessionsLimit {
@@ -295,7 +296,7 @@ func TestShutdown(t *testing.T) {
 	sim := bssim.New()
 	bpm := bsbpm.New()
 	pm := &fakePeerManager{}
-	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "")
+	sm := New(ctx, sessionFactory, sim, peerManagerFactory, bpm, pm, notif, "", 0)
 
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))

--- a/blockservice/blockservice.go
+++ b/blockservice/blockservice.go
@@ -448,7 +448,12 @@ func (s *Session) grabSession() exchange.Fetcher {
 		if !ok {
 			return
 		}
-		s.ses = sesEx.NewSession(s.sesctx)
+		newSes, err := sesEx.NewSession(s.sesctx)
+		if err != nil {
+			logger.Error(err)
+			return
+		}
+		s.ses = newSes
 	})
 
 	return s.ses

--- a/blockservice/blockservice_test.go
+++ b/blockservice/blockservice_test.go
@@ -217,11 +217,11 @@ type fakeSessionExchange struct {
 	session exchange.Fetcher
 }
 
-func (fe *fakeSessionExchange) NewSession(ctx context.Context) exchange.Fetcher {
+func (fe *fakeSessionExchange) NewSession(ctx context.Context) (exchange.Fetcher, error) {
 	if ctx == nil {
 		panic("nil context")
 	}
-	return fe.session
+	return fe.session, nil
 }
 
 func TestNilExchange(t *testing.T) {
@@ -307,9 +307,9 @@ func (*fakeIsNewSessionCreateExchange) GetBlocks(context.Context, []cid.Cid) (<-
 	panic("should call on the session")
 }
 
-func (f *fakeIsNewSessionCreateExchange) NewSession(context.Context) exchange.Fetcher {
+func (f *fakeIsNewSessionCreateExchange) NewSession(context.Context) (exchange.Fetcher, error) {
 	f.newSessionWasCalled = true
-	return f.ses
+	return f.ses, nil
 }
 
 func (*fakeIsNewSessionCreateExchange) NotifyNewBlocks(context.Context, ...blocks.Block) error {

--- a/exchange/interface.go
+++ b/exchange/interface.go
@@ -36,5 +36,5 @@ type SessionExchange interface {
 	// NewSession generates a new exchange session. You should use this, rather
 	// that calling GetBlocks, any time you intend to do several related calls
 	// in a row. The exchange can leverage that to be more efficient.
-	NewSession(context.Context) Fetcher
+	NewSession(context.Context) (Fetcher, error)
 }


### PR DESCRIPTION
Limit number of bitswap client sessions to prevent goroutine runaway