### PR TITLE
refactor(gateway): switch defaults to autoconf.FallbackDNSResolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ The following emojis are used to highlight certain changes:
   - Added `Config.DiagnosticServiceURL` to configure a CID retrievability diagnostic service. When set, 504 Gateway Timeout errors show a "Check CID retrievability" button linking to the service with `?cid=<failed-cid>` [#1023](https://github.com/ipfs/boxo/pull/1023)
   - Improved 504 error pages with "Retry" button, diagnostic service integration, and clear indication when timeout occurs on sub-resource vs root CID [#1023](https://github.com/ipfs/boxo/pull/1023)
 - `gateway`: Added `Config.MaxRangeRequestFileSize` to protect against CDN issues with large file range requests. When set to a non-zero value, range requests for files larger than this limit return HTTP 501 Not Implemented with a suggestion to use verifiable block requests (`application/vnd.ipld.raw`) instead. This provides protection against Cloudflare's issue where range requests for files over 5GiB are silently ignored, causing excess bandwidth consumption and billing
-- `autoconf`: Added `Client.ExpandDNSResolvers()` convenience method for expanding DNS resolver maps with autoconf data ([#771](https://github.com/ipfs/boxo/issues/771), [#772](https://github.com/ipfs/boxo/issues/772))
 
 ### Changed
 
@@ -43,16 +42,12 @@ The following emojis are used to highlight certain changes:
   - The default `MaximumAllowedCid` limit for incoming CIDs can be adjusted using `bitswap.MaxCidSize` or `server.MaxCidSize` options
 - 🛠 `bitswap/client`: The `RebroadcastDelay` option now takes a `time.Duration` value. This is a potentially BREAKING CHANGE. The time-varying functionality of `delay.Delay` was never used, so it was replaced with a fixed duration value. This also removes the `github.com/ipfs/go-ipfs-delay` dependency.
 - `filestore`: Support providing filestore-blocks. A new `provider.MultihashProvider` parameter has been added to `filestore.New()`. When used, the blocks handled by the Filestore's `FileManager` will be provided on write (Put and PutMany).
+- `gateway`: DNS resolver defaults moved to `autoconf.FallbackDNSResolvers`
+  - `NewDNSResolver(nil)` uses `autoconf.FallbackDNSResolvers`, preserving existing behavior for users who did not pass custom config
+  - Pass empty map `NewDNSResolver(map[string]string{})` to use only system DNS
+  - For custom or dynamic DNS resolvers, use `autoconf.ExpandDNSResolvers()` to merge network defaults with your own resolvers
 
 ### Removed
-
-- `gateway`: 🛠 Removed hardcoded `defaultResolvers` for `.eth` and `.crypto` TLDs from `gateway.NewDNSResolver` ([#771](https://github.com/ipfs/boxo/issues/771), [#772](https://github.com/ipfs/boxo/issues/772))
-  - This change removes implicit defaults that were difficult to discover, override, or disable, improving user agency and configuration transparency
-  - `NewDNSResolver(nil)` now uses system DNS only (no implicit DoH resolvers)
-  - Users needing DNS-over-HTTPS for non-ICANN TLDs should either:
-    - Pass explicit resolvers: `NewDNSResolver(map[string]string{"eth.": "https://dns.eth.limo/dns-query"})`
-    - Use `autoconf.ExpandDNSResolvers()` to merge network defaults with custom resolvers
-    - Use `autoconf.Client.ExpandDNSResolvers()` for convenience in long-running applications
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The following emojis are used to highlight certain changes:
   - Added `Config.DiagnosticServiceURL` to configure a CID retrievability diagnostic service. When set, 504 Gateway Timeout errors show a "Check CID retrievability" button linking to the service with `?cid=<failed-cid>` [#1023](https://github.com/ipfs/boxo/pull/1023)
   - Improved 504 error pages with "Retry" button, diagnostic service integration, and clear indication when timeout occurs on sub-resource vs root CID [#1023](https://github.com/ipfs/boxo/pull/1023)
 - `gateway`: Added `Config.MaxRangeRequestFileSize` to protect against CDN issues with large file range requests. When set to a non-zero value, range requests for files larger than this limit return HTTP 501 Not Implemented with a suggestion to use verifiable block requests (`application/vnd.ipld.raw`) instead. This provides protection against Cloudflare's issue where range requests for files over 5GiB are silently ignored, causing excess bandwidth consumption and billing
+- `autoconf`: Added `Client.ExpandDNSResolvers()` convenience method for expanding DNS resolver maps with autoconf data ([#771](https://github.com/ipfs/boxo/issues/771), [#772](https://github.com/ipfs/boxo/issues/772))
 
 ### Changed
 
@@ -44,6 +45,14 @@ The following emojis are used to highlight certain changes:
 - `filestore`: Support providing filestore-blocks. A new `provider.MultihashProvider` parameter has been added to `filestore.New()`. When used, the blocks handled by the Filestore's `FileManager` will be provided on write (Put and PutMany).
 
 ### Removed
+
+- `gateway`: 🛠 Removed hardcoded `defaultResolvers` for `.eth` and `.crypto` TLDs from `gateway.NewDNSResolver` ([#771](https://github.com/ipfs/boxo/issues/771), [#772](https://github.com/ipfs/boxo/issues/772))
+  - This change removes implicit defaults that were difficult to discover, override, or disable, improving user agency and configuration transparency
+  - `NewDNSResolver(nil)` now uses system DNS only (no implicit DoH resolvers)
+  - Users needing DNS-over-HTTPS for non-ICANN TLDs should either:
+    - Pass explicit resolvers: `NewDNSResolver(map[string]string{"eth.": "https://dns.eth.limo/dns-query"})`
+    - Use `autoconf.ExpandDNSResolvers()` to merge network defaults with custom resolvers
+    - Use `autoconf.Client.ExpandDNSResolvers()` for convenience in long-running applications
 
 ### Fixed
 

--- a/autoconf/fetch.go
+++ b/autoconf/fetch.go
@@ -603,32 +603,3 @@ func calculateEffectiveRefreshInterval(userInterval time.Duration, cacheTTLSecon
 	serverTTL := time.Duration(cacheTTLSeconds) * time.Second
 	return min(serverTTL, userInterval)
 }
-
-// ExpandDNSResolvers expands DNS resolvers with "auto" placeholders using cached autoconf data.
-// This is a convenience method for applications that need to construct DNS resolvers.
-//
-// The customResolvers parameter is a map of domain patterns to DNS resolver URLs,
-// where values can be "auto" to use autoconf-provided resolvers. If nil or empty,
-// only autoconf resolvers will be returned.
-//
-// Returns a map ready to be passed to gateway.NewDNSResolver().
-//
-// Example:
-//
-//	client, _ := autoconf.NewClient()
-//
-//	// Apply all autoconf DNS resolvers
-//	resolvers := client.ExpandDNSResolvers(map[string]string{
-//	    ".": "auto",
-//	})
-//
-//	// Mix autoconf with custom resolvers
-//	resolvers = client.ExpandDNSResolvers(map[string]string{
-//	    "eth.": "auto",
-//	    "example.": "https://dns.example.com/dns-query",
-//	})
-//
-//	dnsResolver, _ := gateway.NewDNSResolver(resolvers)
-func (c *Client) ExpandDNSResolvers(customResolvers map[string]string) map[string]string {
-	return ExpandDNSResolvers(customResolvers, c.GetCached())
-}

--- a/autoconf/fetch.go
+++ b/autoconf/fetch.go
@@ -603,3 +603,32 @@ func calculateEffectiveRefreshInterval(userInterval time.Duration, cacheTTLSecon
 	serverTTL := time.Duration(cacheTTLSeconds) * time.Second
 	return min(serverTTL, userInterval)
 }
+
+// ExpandDNSResolvers expands DNS resolvers with "auto" placeholders using cached autoconf data.
+// This is a convenience method for applications that need to construct DNS resolvers.
+//
+// The customResolvers parameter is a map of domain patterns to DNS resolver URLs,
+// where values can be "auto" to use autoconf-provided resolvers. If nil or empty,
+// only autoconf resolvers will be returned.
+//
+// Returns a map ready to be passed to gateway.NewDNSResolver().
+//
+// Example:
+//
+//	client, _ := autoconf.NewClient()
+//
+//	// Apply all autoconf DNS resolvers
+//	resolvers := client.ExpandDNSResolvers(map[string]string{
+//	    ".": "auto",
+//	})
+//
+//	// Mix autoconf with custom resolvers
+//	resolvers = client.ExpandDNSResolvers(map[string]string{
+//	    "eth.": "auto",
+//	    "example.": "https://dns.example.com/dns-query",
+//	})
+//
+//	dnsResolver, _ := gateway.NewDNSResolver(resolvers)
+func (c *Client) ExpandDNSResolvers(customResolvers map[string]string) map[string]string {
+	return ExpandDNSResolvers(customResolvers, c.GetCached())
+}

--- a/gateway/dns.go
+++ b/gateway/dns.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/ipfs/boxo/autoconf"
 	"github.com/libp2p/go-doh-resolver"
 	dns "github.com/miekg/dns"
 	madns "github.com/multiformats/go-multiaddr-dns"
@@ -23,11 +24,11 @@ func newResolver(url string, opts ...doh.Option) (madns.BasicResolver, error) {
 // URLs starting with "https://" indicate [DoH] endpoints. Support for other resolver
 // types may be added in the future.
 //
-// If 'resolvers' is nil or empty, the default system DNS resolver will be used.
+// If 'resolvers' is nil, it defaults to {".": "auto"} and uses [autoconf.FallbackDNSResolvers]
+// for common non-ICANN TLDs. Pass an empty map {} to explicitly use only the system DNS resolver.
 //
-// To use network-specific DNS resolvers (e.g., for .eth or other non-ICANN TLDs),
-// use [boxo/autoconf.ExpandDNSResolvers] to merge autoconf-provided resolvers with
-// custom resolvers before calling this function.
+// For dynamic network-based DNS resolver configuration, use [autoconf.ExpandDNSResolvers]
+// to merge autoconf-provided resolvers with custom resolvers before calling this function.
 //
 // Example:
 //   - Custom resolver for ENS:          "eth." → "https://eth.link/dns-query"
@@ -38,9 +39,33 @@ func newResolver(url string, opts ...doh.Option) (madns.BasicResolver, error) {
 func NewDNSResolver(resolvers map[string]string, dohOpts ...doh.Option) (*madns.Resolver, error) {
 	var opts []madns.Option
 	var err error
-
 	rslvrs := make(map[string]madns.BasicResolver) // to reuse resolvers for the same URL
 
+	// Use autoconf fallback defaults when nil (not when empty map)
+	// These are created without dohOpts (standard configuration)
+	if resolvers == nil {
+		for domain, urls := range autoconf.FallbackDNSResolvers {
+			if len(urls) == 0 {
+				continue
+			}
+			url := urls[0]
+
+			rslv, ok := rslvrs[url]
+			if !ok {
+				rslv, err = newResolver(url)
+				if err != nil {
+					return nil, fmt.Errorf("bad resolver for %s: %w", domain, err)
+				}
+				rslvrs[url] = rslv
+			}
+
+			opts = append(opts, madns.WithDomainResolver(domain, rslv))
+		}
+
+		return madns.NewResolver(opts...)
+	}
+
+	// Handle user-provided resolvers with custom dohOpts
 	for domain, url := range resolvers {
 		if domain != "." && !dns.IsFqdn(domain) {
 			return nil, fmt.Errorf("invalid domain %s; must be FQDN", domain)

--- a/gateway/dns_test.go
+++ b/gateway/dns_test.go
@@ -117,3 +117,15 @@ func dnslinkServerHandlerFunc(t *testing.T, dnslinkName string, txtResponse stri
 		}
 	}
 }
+
+func TestDNSResolverNilUsesAutoconfFallback(t *testing.T) {
+	r, err := NewDNSResolver(nil)
+	require.NoError(t, err)
+	require.NotNil(t, r)
+}
+
+func TestDNSResolverEmptyMapUsesSystemDNS(t *testing.T) {
+	r, err := NewDNSResolver(map[string]string{})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+}

--- a/gateway/dns_test.go
+++ b/gateway/dns_test.go
@@ -41,7 +41,7 @@ func TestAddNewDNSResolver(t *testing.T) {
 	require.Equal(t, dnslinkValue, res[0])
 }
 
-func TestOverrideDNSDefaults(t *testing.T) {
+func TestCustomDNSResolver(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -50,7 +50,7 @@ func TestOverrideDNSDefaults(t *testing.T) {
 	require.NoError(t, err)
 	defer l.Close()
 
-	dnslinkName := "dnslink-test.eth"
+	dnslinkName := "dnslink-test.foo"
 	dnslinkValue := "dnslink=/ipfs/bafkqaaa"
 
 	go func() {
@@ -59,7 +59,7 @@ func TestOverrideDNSDefaults(t *testing.T) {
 
 	listenAddr := l.Addr().(*net.TCPAddr)
 	r, err := NewDNSResolver(map[string]string{
-		"eth.": fmt.Sprintf("http://%s:%d", listenAddr.IP, listenAddr.Port),
+		"foo.": fmt.Sprintf("http://%s:%d", listenAddr.IP, listenAddr.Port),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR moves hardcoded DNS resolver defaults from `gateway.NewDNSResolver` to `autoconf.FallbackDNSResolvers` so we have them in one place, while preserving existing behavior for users.

### Changes

- Move hardcoded DNS resolver defaults to `autoconf.FallbackDNSResolvers`
- `NewDNSResolver(nil)` uses `autoconf.FallbackDNSResolvers` (preserves `.eth` resolution)
- `NewDNSResolver(map[string]string{})` explicitly uses system DNS only
- Remove `autoconf.Client.ExpandDNSResolvers()` method (no use case yet)
- Update test to use `.foo` instead of `.eth` TLD
- No network calls at gateway initialization (privacy-preserving)

  
### Migration

No migration needed. For those wanting custom DNS configuration, existing code (Kubo, Rainbow) continues to work.

### References

- CC #771
- Closes #772

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
