### PR TITLE
provider: depuplicate cids in provider queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The following emojis are used to highlight certain changes:
 - upgrade to `go-libp2p` [v0.41.1](https://github.com/libp2p/go-libp2p/releases/tag/v0.41.1)
 - `bitswap/network`: Add a new `requests_in_flight` metric gauge that measures how many bitswap streams are being written or read at a given time.
 - improve speed of data onboarding by batching/bufering provider queue writes [#888](https://github.com/ipfs/boxo/pull/888)
+- `provider/queue`: change queue internal buffer from a `Deque` to a `lru.Cache` to deduplicate cids as they are added to the provider queue [#909](https://github.com/ipfs/boxo/pull/909)
 
 ### Removed
 

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -277,6 +277,7 @@ func (q *Queue) commitInput(ctx context.Context, counter uint64, cids *lru.Cache
 		return fmt.Errorf("failed to create batch: %w", err)
 	}
 
+	// TODO: don't clear the cache, but write cids that haven't been written before to the datastore
 	oldestCid, _, ok := cids.RemoveOldest()
 	cstr := makeCidString(oldestCid)
 	for c := oldestCid; ok; c, _, ok = cids.RemoveOldest() {

--- a/provider/internal/queue/queue.go
+++ b/provider/internal/queue/queue.go
@@ -277,7 +277,7 @@ func (q *Queue) commitInput(ctx context.Context, counter uint64, cids *lru.Cache
 		return fmt.Errorf("failed to create batch: %w", err)
 	}
 
-	oldestCid, _, ok := cids.GetOldest()
+	oldestCid, _, ok := cids.RemoveOldest()
 	cstr := makeCidString(oldestCid)
 	for c := oldestCid; ok; c, _, ok = cids.RemoveOldest() {
 		key := datastore.NewKey(fmt.Sprintf("%020d/%s", counter, cstr))

--- a/provider/internal/queue/queue_test.go
+++ b/provider/internal/queue/queue_test.go
@@ -118,3 +118,21 @@ func TestInitializationWithManyCids(t *testing.T) {
 
 	assertOrdered(cids, queue, t)
 }
+
+func TestDuplicateCids(t *testing.T) {
+	ds := sync.MutexWrap(datastore.NewMapDatastore())
+	queue := New(ds)
+	defer queue.Close()
+
+	cids := random.Cids(5)
+	queue.Enqueue(cids[0])
+	queue.Enqueue(cids[0])
+	queue.Enqueue(cids[1])
+	queue.Enqueue(cids[2])
+	queue.Enqueue(cids[1])
+	queue.Enqueue(cids[3])
+	queue.Enqueue(cids[0])
+	queue.Enqueue(cids[4])
+
+	assertOrdered(cids, queue, t)
+}


### PR DESCRIPTION
Change the queue internal buffer from a `Deque` to a `lru.Cache` to deduplicate cids that are added to the provider queue.
