### PR TITLE
feat(gateway): add retrieval state tracking for timeout diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `gateway`: Added retrieval state tracking for timeout diagnostics. When retrieval timeouts occur, the error messages now include detailed information about which phase failed (path resolution, provider discovery, connecting, or data retrieval) and provider statistics. [#1015](https://github.com/ipfs/boxo/pull/1015)
+
 ### Changed
 
 ### Removed

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ipfs/boxo/bitswap/tracer"
 	blockstore "github.com/ipfs/boxo/blockstore"
 	exchange "github.com/ipfs/boxo/exchange"
+	"github.com/ipfs/boxo/retrieval"
 	rpqm "github.com/ipfs/boxo/routing/providerquerymanager"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
@@ -444,6 +445,11 @@ func (bs *Client) GetBlocks(ctx context.Context, keys []cid.Cid) (<-chan blocks.
 
 	// Temporary session closed indepentendly of cancellation ctx.
 	sessCtx, cancelSession := context.WithCancel(context.Background())
+
+	// Preserve RetrievalState from the original request context if present
+	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+		sessCtx = context.WithValue(sessCtx, retrieval.ContextKey, retrievalState)
+	}
 	session := bs.sm.NewSession(sessCtx, bs.provSearchDelay, bs.rebroadcastDelay)
 
 	blocksChan, err := session.GetBlocks(ctx, keys)

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -324,7 +324,8 @@ func (bb *BlocksBackend) GetBlock(ctx context.Context, path path.ImmutablePath) 
 
 	b, err := bb.blockService.GetBlock(ctx, lastRoot)
 	if err != nil {
-		return md, nil, err
+		// Wrap error with retrieval diagnostics if available
+		return md, nil, retrieval.WrapWithState(ctx, err)
 	}
 
 	return md, files.NewBytesFile(b.RawData()), nil

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -20,6 +20,7 @@ import (
 	uio "github.com/ipfs/boxo/ipld/unixfs/io"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/boxo/path/resolver"
+	"github.com/ipfs/boxo/retrieval"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
@@ -664,6 +665,11 @@ func (bb *BlocksBackend) getNode(ctx context.Context, path path.ImmutablePath) (
 }
 
 func (bb *BlocksBackend) getPathRoots(ctx context.Context, contentPath path.ImmutablePath) ([]cid.Cid, path.ImmutablePath, []string, error) {
+	// Update retrieval progress, if tracked in the existing context
+	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+		retrievalState.SetPhase(retrieval.PhasePathResolution)
+	}
+
 	/*
 		These are logical roots where each CID represent one path segment
 		and resolves to either a directory or the root block of a file.

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -142,7 +142,8 @@ func (bb *BlocksBackend) Get(ctx context.Context, path path.ImmutablePath, range
 		// Fetch only the root block to check if it's a UnixFS file
 		rootBlock, err := bb.blockService.GetBlock(ctx, lastRoot)
 		if err != nil {
-			return md, nil, err
+			// Wrap error with retrieval diagnostics if available
+			return md, nil, retrieval.WrapWithState(ctx, err)
 		}
 
 		// Try to optimize for dag-pb blocks that might be UnixFS files
@@ -658,7 +659,8 @@ func (bb *BlocksBackend) getNode(ctx context.Context, path path.ImmutablePath) (
 
 	nd, err := bb.dagService.Get(ctx, lastRoot)
 	if err != nil {
-		return ContentPathMetadata{}, nil, err
+		// Wrap error with retrieval diagnostics if available
+		return ContentPathMetadata{}, nil, retrieval.WrapWithState(ctx, err)
 	}
 
 	return md, nd, err
@@ -714,7 +716,8 @@ func (bb *BlocksBackend) getPathRoots(ctx context.Context, contentPath path.Immu
 			if isErrNotFound(err) {
 				return nil, path.ImmutablePath{}, nil, &resolver.ErrNoLink{Name: root, Node: lastPath.RootCid()}
 			}
-			return nil, path.ImmutablePath{}, nil, err
+			// Wrap error with retrieval diagnostics if available
+			return nil, path.ImmutablePath{}, nil, retrieval.WrapWithState(ctx, err)
 		}
 		lastPath = resolvedSubPath
 		remainder = remainderSubPath
@@ -774,7 +777,8 @@ func (bb *BlocksBackend) resolvePath(ctx context.Context, p path.Path) (path.Imm
 
 	node, remainder, err := bb.resolver.ResolveToLastNode(ctx, imPath)
 	if err != nil {
-		return path.ImmutablePath{}, nil, err
+		// Wrap error with retrieval diagnostics if available
+		return path.ImmutablePath{}, nil, retrieval.WrapWithState(ctx, err)
 	}
 
 	p, err = path.Join(path.FromCid(node), remainder...)

--- a/gateway/backend_car.go
+++ b/gateway/backend_car.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs/boxo/ipld/unixfs"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/boxo/path/resolver"
+	"github.com/ipfs/boxo/retrieval"
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	format "github.com/ipfs/go-ipld-format"
@@ -209,6 +210,10 @@ func (api *CarBackend) fetchCAR(ctx context.Context, p path.ImmutablePath, param
 
 // resolvePathWithRootsAndBlock takes a path and linksystem and returns the set of non-terminal cids, the terminal cid, the remainder, and the block corresponding to the terminal cid
 func resolvePathWithRootsAndBlock(ctx context.Context, p path.ImmutablePath, unixFSLsys *ipld.LinkSystem) (ContentPathMetadata, blocks.Block, error) {
+	// Update retrieval progress, if tracked in the existing context
+	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+		retrievalState.SetPhase(retrieval.PhasePathResolution)
+	}
 	md, terminalBlk, err := resolvePathToLastWithRoots(ctx, p, unixFSLsys)
 	if err != nil {
 		return ContentPathMetadata{}, nil, err
@@ -237,6 +242,10 @@ func resolvePathWithRootsAndBlock(ctx context.Context, p path.ImmutablePath, uni
 //
 // Note: the block returned will be nil if the terminal element is a link or the path is just a CID
 func resolvePathToLastWithRoots(ctx context.Context, p path.ImmutablePath, unixFSLsys *ipld.LinkSystem) (ContentPathMetadata, blocks.Block, error) {
+	// Update retrieval progress, if tracked in the existing context
+	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+		retrievalState.SetPhase(retrieval.PhasePathResolution)
+	}
 	root, segments := p.RootCid(), p.Segments()[2:]
 	if len(segments) == 0 {
 		return ContentPathMetadata{

--- a/gateway/middleware_retrieval_timeout.go
+++ b/gateway/middleware_retrieval_timeout.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/ipfs/boxo/retrieval"
 )
 
 const truncationMessage = "\n\n[Gateway Error: Response truncated - unable to retrieve remaining data within timeout period]"
@@ -30,6 +32,10 @@ func withRetrievalTimeout(handler http.Handler, timeout time.Duration, c *Config
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Add RetrievalState to request context for tracking provider diagnostics
+		ctx, retrievalState := retrieval.ContextWithState(r.Context())
+		r = r.WithContext(ctx)
+
 		// Create channels for coordination
 		handlerDone := make(chan struct{})
 		timeoutChan := make(chan struct{})
@@ -66,10 +72,17 @@ func withRetrievalTimeout(handler http.Handler, timeout time.Duration, c *Config
 
 						metrics.recordTimeout(http.StatusGatewayTimeout, false)
 						message := "Unable to retrieve content within timeout period"
+
+						// Include diagnostic context if available
+						if retrievalState != nil {
+							message = fmt.Sprintf("%s: %s", message, retrievalState.Summary())
+						}
+
 						log.Debugw("sending 504 gateway timeout",
 							"path", tw.request.URL.Path,
 							"method", tw.request.Method,
-							"remoteAddr", tw.request.RemoteAddr)
+							"remoteAddr", tw.request.RemoteAddr,
+							"timeoutReason", message)
 
 						// Write error response directly to ResponseWriter (safe because handler uses tw.headers)
 						writeErrorResponse(tw.ResponseWriter, tw.request, tw.config, http.StatusGatewayTimeout, message)
@@ -185,6 +198,12 @@ func (tw *timeoutWriter) Write(p []byte) (int, error) {
 
 	// Reset timer on non-empty write
 	if len(p) > 0 {
+		// Set data retrieval phase on first data write
+		if tw.bytesWritten == 0 {
+			if retrievalState := retrieval.StateFromContext(tw.request.Context()); retrievalState != nil {
+				retrievalState.SetPhase(retrieval.PhaseDataRetrieval)
+			}
+		}
 		tw.timer.Reset(tw.timeout)
 		tw.bytesWritten += int64(len(p))
 	}

--- a/retrieval/state.go
+++ b/retrieval/state.go
@@ -156,20 +156,25 @@ func (rs *RetrievalState) Summary() string {
 		return fmt.Sprintf("Found %d provider(s) but none could be contacted (phase: %s)", found, phase.String())
 	}
 
-	if connected == 0 {
-		return fmt.Sprintf("Found %d provider(s), attempted %d, but none were reachable (phase: %s)",
-			found, attempted, phase.String())
-	}
-
 	failedProviders := rs.GetFailedProviders()
+	failedPeersInfo := ""
 	if len(failedProviders) > 0 {
 		// Convert peer IDs to strings for display
 		peerStrings := make([]string, len(failedProviders))
 		for i, p := range failedProviders {
 			peerStrings[i] = p.String()
 		}
-		return fmt.Sprintf("Found %d provider(s), connected to %d, but they did not return the requested content (phase: %s, failed peers: %v)",
-			found, connected, phase.String(), peerStrings)
+		failedPeersInfo = fmt.Sprintf(", failed peers: %v", peerStrings)
+	}
+
+	if connected == 0 {
+		return fmt.Sprintf("Found %d provider(s), attempted %d, but none were reachable (phase: %s%s)",
+			found, attempted, phase.String(), failedPeersInfo)
+	}
+
+	if len(failedProviders) > 0 {
+		return fmt.Sprintf("Found %d provider(s), connected to %d, but they did not return the requested content (phase: %s%s)",
+			found, connected, phase.String(), failedPeersInfo)
 	}
 
 	return fmt.Sprintf("Timeout occurred after finding %d provider(s) and connecting to %d (phase: %s)",

--- a/retrieval/state.go
+++ b/retrieval/state.go
@@ -1,0 +1,215 @@
+// Package retrieval provides state tracking for IPFS content retrieval operations.
+// It enables detailed diagnostics about the retrieval process, including which stage
+// failed (path resolution, provider discovery, connection, or block retrieval) and
+// statistics about provider interactions. This information is particularly useful
+// for debugging timeout errors and understanding retrieval performance.
+package retrieval
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type contextKey string
+
+// ContextKey is the key used to store RetrievalState in a context.Context.
+// This can be used directly with context.WithValue if needed, though the
+// ContextWithState and StateFromContext functions are preferred.
+const ContextKey contextKey = "boxo-retrieval-state"
+
+// MaxFailedProvidersToTrack limits the number of failed provider peer IDs
+// that are kept for diagnostic purposes. This prevents unbounded memory growth
+// while still providing useful debugging information.
+const MaxFailedProvidersToTrack = 3
+
+// RetrievalPhase represents the current phase of content retrieval.
+// Phases progress monotonically - they can only move forward, never backward.
+// This helps identify where in the retrieval process a timeout or failure occurred.
+type RetrievalPhase int
+
+const (
+	// PhaseInitializing indicates the retrieval process has not yet started.
+	PhaseInitializing RetrievalPhase = iota
+	// PhasePathResolution indicates the system is resolving an IPFS path to determine
+	// what content needs to be fetched (e.g., /ipfs/Qm.../path/to/file).
+	PhasePathResolution
+	// PhaseProviderDiscovery indicates the system is finding peers that have the content.
+	PhaseProviderDiscovery
+	// PhaseConnecting indicates the system is establishing connections to providers.
+	PhaseConnecting
+	// PhaseDataRetrieval indicates the system is transferring data to the client.
+	PhaseDataRetrieval
+)
+
+// String returns a human-readable name for the retrieval phase.
+func (p RetrievalPhase) String() string {
+	switch p {
+	case PhaseInitializing:
+		return "initializing"
+	case PhasePathResolution:
+		return "path resolution"
+	case PhaseProviderDiscovery:
+		return "provider discovery"
+	case PhaseConnecting:
+		return "connecting to providers"
+	case PhaseDataRetrieval:
+		return "data retrieval"
+	default:
+		return "unknown"
+	}
+}
+
+// RetrievalState tracks diagnostic information about IPFS content retrieval operations.
+// It is safe for concurrent use and maintains monotonic stage progression.
+// Use ContextWithState to add tracking to a context, and StateFromContext
+// to retrieve the state for updates or inspection
+type RetrievalState struct {
+	// ProvidersFound tracks the number of providers discovered for the content.
+	ProvidersFound atomic.Int32
+	// ProvidersAttempted tracks the number of providers we tried to connect to.
+	ProvidersAttempted atomic.Int32
+	// ProvidersConnected tracks the number of providers successfully connected.
+	ProvidersConnected atomic.Int32
+
+	// phase tracks the current retrieval phase (stored as int32)
+	phase atomic.Int32
+
+	// mu protects failedProviders slice during concurrent access
+	mu sync.RWMutex
+	// Track specific provider failures (limited to first few for brevity)
+	failedProviders []peer.ID
+}
+
+// NewRetrievalState creates a new RetrievalState initialized to PhaseInitializing.
+// The returned state is safe for concurrent use.
+func NewRetrievalState() *RetrievalState {
+	rs := &RetrievalState{
+		failedProviders: make([]peer.ID, 0, MaxFailedProvidersToTrack),
+	}
+	rs.phase.Store(int32(PhaseInitializing))
+	return rs
+}
+
+// SetPhase updates the current retrieval phase to the given phase.
+// The phase progression is monotonic - phases can only move forward, never backward.
+// If the provided phase is less than or equal to the current phase, this is a no-op.
+// This method is safe for concurrent use.
+func (rs *RetrievalState) SetPhase(phase RetrievalPhase) {
+	newPhase := int32(phase)
+	for {
+		current := rs.phase.Load()
+		// Only update if the new phase is greater (moving forward)
+		if newPhase <= current {
+			return
+		}
+		// Try to update atomically
+		if rs.phase.CompareAndSwap(current, newPhase) {
+			return
+		}
+		// If CAS failed, another goroutine updated it, loop will check again
+	}
+}
+
+// GetPhase returns the current retrieval phase.
+// This method is safe for concurrent use.
+func (rs *RetrievalState) GetPhase() RetrievalPhase {
+	return RetrievalPhase(rs.phase.Load())
+}
+
+// AddFailedProvider records a provider peer ID that failed to deliver the requested content.
+// Only the first MaxFailedProvidersToTrack providers are kept to prevent unbounded memory growth.
+// This method is safe for concurrent use.
+func (rs *RetrievalState) AddFailedProvider(peerID peer.ID) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+	if len(rs.failedProviders) < MaxFailedProvidersToTrack {
+		rs.failedProviders = append(rs.failedProviders, peerID)
+	}
+}
+
+// GetFailedProviders returns the list of failed providers
+func (rs *RetrievalState) GetFailedProviders() []peer.ID {
+	rs.mu.RLock()
+	defer rs.mu.RUnlock()
+	result := make([]peer.ID, len(rs.failedProviders))
+	copy(result, rs.failedProviders)
+	return result
+}
+
+// Summary generates a human-readable summary of the retrieval state,
+// useful for timeout error messages and diagnostics.
+func (rs *RetrievalState) Summary() string {
+	found := rs.ProvidersFound.Load()
+	attempted := rs.ProvidersAttempted.Load()
+	connected := rs.ProvidersConnected.Load()
+	phase := rs.GetPhase()
+
+	if found == 0 {
+		return fmt.Sprintf("No providers found for the CID (phase: %s)", phase.String())
+	}
+
+	if attempted == 0 {
+		return fmt.Sprintf("Found %d provider(s) but none could be contacted (phase: %s)", found, phase.String())
+	}
+
+	if connected == 0 {
+		return fmt.Sprintf("Found %d provider(s), attempted %d, but none were reachable (phase: %s)",
+			found, attempted, phase.String())
+	}
+
+	failedProviders := rs.GetFailedProviders()
+	if len(failedProviders) > 0 {
+		// Convert peer IDs to strings for display
+		peerStrings := make([]string, len(failedProviders))
+		for i, p := range failedProviders {
+			peerStrings[i] = p.String()
+		}
+		return fmt.Sprintf("Found %d provider(s), connected to %d, but they did not return the requested content (phase: %s, failed peers: %v)",
+			found, connected, phase.String(), peerStrings)
+	}
+
+	return fmt.Sprintf("Timeout occurred after finding %d provider(s) and connecting to %d (phase: %s)",
+		found, connected, phase.String())
+}
+
+// ContextWithState ensures a RetrievalState exists in the context.
+// If the context already contains a RetrievalState, it returns the existing one.
+// Otherwise, it creates a new RetrievalState and adds it to the context.
+// This function is idempotent and safe to call multiple times.
+//
+// Example:
+//
+//	ctx, retrievalState := retrieval.ContextWithState(ctx)
+//	// Use retrievalState to track progress
+//	retrievalState.SetStage(retrieval.StageProviderDiscovery)
+func ContextWithState(ctx context.Context) (context.Context, *RetrievalState) {
+	// Check if context already has a RetrievalState
+	if existing := StateFromContext(ctx); existing != nil {
+		return ctx, existing
+	}
+	// Create new one if not present
+	rs := NewRetrievalState()
+	return context.WithValue(ctx, ContextKey, rs), rs
+}
+
+// StateFromContext retrieves the RetrievalState from the context.
+// Returns nil if no RetrievalState is present in the context.
+// This function is typically used by subsystems to check if retrieval tracking
+// is enabled and to update the state if it is.
+//
+// Example:
+//
+//	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+//	    retrievalState.SetStage(retrieval.StageBlockRetrieval)
+//	    retrievalState.ProvidersFound.Add(1)
+//	}
+func StateFromContext(ctx context.Context) *RetrievalState {
+	if v := ctx.Value(ContextKey); v != nil {
+		return v.(*RetrievalState)
+	}
+	return nil
+}

--- a/retrieval/state.go
+++ b/retrieval/state.go
@@ -8,6 +8,7 @@ package retrieval
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 
@@ -87,9 +88,7 @@ type RetrievalState struct {
 // NewRetrievalState creates a new RetrievalState initialized to PhaseInitializing.
 // The returned state is safe for concurrent use.
 func NewRetrievalState() *RetrievalState {
-	rs := &RetrievalState{
-		failedProviders: make([]peer.ID, 0, MaxFailedProvidersToTrack),
-	}
+	rs := &RetrievalState{}
 	rs.phase.Store(int32(PhaseInitializing))
 	return rs
 }
@@ -135,9 +134,7 @@ func (rs *RetrievalState) AddFailedProvider(peerID peer.ID) {
 func (rs *RetrievalState) GetFailedProviders() []peer.ID {
 	rs.mu.RLock()
 	defer rs.mu.RUnlock()
-	result := make([]peer.ID, len(rs.failedProviders))
-	copy(result, rs.failedProviders)
-	return result
+	return slices.Clone(rs.failedProviders)
 }
 
 // Summary generates a human-readable summary of the retrieval state,

--- a/retrieval/state.go
+++ b/retrieval/state.go
@@ -259,13 +259,6 @@ func (e *ErrorWithState) Unwrap() error {
 	return e.err
 }
 
-// Is reports whether target matches this error or its underlying error.
-// This allows errors.Is(err, &ErrorWithState{}) to match any ErrorWithState.
-func (e *ErrorWithState) Is(target error) bool {
-	_, ok := target.(*ErrorWithState)
-	return ok
-}
-
 // RetrievalState returns the retrieval state associated with this error.
 // This allows callers to access detailed diagnostics for custom handling.
 func (e *ErrorWithState) RetrievalState() *RetrievalState {

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -5,11 +5,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRetrievalState(t *testing.T) {

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -5,10 +5,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
 )
 
 func TestRetrievalState(t *testing.T) {
@@ -140,7 +141,7 @@ func TestRetrievalState(t *testing.T) {
 					rs.AddFailedProvider(peerID1)
 					rs.AddFailedProvider(peerID2)
 					rs.SetPhase(PhaseConnecting)
-					
+
 					// Verify the summary includes the actual peer IDs
 					summary := rs.Summary()
 					assert.Contains(t, summary, "failed peers:")

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -404,7 +404,7 @@ func TestErrorWithState(t *testing.T) {
 		assert.True(t, errors.Is(err, baseErr))
 	})
 
-	t.Run("ErrorWithState Is() method works", func(t *testing.T) {
+	t.Run("ErrorWithState type extraction with errors.As", func(t *testing.T) {
 		baseErr := errors.New("base error")
 		rs := NewRetrievalState()
 
@@ -412,12 +412,17 @@ func TestErrorWithState(t *testing.T) {
 		ctx = context.WithValue(ctx, ContextKey, rs)
 		err1 := WrapWithState(ctx, baseErr)
 
-		// Test errors.Is with ErrorWithState type
-		assert.True(t, errors.Is(err1, &ErrorWithState{}), "errors.Is should work with ErrorWithState")
+		// Test errors.As for type extraction
+		var errWithState *ErrorWithState
+		assert.True(t, errors.As(err1, &errWithState), "errors.As should extract ErrorWithState")
+		assert.NotNil(t, errWithState)
 
-		// Test that it doesn't match other error types
+		// Test that errors.Is checks the wrapped error
+		assert.True(t, errors.Is(err1, baseErr), "errors.Is should find the wrapped base error")
+
+		// Test that it doesn't match other errors
 		otherErr := errors.New("other")
-		assert.False(t, errors.Is(err1, otherErr), "Should not match non-ErrorWithState errors")
+		assert.False(t, errors.Is(err1, otherErr), "Should not match unrelated errors")
 	})
 
 	t.Run("ErrorWithState RetrievalState getter works", func(t *testing.T) {

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -1,0 +1,253 @@
+package retrieval
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrievalState(t *testing.T) {
+	t.Run("NewRetrievalState initializes correctly", func(t *testing.T) {
+		rs := NewRetrievalState()
+		assert.NotNil(t, rs)
+		assert.Equal(t, PhaseInitializing, rs.GetPhase())
+		assert.Equal(t, int32(0), rs.ProvidersFound.Load())
+		assert.Equal(t, int32(0), rs.ProvidersAttempted.Load())
+		assert.Equal(t, int32(0), rs.ProvidersConnected.Load())
+		assert.Empty(t, rs.GetFailedProviders())
+	})
+
+	t.Run("SetPhase updates phase correctly", func(t *testing.T) {
+		rs := NewRetrievalState()
+
+		rs.SetPhase(PhasePathResolution)
+		assert.Equal(t, PhasePathResolution, rs.GetPhase())
+
+		rs.SetPhase(PhaseProviderDiscovery)
+		assert.Equal(t, PhaseProviderDiscovery, rs.GetPhase())
+
+		rs.SetPhase(PhaseConnecting)
+		assert.Equal(t, PhaseConnecting, rs.GetPhase())
+
+		rs.SetPhase(PhaseDataRetrieval)
+		assert.Equal(t, PhaseDataRetrieval, rs.GetPhase())
+	})
+
+	t.Run("SetPhase enforces monotonic progression", func(t *testing.T) {
+		rs := NewRetrievalState()
+
+		// Start at initializing
+		assert.Equal(t, PhaseInitializing, rs.GetPhase())
+
+		// Move forward to connecting
+		rs.SetPhase(PhaseConnecting)
+		assert.Equal(t, PhaseConnecting, rs.GetPhase())
+
+		// Try to go backward - should not change
+		rs.SetPhase(PhaseProviderDiscovery)
+		assert.Equal(t, PhaseConnecting, rs.GetPhase(), "Stage should not move backward")
+
+		// Try to set same phase - should not change
+		rs.SetPhase(PhaseConnecting)
+		assert.Equal(t, PhaseConnecting, rs.GetPhase())
+
+		// Can still move forward
+		rs.SetPhase(PhaseDataRetrieval)
+		assert.Equal(t, PhaseDataRetrieval, rs.GetPhase())
+
+		// Try to go back again - should not change
+		rs.SetPhase(PhaseInitializing)
+		assert.Equal(t, PhaseDataRetrieval, rs.GetPhase(), "Stage should not move backward from data retrieval")
+	})
+
+	t.Run("Provider stats are tracked correctly", func(t *testing.T) {
+		rs := NewRetrievalState()
+
+		rs.ProvidersFound.Add(3)
+		assert.Equal(t, int32(3), rs.ProvidersFound.Load())
+
+		rs.ProvidersAttempted.Add(2)
+		assert.Equal(t, int32(2), rs.ProvidersAttempted.Load())
+
+		rs.ProvidersConnected.Add(1)
+		assert.Equal(t, int32(1), rs.ProvidersConnected.Load())
+	})
+
+	t.Run("Failed providers are tracked up to limit", func(t *testing.T) {
+		rs := NewRetrievalState()
+
+		// Create real peer IDs for testing
+		peerIDs := make([]peer.ID, 5)
+		for i := range peerIDs {
+			peerIDs[i] = test.RandPeerIDFatal(t)
+		}
+
+		// Add more than MaxFailedProvidersToTrack providers
+		for _, peerID := range peerIDs {
+			rs.AddFailedProvider(peerID)
+		}
+
+		failedProviders := rs.GetFailedProviders()
+		assert.Len(t, failedProviders, MaxFailedProvidersToTrack)
+		assert.Equal(t, peerIDs[0], failedProviders[0])
+		assert.Equal(t, peerIDs[1], failedProviders[1])
+		assert.Equal(t, peerIDs[2], failedProviders[2])
+	})
+
+	t.Run("Summary generates correct messages", func(t *testing.T) {
+		tests := []struct {
+			name              string
+			setup             func(*RetrievalState)
+			expectedSubstring string
+		}{
+			{
+				name: "No providers found",
+				setup: func(rs *RetrievalState) {
+					rs.SetPhase(PhaseProviderDiscovery)
+				},
+				expectedSubstring: "No providers found for the CID",
+			},
+			{
+				name: "Providers found but none contacted",
+				setup: func(rs *RetrievalState) {
+					rs.ProvidersFound.Store(5)
+					rs.SetPhase(PhaseConnecting)
+				},
+				expectedSubstring: "Found 5 provider(s) but none could be contacted",
+			},
+			{
+				name: "Providers attempted but none reachable",
+				setup: func(rs *RetrievalState) {
+					rs.ProvidersFound.Store(5)
+					rs.ProvidersAttempted.Store(3)
+					rs.SetPhase(PhaseConnecting)
+				},
+				expectedSubstring: "Found 5 provider(s), attempted 3, but none were reachable",
+			},
+			{
+				name: "Providers connected but didn't return content",
+				setup: func(rs *RetrievalState) {
+					rs.ProvidersFound.Store(5)
+					rs.ProvidersAttempted.Store(3)
+					rs.ProvidersConnected.Store(2)
+					// Use real peer IDs
+					rs.AddFailedProvider(test.RandPeerIDFatal(t))
+					rs.AddFailedProvider(test.RandPeerIDFatal(t))
+					rs.SetPhase(PhaseDataRetrieval)
+				},
+				expectedSubstring: "connected to 2, but they did not return the requested content",
+			},
+			{
+				name: "Timeout with successful connections",
+				setup: func(rs *RetrievalState) {
+					rs.ProvidersFound.Store(5)
+					rs.ProvidersAttempted.Store(3)
+					rs.ProvidersConnected.Store(2)
+					rs.SetPhase(PhaseDataRetrieval)
+				},
+				expectedSubstring: "Timeout occurred after finding 5 provider(s) and connecting to 2",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				rs := NewRetrievalState()
+				tt.setup(rs)
+				summary := rs.Summary()
+				assert.Contains(t, summary, tt.expectedSubstring)
+				assert.Contains(t, summary, "(phase:")
+			})
+		}
+	})
+
+	t.Run("Context integration", func(t *testing.T) {
+		// Test ContextWithState
+		ctx := context.Background()
+		ctxWithState, rs := ContextWithState(ctx)
+		require.NotNil(t, rs)
+
+		// Test StateFromContext retrieval
+		retrievedRS := StateFromContext(ctxWithState)
+		assert.Equal(t, rs, retrievedRS)
+
+		// Test StateFromContext on context without timeout
+		assert.Nil(t, StateFromContext(context.Background()))
+
+		// Test that modifications are visible through context
+		rs.ProvidersFound.Store(10)
+		rs.SetPhase(PhaseDataRetrieval)
+
+		retrievedRS = StateFromContext(ctxWithState)
+		assert.Equal(t, int32(10), retrievedRS.ProvidersFound.Load())
+		assert.Equal(t, PhaseDataRetrieval, retrievedRS.GetPhase())
+	})
+
+	t.Run("RetrievalPhase String method", func(t *testing.T) {
+		assert.Equal(t, "initializing", PhaseInitializing.String())
+		assert.Equal(t, "path resolution", PhasePathResolution.String())
+		assert.Equal(t, "provider discovery", PhaseProviderDiscovery.String())
+		assert.Equal(t, "connecting to providers", PhaseConnecting.String())
+		assert.Equal(t, "data retrieval", PhaseDataRetrieval.String())
+		assert.Equal(t, "unknown", RetrievalPhase(999).String())
+	})
+
+	t.Run("Summary includes failed peer IDs", func(t *testing.T) {
+		rs := NewRetrievalState()
+		rs.ProvidersFound.Store(5)
+		rs.ProvidersAttempted.Store(3)
+		rs.ProvidersConnected.Store(2)
+
+		// Create real peer IDs for testing
+		peerID1 := test.RandPeerIDFatal(t)
+		peerID2 := test.RandPeerIDFatal(t)
+
+		// Add some failed providers
+		rs.AddFailedProvider(peerID1)
+		rs.AddFailedProvider(peerID2)
+
+		summary := rs.Summary()
+		t.Logf("Summary: %s", summary)
+		assert.Contains(t, summary, "failed peers:")
+		// Check that at least one of the peer IDs is in the summary
+		hasID1 := assert.Contains(t, summary, peerID1.String())
+		hasID2 := assert.Contains(t, summary, peerID2.String())
+		assert.True(t, hasID1 || hasID2, "Summary should contain at least one of the peer IDs")
+	})
+
+	t.Run("SetPhase is thread-safe and maintains monotonic ordering", func(t *testing.T) {
+		rs := NewRetrievalState()
+		stages := []RetrievalPhase{
+			PhasePathResolution,
+			PhaseProviderDiscovery,
+			PhaseConnecting,
+			PhaseDataRetrieval,
+		}
+
+		// Run multiple goroutines trying to set stages in various orders
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				// Each goroutine tries to set a random phase
+				phase := stages[i%len(stages)]
+				rs.SetPhase(phase)
+
+				// Also try to go backward sometimes
+				if i%3 == 0 {
+					rs.SetPhase(PhaseInitializing)
+				}
+			}(i)
+		}
+		wg.Wait()
+
+		// Final phase should be the highest one that was set
+		finalStage := rs.GetPhase()
+		assert.Equal(t, PhaseDataRetrieval, finalStage, "Should end at highest phase attempted")
+	})
+}

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -2,6 +2,7 @@ package retrieval
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
@@ -110,7 +111,7 @@ func TestRetrievalState(t *testing.T) {
 				setup: func(rs *RetrievalState) {
 					rs.SetPhase(PhaseProviderDiscovery)
 				},
-				expectedSubstring: "No providers found for the CID",
+				expectedSubstring: "no providers found for the CID",
 			},
 			{
 				name: "Providers found but none contacted",
@@ -118,7 +119,7 @@ func TestRetrievalState(t *testing.T) {
 					rs.ProvidersFound.Store(5)
 					rs.SetPhase(PhaseConnecting)
 				},
-				expectedSubstring: "Found 5 provider(s) but none could be contacted",
+				expectedSubstring: "found 5 provider(s) but none could be contacted",
 			},
 			{
 				name: "Providers attempted but none reachable",
@@ -127,7 +128,7 @@ func TestRetrievalState(t *testing.T) {
 					rs.ProvidersAttempted.Store(3)
 					rs.SetPhase(PhaseConnecting)
 				},
-				expectedSubstring: "Found 5 provider(s), attempted 3, but none were reachable",
+				expectedSubstring: "found 5 provider(s), attempted 3, but none were reachable",
 			},
 			{
 				name: "Providers attempted but none reachable with failed peers",
@@ -147,7 +148,7 @@ func TestRetrievalState(t *testing.T) {
 					assert.Contains(t, summary, peerID1.String())
 					assert.Contains(t, summary, peerID2.String())
 				},
-				expectedSubstring: "Found 5 provider(s), attempted 3, but none were reachable",
+				expectedSubstring: "found 5 provider(s), attempted 3, but none were reachable",
 			},
 			{
 				name: "Providers connected but didn't return content",
@@ -170,7 +171,7 @@ func TestRetrievalState(t *testing.T) {
 					rs.ProvidersConnected.Store(2)
 					rs.SetPhase(PhaseDataRetrieval)
 				},
-				expectedSubstring: "Timeout occurred after finding 5 provider(s) and connecting to 2",
+				expectedSubstring: "timeout occurred after finding 5 provider(s) and connecting to 2",
 			},
 		}
 
@@ -269,5 +270,254 @@ func TestRetrievalState(t *testing.T) {
 		// Final phase should be the highest one that was set
 		finalStage := rs.GetPhase()
 		assert.Equal(t, PhaseDataRetrieval, finalStage, "Should end at highest phase attempted")
+	})
+}
+
+func TestErrorWithState(t *testing.T) {
+	t.Run("ErrorWithState formats correctly - no providers", func(t *testing.T) {
+		baseErr := errors.New("block not found")
+		rs := NewRetrievalState()
+		rs.SetPhase(PhaseProviderDiscovery)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check exact error formatting for no providers
+		expected := "block not found: retrieval: no providers found for the CID (phase: provider discovery)"
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("ErrorWithState formats correctly - providers found but none contacted", func(t *testing.T) {
+		baseErr := errors.New("block not found")
+		rs := NewRetrievalState()
+		rs.ProvidersFound.Store(5)
+		rs.SetPhase(PhaseConnecting)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check exact error formatting
+		expected := "block not found: retrieval: found 5 provider(s) but none could be contacted (phase: connecting to providers)"
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("ErrorWithState formats correctly - providers attempted but none reachable", func(t *testing.T) {
+		baseErr := errors.New("block not found")
+		rs := NewRetrievalState()
+		rs.ProvidersFound.Store(3)
+		rs.ProvidersAttempted.Store(2)
+		rs.SetPhase(PhaseConnecting)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check exact error formatting
+		expected := "block not found: retrieval: found 3 provider(s), attempted 2, but none were reachable (phase: connecting to providers)"
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("ErrorWithState formats correctly - providers connected but didn't return content", func(t *testing.T) {
+		baseErr := errors.New("timeout")
+		rs := NewRetrievalState()
+		rs.ProvidersFound.Store(5)
+		rs.ProvidersAttempted.Store(3)
+		rs.ProvidersConnected.Store(2)
+		rs.SetPhase(PhaseDataRetrieval)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check exact error formatting
+		expected := "timeout: retrieval: timeout occurred after finding 5 provider(s) and connecting to 2 (phase: data retrieval)"
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("ErrorWithState formats correctly - with failed peers", func(t *testing.T) {
+		baseErr := errors.New("connection failed")
+		rs := NewRetrievalState()
+		rs.ProvidersFound.Store(3)
+		rs.ProvidersAttempted.Store(3)
+		rs.ProvidersConnected.Store(1)
+		rs.SetPhase(PhaseDataRetrieval)
+
+		// Add specific peer IDs for predictable output
+		peerID1 := test.RandPeerIDFatal(t)
+		peerID2 := test.RandPeerIDFatal(t)
+		rs.AddFailedProvider(peerID1)
+		rs.AddFailedProvider(peerID2)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check that error includes failed peers
+		errMsg := err.Error()
+		assert.Contains(t, errMsg, "connection failed: retrieval: found 3 provider(s), connected to 1, but they did not return the requested content (phase: data retrieval, failed peers: [")
+		assert.Contains(t, errMsg, peerID1.String())
+		assert.Contains(t, errMsg, peerID2.String())
+	})
+
+	t.Run("ErrorWithState formats correctly - path resolution phase", func(t *testing.T) {
+		baseErr := errors.New("failed to resolve")
+		rs := NewRetrievalState()
+		rs.SetPhase(PhasePathResolution)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check exact error formatting
+		expected := "failed to resolve: retrieval: no providers found for the CID (phase: path resolution)"
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("ErrorWithState formats correctly - initializing phase", func(t *testing.T) {
+		baseErr := errors.New("not started")
+		rs := NewRetrievalState()
+		// Phase is PhaseInitializing by default
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Check exact error formatting
+		expected := "not started: retrieval: no providers found for the CID (phase: initializing)"
+		assert.Equal(t, expected, err.Error())
+	})
+
+	t.Run("ErrorWithState unwraps correctly", func(t *testing.T) {
+		baseErr := errors.New("base error")
+		rs := NewRetrievalState()
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err := WrapWithState(ctx, baseErr)
+
+		// Test Unwrap
+		assert.Equal(t, baseErr, errors.Unwrap(err))
+
+		// Test errors.Is with underlying error
+		assert.True(t, errors.Is(err, baseErr))
+	})
+
+	t.Run("ErrorWithState Is() method works", func(t *testing.T) {
+		baseErr := errors.New("base error")
+		rs := NewRetrievalState()
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		err1 := WrapWithState(ctx, baseErr)
+
+		// Test errors.Is with ErrorWithState type
+		assert.True(t, errors.Is(err1, &ErrorWithState{}), "errors.Is should work with ErrorWithState")
+
+		// Test that it doesn't match other error types
+		otherErr := errors.New("other")
+		assert.False(t, errors.Is(err1, otherErr), "Should not match non-ErrorWithState errors")
+	})
+
+	t.Run("ErrorWithState RetrievalState getter works", func(t *testing.T) {
+		rs := NewRetrievalState()
+		rs.ProvidersFound.Store(5)
+
+		ctx := context.Background()
+		ctx = context.WithValue(ctx, ContextKey, rs)
+		wrappedErr := WrapWithState(ctx, errors.New("test"))
+
+		var err *ErrorWithState
+		require.True(t, errors.As(wrappedErr, &err))
+
+		retrievedState := err.RetrievalState()
+		assert.Equal(t, rs, retrievedState)
+		assert.Equal(t, int32(5), retrievedState.ProvidersFound.Load())
+	})
+
+	t.Run("WrapWithState wraps error with retrieval state", func(t *testing.T) {
+		ctx, rs := ContextWithState(context.Background())
+		rs.ProvidersFound.Store(3)
+		rs.SetPhase(PhaseProviderDiscovery)
+
+		baseErr := errors.New("connection failed")
+		wrappedErr := WrapWithState(ctx, baseErr)
+
+		// Check that it's wrapped
+		var errWithState *ErrorWithState
+		require.True(t, errors.As(wrappedErr, &errWithState))
+		assert.Equal(t, baseErr, errors.Unwrap(errWithState))
+		assert.Equal(t, rs, errWithState.RetrievalState())
+
+		// Check formatting
+		assert.Contains(t, wrappedErr.Error(), "connection failed: retrieval:")
+		assert.Contains(t, wrappedErr.Error(), "found 3 provider(s)")
+	})
+
+	t.Run("WrapWithState returns nil for nil error", func(t *testing.T) {
+		ctx, _ := ContextWithState(context.Background())
+		assert.Nil(t, WrapWithState(ctx, nil))
+	})
+
+	t.Run("WrapWithState returns original error if no state in context", func(t *testing.T) {
+		ctx := context.Background()
+		baseErr := errors.New("test error")
+		wrappedErr := WrapWithState(ctx, baseErr)
+
+		// Should return the same error
+		assert.Equal(t, baseErr, wrappedErr)
+
+		// Should NOT be wrapped
+		var errWithState *ErrorWithState
+		assert.False(t, errors.As(wrappedErr, &errWithState))
+	})
+
+	t.Run("WrapWithState doesn't double-wrap", func(t *testing.T) {
+		ctx, rs := ContextWithState(context.Background())
+		rs.ProvidersFound.Store(3)
+
+		baseErr := errors.New("test error")
+
+		// First wrap
+		wrappedOnce := WrapWithState(ctx, baseErr)
+
+		// Try to wrap again
+		wrappedTwice := WrapWithState(ctx, wrappedOnce)
+
+		// Should be the same object
+		assert.Equal(t, wrappedOnce, wrappedTwice)
+	})
+
+	t.Run("WrapWithState always wraps when state exists", func(t *testing.T) {
+		ctx, rs := ContextWithState(context.Background())
+		// Even with no providers found, it should wrap
+		assert.Equal(t, int32(0), rs.ProvidersFound.Load())
+
+		baseErr := errors.New("no content")
+		wrappedErr := WrapWithState(ctx, baseErr)
+
+		var errWithState *ErrorWithState
+		require.True(t, errors.As(wrappedErr, &errWithState))
+		assert.Contains(t, wrappedErr.Error(), "no content: retrieval:")
+		assert.Contains(t, wrappedErr.Error(), "no providers found")
+	})
+
+	t.Run("ErrorWithState works with errors.As", func(t *testing.T) {
+		ctx, rs := ContextWithState(context.Background())
+		rs.ProvidersFound.Store(2)
+		rs.AddFailedProvider(test.RandPeerIDFatal(t))
+
+		baseErr := errors.New("fetch failed")
+		wrappedErr := WrapWithState(ctx, baseErr)
+
+		// Test errors.As
+		var errWithState *ErrorWithState
+		require.True(t, errors.As(wrappedErr, &errWithState))
+
+		// Access state through the getter
+		state := errWithState.RetrievalState()
+		assert.Equal(t, int32(2), state.ProvidersFound.Load())
+		assert.Len(t, state.GetFailedProviders(), 1)
 	})
 }

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -130,6 +130,26 @@ func TestRetrievalState(t *testing.T) {
 				expectedSubstring: "Found 5 provider(s), attempted 3, but none were reachable",
 			},
 			{
+				name: "Providers attempted but none reachable with failed peers",
+				setup: func(rs *RetrievalState) {
+					rs.ProvidersFound.Store(5)
+					rs.ProvidersAttempted.Store(3)
+					// Store peer IDs so we can verify they appear in the message
+					peerID1 := test.RandPeerIDFatal(t)
+					peerID2 := test.RandPeerIDFatal(t)
+					rs.AddFailedProvider(peerID1)
+					rs.AddFailedProvider(peerID2)
+					rs.SetPhase(PhaseConnecting)
+					
+					// Verify the summary includes the actual peer IDs
+					summary := rs.Summary()
+					assert.Contains(t, summary, "failed peers:")
+					assert.Contains(t, summary, peerID1.String())
+					assert.Contains(t, summary, peerID2.String())
+				},
+				expectedSubstring: "Found 5 provider(s), attempted 3, but none were reachable",
+			},
+			{
 				name: "Providers connected but didn't return content",
 				setup: func(rs *RetrievalState) {
 					rs.ProvidersFound.Store(5)

--- a/routing/providerquerymanager/providerquerymanager.go
+++ b/routing/providerquerymanager/providerquerymanager.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gammazero/chanqueue"
 	"github.com/gammazero/deque"
+	"github.com/ipfs/boxo/retrieval"
 	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	peer "github.com/libp2p/go-libp2p/core/peer"
@@ -357,6 +358,13 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 			findProviderCtx, cancel := context.WithTimeout(ctx, pqm.findProviderTimeout)
 			span := trace.SpanFromContext(findProviderCtx)
 			span.AddEvent("StartFindProvidersAsync")
+
+			// Update retrieval progress, if tracked in the existing context
+			retrievalState := retrieval.StateFromContext(ctx)
+			if retrievalState != nil {
+				retrievalState.SetPhase(retrieval.PhaseProviderDiscovery)
+			}
+
 			// We set count == 0. We will cancel the query manually once we
 			// have enough. This assumes the ContentDiscovery
 			// implementation does that, which a requirement per the
@@ -374,13 +382,25 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 					}
 
 					span.AddEvent("FoundProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID)))
+					if retrievalState != nil {
+						retrievalState.ProvidersFound.Add(1)
+						retrievalState.SetPhase(retrieval.PhaseConnecting)
+						retrievalState.ProvidersAttempted.Add(1)
+					}
+
 					err := pqm.dialer.Connect(findProviderCtx, p)
 					if err != nil && err != swarm.ErrDialToSelf {
 						span.RecordError(err, trace.WithAttributes(attribute.Stringer("peer", p.ID)))
 						log.Debugf("failed to connect to provider %s: %s", p.ID, err)
+						if retrievalState != nil {
+							retrievalState.AddFailedProvider(p.ID)
+						}
 						return
 					}
 					span.AddEvent("ConnectedToProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID)))
+					if retrievalState != nil {
+						retrievalState.ProvidersConnected.Add(1)
+					}
 					select {
 					case pqm.providerQueryMessages <- &receivedProviderMessage{
 						ctx: ctx,
@@ -487,6 +507,11 @@ func (npqm *newProvideQueryMessage) handle(pqm *ProviderQueryManager) {
 		span := trace.SpanFromContext(npqm.ctx)
 		span.AddEvent("NewQuery", trace.WithAttributes(attribute.Stringer("cid", npqm.k)))
 		ctx = trace.ContextWithSpan(ctx, span)
+
+		// Preserve RetrievalState from the original request context if present
+		if retrievalState := retrieval.StateFromContext(npqm.ctx); retrievalState != nil {
+			ctx = context.WithValue(ctx, retrieval.ContextKey, retrievalState)
+		}
 
 		// Use context derived from background here, and not the context from the
 		// request (npqm.ctx), because this inProgressRequestStatus applies to


### PR DESCRIPTION
This PR adds diagnostic tracking for IPFS content retrieval to provide meaningful error context when timeouts occur. This helps users understand exactly where and why retrieval failed.

We can refine presentation in future PRs.

- Closes https://github.com/ipshipyard/roadmaps/issues/14

## TLDR

- New boxo/retrieval package with `RetrievalState` for tracking retrieval phases
- Tracks provider discovery stats (found/attempted/connected)
- Records failed provider peer IDs for debugging
- Monotonic phase progression through retrieval stages
- Thread-safe concurrent access with atomic operations

### Integration points

The high level flow is:
1. Gateway handler creates context with `RetrievalState`: `retrieval.ContextWithState(r.Context())`
2. Gateway wraps context for request with session: `blockservice.ContextWithSession(ctx, bb.blockService)`
3. When blocks are fetched, blockservice creates exchange session with this context: `sesEx.NewSession(s.sesctx)`
4. Bitswap session manager creates session with this context
5. When the bitswap session calls `FindProvidersAsync`, it passes this context
6. `ProviderQueryManager` receives the context and can access the `RetrievalState`: `retrieval.StateFromContext(ctx)`
7. The `ProvidersFound.Add(1)` call in `providerquerymanager` updates the `RetrievalState` that will be included in the 504 timeout error message etc
8. Retrieval continues (or timeouts)  
9. The `RetrievalState.Summary()` provides human-readable diagnostics like seen in "Demo" section below


In practice, I had to make sure we manually pass/preserve state in two places, where `context.Background()` is used instead of `r.Context()` of the HTTP request:  
1. In `routing/providerquerymanager/providerquerymanager.go`: when creating a new context for provider queries, now copies the RetrievalState from the original request context
2. In `bitswap/client/client.go`: when creating a session context in GetBlocks(), now preserves the RetrievalState from the request context


## Demo

Basic test where there are no providers for a CID:

> <img width="732" height="364" alt="Screen Shot 2025-08-27 at 04 47 27" src="https://github.com/user-attachments/assets/e6e600e1-6381-44f3-a445-d95ab048dad5" />


Extra test where there was one provider in DHT, but I've shut it down, so Gateway found it, but failed to connect. We show up to 3 sample peers that failed:

> <img width="946" height="366" alt="Screen Shot 2025-08-27 at 05 00 53" src="https://github.com/user-attachments/assets/40818f01-5155-44d2-8435-ff0c15088529" />



| Before | After |
| ---- | ---- |
| <img width="1133" height="337" alt="image" src="https://github.com/user-attachments/assets/104f21af-2f25-4820-ac1d-b6d303e5feae" /> | <img width="1120" height="395" alt="image" src="https://github.com/user-attachments/assets/35abe246-7c63-4afa-b1d3-c03591b9c40e" /> |
