### PR TITLE
feat(gateway): enhance 504 timeout errors with diagnostic UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
-- `gateway`: Added retrieval state tracking for timeout diagnostics. When retrieval timeouts occur, the error messages now include detailed information about which phase failed (path resolution, provider discovery, connecting, or data retrieval) and provider statistics. [#1015](https://github.com/ipfs/boxo/pull/1015)
+- `gateway`: Enhanced error handling and UX for timeouts:
+  - Added retrieval state tracking for timeout diagnostics. When retrieval timeouts occur, the error messages now include detailed information about which phase failed (path resolution, provider discovery, connecting, or data retrieval) and provider statistics including failed peer IDs [#1015](https://github.com/ipfs/boxo/pull/1015)
+  - Added `Config.DiagnosticServiceURL` to configure a CID retrievability diagnostic service. When set, 504 Gateway Timeout errors show a "Check CID retrievability" button linking to the service with `?cid=<failed-cid>`
+  - Improved 504 error pages with "Retry" button, diagnostic service integration, and clear indication when timeout occurs on sub-resource vs root CID
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,9 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - `gateway`: Enhanced error handling and UX for timeouts:
-  - Added retrieval state tracking for timeout diagnostics. When retrieval timeouts occur, the error messages now include detailed information about which phase failed (path resolution, provider discovery, connecting, or data retrieval) and provider statistics including failed peer IDs [#1015](https://github.com/ipfs/boxo/pull/1015)
-  - Added `Config.DiagnosticServiceURL` to configure a CID retrievability diagnostic service. When set, 504 Gateway Timeout errors show a "Check CID retrievability" button linking to the service with `?cid=<failed-cid>`
-  - Improved 504 error pages with "Retry" button, diagnostic service integration, and clear indication when timeout occurs on sub-resource vs root CID
+  - Added retrieval state tracking for timeout diagnostics. When retrieval timeouts occur, the error messages now include detailed information about which phase failed (path resolution, provider discovery, connecting, or data retrieval) and provider statistics including failed peer IDs [#1015](https://github.com/ipfs/boxo/pull/1015) [#1023](https://github.com/ipfs/boxo/pull/1023)
+  - Added `Config.DiagnosticServiceURL` to configure a CID retrievability diagnostic service. When set, 504 Gateway Timeout errors show a "Check CID retrievability" button linking to the service with `?cid=<failed-cid>` [#1023](https://github.com/ipfs/boxo/pull/1023)
+  - Improved 504 error pages with "Retry" button, diagnostic service integration, and clear indication when timeout occurs on sub-resource vs root CID [#1023](https://github.com/ipfs/boxo/pull/1023)
 
 ### Changed
 

--- a/gateway/assets/assets.go
+++ b/gateway/assets/assets.go
@@ -106,9 +106,12 @@ type DagTemplateData struct {
 
 type ErrorTemplateData struct {
 	GlobalData
-	StatusCode int
-	StatusText string
-	Error      string
+	StatusCode           int
+	StatusText           string
+	Error                string
+	DiagnosticServiceURL string
+	RootCID              string
+	FailedCID            string
 }
 
 type DirectoryTemplateData struct {

--- a/gateway/assets/error.html
+++ b/gateway/assets/error.html
@@ -34,22 +34,42 @@
       {{ else if eq .StatusCode 502 }}
         <p>The gateway backed was unable to fullfil your request due to an error.</p>
       {{ else if eq .StatusCode 504 }}
-        <p>The gateway backend was unable to fullfil your request due to a timeout.</p>
+        <p>This gateway is taking too long to fetch content from content providers. Please check the error below for more information.</p>
+
+        {{ if and .RootCID .FailedCID (ne .RootCID .FailedCID) }}
+          <p><strong>Note:</strong> The timeout occurred while fetching a sub-resource (CID: <code>{{ .FailedCID }}</code>) of the root content (CID: <code>{{ .RootCID }}</code>).</p>
+        {{ end }}
+
       {{ else if eq .StatusCode 506 }}
         <p>The gateway backend was unable to fullfil your request at this time. Try again later.</p>
       {{ end }}
 
       <pre class="terminal wrap">{{ .Error }}</pre>
-         
+
       <p>How you can proceed:</p>
       <ul>
-        <li>Check the <a href="https://discuss.ipfs.tech/c/help/13" rel="noopener noreferrer">Discussion Forums</a> for similar errors.</li>
-        <li>Try diagnosing your request with the <a href="https://docs.ipfs.tech/reference/diagnostic-tools/" rel="noopener noreferrer">diagnostic tools</a>.</li>
-        <li>Self-host and run an <a href="https://docs.ipfs.tech/concepts/ipfs-implementations/" rel="noopener noreferrer">IPFS client</a> that verifies your data.</li>
+        <li>Check the <a href="https://discuss.ipfs.tech/c/help/13" target="_blank" rel="noopener noreferrer">Discussion Forums</a> for similar errors.</li>
+        <li>Try diagnosing your request with the <a href="https://docs.ipfs.tech/reference/diagnostic-tools/" target="_blank" rel="noopener noreferrer">diagnostic tools</a>.</li>
+        <li>Self-host and run an <a href="https://docs.ipfs.tech/concepts/ipfs-implementations/" target="_blank" rel="noopener noreferrer">IPFS client</a> that verifies your data.</li>
         {{ if or (eq .StatusCode 400) (eq .StatusCode 404) }}
-          <li>Inspect the <a href="https://cid.ipfs.tech/" rel="noopener noreferrer">CID</a> or <a href="https://explore.ipld.io/" rel="noopener noreferrer">DAG</a>.</li>
+          <li>Inspect the <a href="https://cid.ipfs.tech/" target="_blank" rel="noopener noreferrer">CID</a> or <a href="https://explore.ipld.io/" target="_blank" rel="noopener noreferrer">DAG</a>.</li>
         {{ end }}
       </ul>
+
+      <div class="buttons">
+        <button onclick="document.querySelector('#main .container').innerHTML = '<p>Retrying, please wait...</p>'; window.location.reload(true)"
+                class="button retry-button">
+          Retry
+        </button>
+        {{ if and (eq .StatusCode 504) .FailedCID .DiagnosticServiceURL }}
+          <a href="{{ .DiagnosticServiceURL }}?cid={{ .FailedCID }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="button diagnose-button">
+            Check CID retrievability
+          </a>
+        {{ end }}
+      </div>
     </section>
   </main>
 </body>

--- a/gateway/assets/error.html
+++ b/gateway/assets/error.html
@@ -32,7 +32,7 @@
       {{ else if eq .StatusCode 500 }}
         <p>This gateway was unable to return the requested data due to an internal error. Please check the error below for more information.</p>
       {{ else if eq .StatusCode 502 }}
-        <p>The gateway backed was unable to fullfil your request due to an error.</p>
+        <p>The gateway backend was unable to fulfill your request due to an error.</p>
       {{ else if eq .StatusCode 504 }}
         <p>This gateway is taking too long to fetch content from content providers. Please check the error below for more information.</p>
 
@@ -41,7 +41,7 @@
         {{ end }}
 
       {{ else if eq .StatusCode 506 }}
-        <p>The gateway backend was unable to fullfil your request at this time. Try again later.</p>
+        <p>The gateway backend was unable to fulfill your request at this time. Try again later.</p>
       {{ end }}
 
       <pre class="terminal wrap">{{ .Error }}</pre>

--- a/gateway/assets/style.css
+++ b/gateway/assets/style.css
@@ -36,11 +36,6 @@ a:hover {
 	text-decoration: underline;
 }
 
-a:active,
-a:visited {
-	color: #00b0e9;
-}
-
 .flex {
 	display: flex;
 }
@@ -235,7 +230,7 @@ section > .grid.dag > div:nth-of-type(2n+1) {
 .terminal {
 	background: var(--steel-gray);
 	color: white;
-	padding: .7em;
+	padding: 0.625em 1.25em;
 	border-radius: var(--radius);
 	word-wrap: break-word;
 	white-space: break-spaces;
@@ -272,4 +267,42 @@ section > .grid.dag > div:nth-of-type(2n+1) {
 	.dn-mobile {
 		display: none;
 	}
+}
+
+.buttons {
+	margin: 1.5em 0;
+	display: flex;
+	gap: 0.75em;
+	flex-wrap: wrap;
+}
+
+.button {
+	display: inline-block;
+	padding: 0.625em 1.25em;
+	font-size: 1em;
+	cursor: pointer;
+	border-radius: var(--radius);
+	text-decoration: none;
+	border: none;
+	font-family: inherit;
+}
+
+.retry-button {
+	background-color: #3B8C90;
+	color: var(--near-white);
+}
+
+.retry-button:hover {
+	background-color: var(--navy);
+}
+
+.diagnose-button {
+	background-color: var(--steel-gray);
+	color: var(--near-white);
+}
+
+.diagnose-button:hover {
+	background-color: var(--navy);
+	color: var(--near-white);
+	text-decoration: none;
 }

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -671,6 +671,8 @@ func (bb *BlocksBackend) getPathRoots(ctx context.Context, contentPath path.Immu
 	// Update retrieval progress, if tracked in the existing context
 	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
 		retrievalState.SetPhase(retrieval.PhasePathResolution)
+		// Set the root CID (first CID in the path)
+		retrievalState.SetRootCID(contentPath.RootCid())
 	}
 
 	/*
@@ -726,6 +728,14 @@ func (bb *BlocksBackend) getPathRoots(ctx context.Context, contentPath path.Immu
 	}
 
 	pathRoots = pathRoots[:len(pathRoots)-1]
+
+	// Set the terminal CID after successful path resolution
+	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+		if rootCid := lastPath.RootCid(); rootCid.Defined() {
+			retrievalState.SetTerminalCID(rootCid)
+		}
+	}
+
 	return pathRoots, lastPath, remainder, nil
 }
 

--- a/gateway/backend_car.go
+++ b/gateway/backend_car.go
@@ -213,6 +213,8 @@ func resolvePathWithRootsAndBlock(ctx context.Context, p path.ImmutablePath, uni
 	// Update retrieval progress, if tracked in the existing context
 	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
 		retrievalState.SetPhase(retrieval.PhasePathResolution)
+		// Set the root CID (first CID in the path)
+		retrievalState.SetRootCID(p.RootCid())
 	}
 	md, terminalBlk, err := resolvePathToLastWithRoots(ctx, p, unixFSLsys)
 	if err != nil {
@@ -232,6 +234,11 @@ func resolvePathWithRootsAndBlock(ctx context.Context, p path.ImmutablePath, uni
 		if err != nil {
 			return ContentPathMetadata{}, nil, err
 		}
+	}
+
+	// Set the terminal CID after successful path resolution
+	if retrievalState := retrieval.StateFromContext(ctx); retrievalState != nil {
+		retrievalState.SetTerminalCID(terminalCid)
 	}
 
 	return md, terminalBlk, err

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -32,6 +32,9 @@ const (
 	//
 	// See the MaxConcurrentRequests field documentation for detailed tuning guidance.
 	DefaultMaxConcurrentRequests = 4096
+
+	// DefaultDiagnosticServiceURL is the default URL for CID diagnostic service
+	DefaultDiagnosticServiceURL = "https://check.ipfs.network"
 )
 
 // Config is the configuration used when creating a new gateway handler.
@@ -114,6 +117,13 @@ type Config struct {
 	//
 	// A value of 0 disables the limit entirely (use with caution).
 	MaxConcurrentRequests int
+
+	// DiagnosticServiceURL is the URL for a service that can be used to diagnose
+	// issues with CID retrievability. When the gateway returns a 504 Gateway Timeout
+	// error, an "Inspect retrievability of CID" button will be shown that links to
+	// this service with the CID as a query parameter. When set to empty string, the
+	// button is not shown.
+	DiagnosticServiceURL string
 
 	// MetricsRegistry is the Prometheus registry to use for metrics.
 	// If nil, prometheus.DefaultRegisterer will be used.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -128,6 +129,22 @@ type Config struct {
 	// MetricsRegistry is the Prometheus registry to use for metrics.
 	// If nil, prometheus.DefaultRegisterer will be used.
 	MetricsRegistry prometheus.Registerer
+}
+
+// validateConfig validates and normalizes the Config, returning a modified copy.
+// Invalid values are logged and set to safe defaults.
+func validateConfig(c Config) Config {
+	// Validate DiagnosticServiceURL
+	if c.DiagnosticServiceURL != "" {
+		if _, err := url.Parse(c.DiagnosticServiceURL); err != nil {
+			log.Errorf("invalid DiagnosticServiceURL %q: %v, disabling diagnostic service", c.DiagnosticServiceURL, err)
+			c.DiagnosticServiceURL = ""
+		}
+	}
+
+	// Future validations can be added here
+
+	return c
 }
 
 // PublicGateway is the specification of an IPFS Public Gateway.

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -68,6 +68,9 @@ type handler struct {
 //
 // [IPFS HTTP Gateway]: https://specs.ipfs.tech/http-gateways/
 func NewHandler(c Config, backend IPFSBackend) http.Handler {
+	// Validate and normalize configuration
+	c = validateConfig(c)
+
 	// Get registry from config or use default
 	reg := c.MetricsRegistry
 	if reg == nil {

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -356,7 +356,7 @@ func TestErrorWithState(t *testing.T) {
 
 		// Check that error includes failed peers
 		errMsg := err.Error()
-		assert.Contains(t, errMsg, "connection failed: retrieval: found 3 provider(s), connected to 1, but they did not return the requested content (phase: data retrieval, failed peers: [")
+		assert.Contains(t, errMsg, "connection failed: retrieval: found 3 provider(s), connected to 1, but they did not return the requested content (phase: data retrieval, failed peers: ")
 		assert.Contains(t, errMsg, peerID1.String())
 		assert.Contains(t, errMsg, peerID2.String())
 	})

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -79,6 +79,27 @@ func TestRetrievalState(t *testing.T) {
 		assert.Equal(t, int32(1), rs.ProvidersConnected.Load())
 	})
 
+	t.Run("Found providers are tracked up to limit", func(t *testing.T) {
+		rs := NewRetrievalState()
+
+		// Create real peer IDs for testing
+		peerIDs := make([]peer.ID, 5)
+		for i := range peerIDs {
+			peerIDs[i] = test.RandPeerIDFatal(t)
+		}
+
+		// Add more than MaxProvidersSampleSize providers
+		for _, peerID := range peerIDs {
+			rs.AddFoundProvider(peerID)
+		}
+
+		foundProviders := rs.GetFoundProviders()
+		assert.Len(t, foundProviders, MaxProvidersSampleSize)
+		assert.Equal(t, peerIDs[0], foundProviders[0])
+		assert.Equal(t, peerIDs[1], foundProviders[1])
+		assert.Equal(t, peerIDs[2], foundProviders[2])
+	})
+
 	t.Run("Failed providers are tracked up to limit", func(t *testing.T) {
 		rs := NewRetrievalState()
 
@@ -88,13 +109,13 @@ func TestRetrievalState(t *testing.T) {
 			peerIDs[i] = test.RandPeerIDFatal(t)
 		}
 
-		// Add more than MaxFailedProvidersToTrack providers
+		// Add more than MaxProvidersSampleSize providers
 		for _, peerID := range peerIDs {
 			rs.AddFailedProvider(peerID)
 		}
 
 		failedProviders := rs.GetFailedProviders()
-		assert.Len(t, failedProviders, MaxFailedProvidersToTrack)
+		assert.Len(t, failedProviders, MaxProvidersSampleSize)
 		assert.Equal(t, peerIDs[0], failedProviders[0])
 		assert.Equal(t, peerIDs[1], failedProviders[1])
 		assert.Equal(t, peerIDs[2], failedProviders[2])
@@ -122,6 +143,21 @@ func TestRetrievalState(t *testing.T) {
 				expectedSubstring: "found 5 provider(s) but none could be contacted",
 			},
 			{
+				name: "Single provider found but not reachable shows peer ID",
+				setup: func(rs *RetrievalState) {
+					rs.ProvidersFound.Store(1)
+					rs.ProvidersAttempted.Store(1)
+					peerID := test.RandPeerIDFatal(t)
+					rs.AddFoundProvider(peerID)
+					rs.SetPhase(PhaseConnecting)
+
+					// Verify the peer ID appears in the summary
+					summary := rs.Summary()
+					assert.Contains(t, summary, peerID.String())
+				},
+				expectedSubstring: "found 1 provider(s), attempted 1, but none were reachable (phase: connecting to providers, peers:",
+			},
+			{
 				name: "Providers attempted but none reachable",
 				setup: func(rs *RetrievalState) {
 					rs.ProvidersFound.Store(5)
@@ -131,20 +167,20 @@ func TestRetrievalState(t *testing.T) {
 				expectedSubstring: "found 5 provider(s), attempted 3, but none were reachable",
 			},
 			{
-				name: "Providers attempted but none reachable with failed peers",
+				name: "Providers attempted but none reachable with found peers",
 				setup: func(rs *RetrievalState) {
 					rs.ProvidersFound.Store(5)
 					rs.ProvidersAttempted.Store(3)
 					// Store peer IDs so we can verify they appear in the message
 					peerID1 := test.RandPeerIDFatal(t)
 					peerID2 := test.RandPeerIDFatal(t)
-					rs.AddFailedProvider(peerID1)
-					rs.AddFailedProvider(peerID2)
+					rs.AddFoundProvider(peerID1)
+					rs.AddFoundProvider(peerID2)
 					rs.SetPhase(PhaseConnecting)
 
 					// Verify the summary includes the actual peer IDs
 					summary := rs.Summary()
-					assert.Contains(t, summary, "failed peers:")
+					assert.Contains(t, summary, "peers:")
 					assert.Contains(t, summary, peerID1.String())
 					assert.Contains(t, summary, peerID2.String())
 				},

--- a/routing/providerquerymanager/providerquerymanager.go
+++ b/routing/providerquerymanager/providerquerymanager.go
@@ -384,6 +384,7 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 					span.AddEvent("FoundProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID)))
 					if retrievalState != nil {
 						retrievalState.ProvidersFound.Add(1)
+						retrievalState.AddFoundProvider(p.ID)
 						retrievalState.SetPhase(retrieval.PhaseConnecting)
 						retrievalState.ProvidersAttempted.Add(1)
 					}


### PR DESCRIPTION
This expands on foundations from  https://github.com/ipfs/boxo/pull/1015:

- [x] add `DiagnosticServiceURL` config for CID retrievability checks
- [x] show "Check CID retrievability" button on 504 errors
- [x] add "Retry" button on all error pages
- [x] track and display failed peer IDs in timeout messages
- [x] indicate when timeout occurs on sub-resource vs root CID
- [x] improve error page styling and button UX
- [x] show peerids when we discovered them but failed to connect to them because they are offline DHT peer (found peerid but no addrs, or cant connect to them)

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


- Part of https://github.com/ipshipyard/roadmaps/issues/14


----


## Demo

This PR not only shows the PeerID of "offline" peer found as a provider on DHT, but also has two buttons to Refresh or Debug:

> <img width="955" height="427" alt="image" src="https://github.com/user-attachments/assets/18432c74-a5e0-4bbf-9815-7c780779dc98" />

