### PR TITLE
fix(pinner): restore indirect pin detection and add context cancellation

### DIFF
--- a/pinning/pinner/dspinner/pin.go
+++ b/pinning/pinner/dspinner/pin.go
@@ -646,34 +646,8 @@ func (p *pinner) CheckIfPinnedWithType(ctx context.Context, mode ipfspinner.Mode
 
 		// Check for indirect pins
 		if toCheck.Len() > 0 {
-			var walkErr error
-			visited := cid.NewSet()
-			err := p.cidRIndex.ForEach(ctx, "", func(key, value string) bool {
-				var rk cid.Cid
-				rk, walkErr = cid.Cast([]byte(key))
-				if walkErr != nil {
-					return false
-				}
-				walkErr = merkledag.Walk(ctx, merkledag.GetLinksWithDAG(p.dserv), rk, func(c cid.Cid) bool {
-					if toCheck.Len() == 0 || !visited.Visit(c) {
-						return false
-					}
-					if toCheck.Has(c) {
-						pinned = append(pinned, ipfspinner.Pinned{Key: c, Mode: ipfspinner.Indirect, Via: rk})
-						toCheck.Remove(c)
-					}
-					return true
-				}, merkledag.Concurrent())
-				if walkErr != nil {
-					return false
-				}
-				return toCheck.Len() > 0
-			})
-			if err != nil {
+			if err := p.traverseIndirectPins(ctx, toCheck, &pinned); err != nil {
 				return nil, err
-			}
-			if walkErr != nil {
-				return nil, walkErr
 			}
 		}
 
@@ -741,6 +715,49 @@ func (p *pinner) checkPinsInIndex(ctx context.Context, mode ipfspinner.Mode, inc
 	return pinned, nil
 }
 
+// traverseIndirectPins is a helper that traverses all recursive pins to find indirect pins.
+// It modifies the pinned slice and toCheck set in place.
+func (p *pinner) traverseIndirectPins(ctx context.Context, toCheck *cid.Set, pinned *[]ipfspinner.Pinned) error {
+	var walkErr error
+	visited := cid.NewSet()
+	err := p.cidRIndex.ForEach(ctx, "", func(key, value string) bool {
+		// Check for context cancellation at the start of each recursive pin
+		select {
+		case <-ctx.Done():
+			walkErr = ctx.Err()
+			return false
+		default:
+		}
+
+		var rk cid.Cid
+		rk, walkErr = cid.Cast([]byte(key))
+		if walkErr != nil {
+			return false
+		}
+		walkErr = merkledag.Walk(ctx, merkledag.GetLinksWithDAG(p.dserv), rk, func(c cid.Cid) bool {
+			if toCheck.Len() == 0 || !visited.Visit(c) {
+				return false
+			}
+			if toCheck.Has(c) {
+				*pinned = append(*pinned, ipfspinner.Pinned{Key: c, Mode: ipfspinner.Indirect, Via: rk})
+				toCheck.Remove(c)
+			}
+			return true
+		}, merkledag.Concurrent())
+		if walkErr != nil {
+			return false
+		}
+		return toCheck.Len() > 0
+	})
+	if err != nil {
+		return err
+	}
+	if walkErr != nil {
+		return walkErr
+	}
+	return nil
+}
+
 // checkIndirectPins checks if the given cids are pinned indirectly
 func (p *pinner) checkIndirectPins(ctx context.Context, cids ...cid.Cid) ([]ipfspinner.Pinned, error) {
 	pinned := make([]ipfspinner.Pinned, 0, len(cids))
@@ -754,34 +771,8 @@ func (p *pinner) checkIndirectPins(ctx context.Context, cids ...cid.Cid) ([]ipfs
 
 	// Now check for indirect pins by traversing recursive pins
 	if toCheck.Len() > 0 {
-		var walkErr error
-		visited := cid.NewSet()
-		err := p.cidRIndex.ForEach(ctx, "", func(key, value string) bool {
-			var rk cid.Cid
-			rk, walkErr = cid.Cast([]byte(key))
-			if walkErr != nil {
-				return false
-			}
-			walkErr = merkledag.Walk(ctx, merkledag.GetLinksWithDAG(p.dserv), rk, func(c cid.Cid) bool {
-				if toCheck.Len() == 0 || !visited.Visit(c) {
-					return false
-				}
-				if toCheck.Has(c) {
-					pinned = append(pinned, ipfspinner.Pinned{Key: c, Mode: ipfspinner.Indirect, Via: rk})
-					toCheck.Remove(c)
-				}
-				return true
-			}, merkledag.Concurrent())
-			if walkErr != nil {
-				return false
-			}
-			return toCheck.Len() > 0
-		})
-		if err != nil {
+		if err := p.traverseIndirectPins(ctx, toCheck, &pinned); err != nil {
 			return nil, err
-		}
-		if walkErr != nil {
-			return nil, walkErr
 		}
 	}
 


### PR DESCRIPTION
Follow-up for #1035 (forgot to push local changes):
- Small fix to ensure behavior from before PR #1035 is exactly the same 
  - Sharness in https://github.com/ipfs/kubo/pull/10970 caught this regression


While at it, some cleanup:
- Dry helper `traverseIndirectPins` to avoid duplicated code
- Added check for context cancellation at the start of each recursive pin
  - It was not present in old code before #1035, so in theory aborting listing all pins was sometimes stuck for longer than it should