### PR TITLE
Do not return error from notify blocks when bitswap shutdown

### DIFF
--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -4,7 +4,6 @@ package client
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -354,7 +353,7 @@ func (bs *Client) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) err
 
 	select {
 	case <-bs.closing:
-		return errors.New("bitswap is closed")
+		return nil
 	default:
 	}
 
@@ -377,10 +376,10 @@ func (bs *Client) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) err
 }
 
 // receiveBlocksFrom processes blocks received from the network
-func (bs *Client) receiveBlocksFrom(ctx context.Context, from peer.ID, blks []blocks.Block, haves []cid.Cid, dontHaves []cid.Cid) error {
+func (bs *Client) receiveBlocksFrom(ctx context.Context, from peer.ID, blks []blocks.Block, haves []cid.Cid, dontHaves []cid.Cid) {
 	select {
 	case <-bs.closing:
-		return errors.New("bitswap is closed")
+		return
 	default:
 	}
 
@@ -416,8 +415,6 @@ func (bs *Client) receiveBlocksFrom(ctx context.Context, from peer.ID, blks []bl
 	for _, b := range wanted {
 		bs.notif.Publish(from, b)
 	}
-
-	return nil
 }
 
 // ReceiveMessage is called by the network interface when a new message is
@@ -446,11 +443,7 @@ func (bs *Client) ReceiveMessage(ctx context.Context, p peer.ID, incoming bsmsg.
 	dontHaves := incoming.DontHaves()
 	if len(iblocks) > 0 || len(haves) > 0 || len(dontHaves) > 0 {
 		// Process blocks
-		err := bs.receiveBlocksFrom(ctx, p, iblocks, haves, dontHaves)
-		if err != nil {
-			log.Warnf("ReceiveMessage recvBlockFrom error: %s", err)
-			return
-		}
+		bs.receiveBlocksFrom(ctx, p, iblocks, haves, dontHaves)
 	}
 }
 

--- a/bitswap/server/server.go
+++ b/bitswap/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -385,7 +384,7 @@ func (bs *Server) Stat() (Stat, error) {
 func (bs *Server) NotifyNewBlocks(ctx context.Context, blks ...blocks.Block) error {
 	select {
 	case <-bs.closing:
-		return errors.New("bitswap is closed")
+		return nil
 	default:
 	}
 


### PR DESCRIPTION
On ipfs shutdown, MFS closes its root which adds an empty directory block. This results in an error because bitswap is shutdown, even though there is no real error to address.

To fix this, this PR changes NotifyNewBlocks to not return any error if bitswap is closed. Reporting this error is not necessary because there is not action that can or should be taken to handle it, and bitswap was closed intentionally so this is not even an unexpected situation.
