### PR TITLE
provider: dedicated provide queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The following emojis are used to highlight certain changes:
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)
 - `bitswap/network`: Add a new `requests_in_flight` metric gauge that measures how many bitswap streams are being written or read at a given time.
 - improve speed of data onboarding by batching/bufering provider queue writes [#888](https://github.com/ipfs/boxo/pull/888)
-- `provider`: prioritize providing newly added CIDs over reproviding older CIDs [#907](https://github.com/ipfs/boxo/pull/907)
+- `provider`: providing queue is now independent from reprovides, speeding up initial provides [#907](https://github.com/ipfs/boxo/pull/907)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The following emojis are used to highlight certain changes:
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)
 - `bitswap/network`: Add a new `requests_in_flight` metric gauge that measures how many bitswap streams are being written or read at a given time.
 - improve speed of data onboarding by batching/bufering provider queue writes [#888](https://github.com/ipfs/boxo/pull/888)
+- `provider`: prioritize providing newly added CIDs over reproviding older CIDs [#907](https://github.com/ipfs/boxo/pull/907)
 
 ### Removed
 

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -197,11 +197,11 @@ func DatastorePrefix(k datastore.Key) Option {
 // which can speed up provide operations under heavy load. Use this option
 // carefully, as it may cause the libp2p node to open a very high number of
 // connections to remote peers.
-//
-// This setting has no effect when batch providing is enabled.
-func ProvideWorkerCount(n uint) Option {
+func ProvideWorkerCount(n int) Option {
 	return func(system *reprovider) error {
-		system.provideWorkerCount = n
+		if n > 0 {
+			system.provideWorkerCount = uint(n)
+		}
 		return nil
 	}
 }

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -286,6 +286,15 @@ func (s *reprovider) run() {
 
 				select {
 				case c := <-provCh:
+					// Prioritize newly provided keys
+					resetTimersAfterReceivingProvide()
+					m[c] = struct{}{}
+					continue
+				default:
+				}
+
+				select {
+				case c := <-provCh:
 					resetTimersAfterReceivingProvide()
 					m[c] = struct{}{}
 				case c := <-s.reprovideCh:

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -419,10 +419,10 @@ func (s *reprovider) Reprovide(ctx context.Context) error {
 		batchSize = s.throughputMinimumProvides
 	}
 
-	var cids []cid.Cid
+	cids := make([]cid.Cid, 0, min(batchSize, 1024))
 	allCidsProcessed := false
 	for !allCidsProcessed {
-		cids = make([]cid.Cid, 0, batchSize)
+		cids = cids[:0]
 		for range batchSize {
 			c, ok := <-kch
 			if !ok {

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -254,16 +254,11 @@ func (s *reprovider) run() {
 		defer maxCollectionDurationTimer.Stop()
 		defer pauseDetectTimer.Stop()
 
-		batchSize := s.maxReprovideBatchSize
-		if s.throughputCallback != nil && s.throughputMinimumProvides < batchSize {
-			batchSize = s.throughputMinimumProvides
-		}
-
 		for {
 			// At the start of every loop the maxCollectionDurationTimer and
 			// pauseDetectTimer should already be stopped and have empty
 			// channels.
-			for uint(len(m)) < batchSize {
+			for uint(len(m)) < s.maxReprovideBatchSize {
 				select {
 				case c := <-provCh:
 					if len(m) == 0 {

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -508,8 +508,12 @@ func (s *reprovider) run() {
 
 func (s *reprovider) waitUntilProvideSystemReady() {
 	if r, ok := s.rsys.(Ready); ok {
-		ticker := time.NewTicker(time.Minute)
+		var ticker *time.Ticker
 		for !r.Ready() {
+			if ticker == nil {
+				ticker = time.NewTicker(time.Minute)
+				defer ticker.Stop()
+			}
 			log.Debugf("reprovider system not ready")
 			select {
 			case <-ticker.C:
@@ -517,7 +521,6 @@ func (s *reprovider) waitUntilProvideSystemReady() {
 				return
 			}
 		}
-		ticker.Stop()
 	}
 }
 

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -159,7 +159,7 @@ func testProvider(t *testing.T, singleProvide bool) {
 	defer batchSystem.Close()
 
 	keyWait.Lock()
-	time.Sleep(pauseDetectionThreshold + time.Millisecond*50) // give it time to call provider after that
+	time.Sleep(time.Millisecond * 50) // give it time to call provider after that
 
 	keys, calls := orig.GetKeys()
 	if len(keys) != numProvides {
@@ -219,7 +219,7 @@ func TestOfflineRecordsThenOnlineRepublish(t *testing.T) {
 	sys, err = New(ds, Online(prov), initialReprovideDelay(0))
 	assert.NoError(t, err)
 
-	time.Sleep(pauseDetectionThreshold + time.Millisecond*10) // give it time to call provider after that
+	time.Sleep(time.Millisecond * 10) // give it time to call provider after that
 
 	err = sys.Close()
 	assert.NoError(t, err)

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -114,6 +114,7 @@ func testProvider(t *testing.T, singleProvide bool) {
 		ch := make(chan cid.Cid)
 		go func() {
 			defer keyWait.Unlock()
+			defer close(ch)
 			for _, k := range keysToProvide {
 				select {
 				case ch <- k:

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -72,27 +72,27 @@ type singleMockWrapper struct {
 	allButMany
 }
 
+func initialReprovideDelay(duration time.Duration) Option {
+	return func(system *reprovider) error {
+		system.initialReprovideDelaySet = true
+		system.initalReprovideDelay = duration
+		return nil
+	}
+}
+
 func TestReprovider(t *testing.T) {
 	t.Parallel()
-	t.Run("single/batch", func(t *testing.T) {
+	t.Run("single", func(t *testing.T) {
 		t.Parallel()
-		testProvider(t, true, true)
+		testProvider(t, true)
 	})
-	t.Run("single/instant", func(t *testing.T) {
+	t.Run("many", func(t *testing.T) {
 		t.Parallel()
-		testProvider(t, true, false)
-	})
-	t.Run("many/batch", func(t *testing.T) {
-		t.Parallel()
-		testProvider(t, false, true)
-	})
-	t.Run("many/instant", func(t *testing.T) {
-		t.Parallel()
-		testProvider(t, false, false)
+		testProvider(t, false)
 	})
 }
 
-func testProvider(t *testing.T, singleProvide, batchProvides bool) {
+func testProvider(t *testing.T, singleProvide bool) {
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 
 	// It has to be so big because the combo of noisy CI runners + OSes that don't
@@ -119,7 +119,7 @@ func testProvider(t *testing.T, singleProvide, batchProvides bool) {
 
 	var keyWait sync.Mutex
 	keyWait.Lock()
-	batchSystem, err := New(ds, Online(provider), BatchProvides(batchProvides), KeyProvider(func(ctx context.Context) (<-chan cid.Cid, error) {
+	batchSystem, err := New(ds, Online(provider), KeyProvider(func(ctx context.Context) (<-chan cid.Cid, error) {
 		ch := make(chan cid.Cid)
 		go func() {
 			defer keyWait.Unlock()


### PR DESCRIPTION
Reprovides are currently spiky since all keys are reprovided at once (for both normal and accelerated DHT clients). If new keys are added during a reprovide, the `reprovider` will wait until the current reprovide is finished before advertising the newly added keys to the DHT. So new keys are blocked by reprovides.

This PR splits the (re)provide queue in a provide queue and a reprovide queue, allowing provides to be advertised immediately, even during reprovides.

https://github.com/ipfs/kubo/issues/10777

Depending on either:
- [x] https://github.com/ipfs/boxo/pull/910
- [x] https://github.com/ipfs/boxo/issues/901

> - Part of https://github.com/ipshipyard/roadmaps/issues/6