### PR TITLE
remove sha1 from list of hashes allowed in IPFS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ The following emojis are used to highlight certain changes:
 
 ### Removed
 
+- remove sha1 from list of hashes allowed in IPFS [#1013](https://github.com/ipfs/boxo/pull/1013)
+ 
 ### Fixed
 
 ### Security

--- a/verifcid/allowlist.go
+++ b/verifcid/allowlist.go
@@ -52,9 +52,8 @@ func (defaultAllowlist) IsAllowed(code uint64) bool {
 		mh.IDENTITY,
 
 		mh.SHA3_224, mh.SHA3_256, mh.SHA3_384, mh.SHA3_512,
-		mh.KECCAK_224, mh.KECCAK_256, mh.KECCAK_384, mh.KECCAK_512,
+		mh.KECCAK_224, mh.KECCAK_256, mh.KECCAK_384, mh.KECCAK_512:
 
-		mh.SHA1: // not really secure but still useful for git
 		return true
 	default:
 		if code >= mh.BLAKE2B_MIN+19 && code <= mh.BLAKE2B_MAX {

--- a/verifcid/allowlist_test.go
+++ b/verifcid/allowlist_test.go
@@ -34,7 +34,7 @@ func TestDefaultAllowList(t *testing.T) {
 	assertTrue(allowlist.IsAllowed(mh.DBL_SHA2_256))
 	assertTrue(allowlist.IsAllowed(mh.KECCAK_256))
 	assertTrue(allowlist.IsAllowed(mh.SHA3))
-	assertTrue(allowlist.IsAllowed(mh.SHA1))
+	assertFalse(allowlist.IsAllowed(mh.SHA1))
 	assertFalse(allowlist.IsAllowed(mh.BLAKE2B_MIN + 5))
 
 	cases := []struct {


### PR DESCRIPTION
Closes kubo issue https://github.com/ipfs/kubo/issues/8703
