### PR TITLE
fix(gateway): prevent blocked CIDs in CAR responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `gateway`: Fixed CAR responses including blocked content. The gateway now properly filters out blocked CIDs from CAR format responses, ensuring content filtering policies are enforced across all response formats. ([ipfs/kubo#10361](https://github.com/ipfs/kubo/issues/10361))
+
 ### Security
 
 

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -448,7 +448,8 @@ func (bb *BlocksBackend) streamCAR(ctx context.Context, p path.ImmutablePath, pa
 		}
 
 		// Create DAG service with blocking detection
-		// Note: We don't use Session here as it might cache blocks and bypass blocking checks
+		// TODO: Restore .Session(ctx) once https://github.com/ipfs-shipyard/nopfs/issues/34
+		// is resolved. Sessions improve performance but currently bypass denylist checks.
 		dagService := merkledag.NewDAGService(bb.blockService)
 
 		// Wrap DAG service to write blocks to CAR as they're fetched
@@ -533,7 +534,9 @@ func (bb *BlocksBackend) handleCarErrorPath(ctx context.Context, p path.Immutabl
 	}
 
 	// Try to fetch just the root block to determine error type
-	dagService := merkledag.NewDAGService(bb.blockService).Session(ctx)
+	// TODO: Restore .Session(ctx) once https://github.com/ipfs-shipyard/nopfs/issues/34
+	// is resolved. Sessions improve performance but currently bypass denylist checks.
+	dagService := merkledag.NewDAGService(bb.blockService)
 	_, err := dagService.Get(ctx, rootCid)
 
 	if err != nil {

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -525,7 +525,6 @@ func (bb *BlocksBackend) handleCarErrorPath(ctx context.Context, p path.Immutabl
 	session := blockservice.NewSession(ctx, bb.blockService)
 	dagService := merkledag.WrapSession(session)
 	_, err := dagService.Get(ctx, rootCid)
-
 	if err != nil {
 		// Use existing error checking functions from errors.go
 		if isErrContentBlocked(err) {

--- a/gateway/backend_car.go
+++ b/gateway/backend_car.go
@@ -1048,7 +1048,7 @@ func (api *CarBackend) GetCAR(ctx context.Context, p path.ImmutablePath, params 
 
 			if !isNotFound {
 				params.Duplicates = DuplicateBlocksIncluded
-				err = walkGatewaySimpleSelector(ctx, terminalBlk.Cid(), terminalBlk, []string{}, params, l, nil)
+				err = walkGatewaySimpleSelector(ctx, terminalBlk.Cid(), terminalBlk, []string{}, params, l)
 				if err != nil {
 					return err
 				}

--- a/gateway/backend_car.go
+++ b/gateway/backend_car.go
@@ -1048,7 +1048,7 @@ func (api *CarBackend) GetCAR(ctx context.Context, p path.ImmutablePath, params 
 
 			if !isNotFound {
 				params.Duplicates = DuplicateBlocksIncluded
-				err = walkGatewaySimpleSelector(ctx, terminalBlk.Cid(), terminalBlk, []string{}, params, l)
+				err = walkGatewaySimpleSelector(ctx, terminalBlk.Cid(), terminalBlk, []string{}, params, l, nil)
 				if err != nil {
 					return err
 				}

--- a/gateway/errors.go
+++ b/gateway/errors.go
@@ -253,6 +253,12 @@ func webError(w http.ResponseWriter, r *http.Request, c *Config, err error, defa
 // isErrNotFound returns true for IPLD errors that should return 4xx errors (e.g. the path doesn't exist, the data is
 // the wrong type, etc.), rather than issues with just finding and retrieving the data.
 func isErrNotFound(err error) bool {
+	// Check for ErrorStatusCode with 404
+	var statusErr *ErrorStatusCode
+	if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound {
+		return true
+	}
+
 	if errors.Is(err, &resolver.ErrNoLink{}) || errors.Is(err, schema.ErrNoSuchField{}) {
 		return true
 	}
@@ -295,6 +301,12 @@ func isErrNotFound(err error) bool {
 // TODO: When nopfs becomes a direct dependency, replace this string matching with proper
 // type assertion or errors.Is() for more robust error detection.
 func isErrContentBlocked(err error) bool {
+	// Check for ErrorStatusCode with 410
+	var statusErr *ErrorStatusCode
+	if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusGone {
+		return true
+	}
+
 	// The nopfs StatusError.Error() returns messages in the format:
 	// - "{cid} is blocked and cannot be provided" for blocked CIDs
 	// - "{path} is blocked and cannot be provided" for blocked paths


### PR DESCRIPTION
> [!WARNING]
> This wip experimentation to see gateway-conformance regressions, not ready for review yet.

- Depends on:
  - https://github.com/ipfs-shipyard/nopfs/pull/50
  - https://github.com/ipfs/gateway-conformance/pull/244
  - https://github.com/ipfs/gateway-conformance/pull/245
- Closes #458

## fix for ipfs/kubo#10361

The gateway was including blocked CIDs in CAR format responses, bypassing content filtering policies.

The fix separates the DAGService usage in GetCAR:
- `nodeGetterToCarExporer` continues wrapping for path resolution
- Original `dagService` is now used for `blockOpener` during traversal
- `blockOpener` returns `traversal.SkipMe{}` for blocked content
- Added detailed comments explaining the blocking architecture

This ensures blocked content is filtered from CAR responses while allowing partial CAR generation when internal blocks are blocked.

- Tests in Kubo PR: https://github.com/ipfs/kubo/pull/10948

## fix for https://github.com/ipfs/boxo/issues/458

We wait with headers until first block, and return 410 / 404 when we know we can't serve the data.


<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
