### PR TITLE
bitswap/httpnet: fix peers silently stopping from doing http requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `bitswap/httpnet`: fix an issue where boxo silently stops making http retrieval requests.
+
 ### Security
 
 


### PR DESCRIPTION
Fixes #979 (hopefully). If connectivity status has been switched from Connected without doing an httpnet DisconnectFrom(), it may be that we keep pinging the peers, and think we are connected to them, but never restore the connectivity status when skipping the connectivity checks (because we are connected). This results in silent, successful "Connect()" requests that do nothing.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
