### PR TITLE
fix: typo in HAMT error message

### DIFF
--- a/ipld/unixfs/hamt/hamt.go
+++ b/ipld/unixfs/hamt/hamt.go
@@ -779,7 +779,7 @@ const maximumHamtWidth = 1 << 10 // FIXME: Spec this and decide of a correct val
 
 func newChilder(ds ipld.DAGService, size int) (*childer, error) {
 	if size > maximumHamtWidth {
-		return nil, fmt.Errorf("hamt witdh (%d) exceed maximum allowed (%d)", size, maximumHamtWidth)
+		return nil, fmt.Errorf("hamt width (%d) exceed maximum allowed (%d)", size, maximumHamtWidth)
 	}
 	bf, err := bitfield.NewBitfield(size)
 	if err != nil {


### PR DESCRIPTION
Fixes a small typo in the error message.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
