### PR TITLE
[skip changelog] fix sending empty want from #968

### DIFF
--- a/bitswap/message/message.go
+++ b/bitswap/message/message.go
@@ -234,7 +234,7 @@ func (m *impl) Empty() bool {
 
 func (m *impl) FillWantlist(out []Entry) []Entry {
 	if cap(out) < len(m.wantlist) {
-		out = make([]Entry, len(m.wantlist))
+		out = make([]Entry, 0, len(m.wantlist))
 	} else {
 		out = out[:0]
 	}


### PR DESCRIPTION
#968 has been changed from index filling to direct append, so when making a new slice, we need to declare cap instead of length.

```go
out := make([]Entry, 10)
out = append(out, item)
len(out) // 11
```