### PR TITLE
bitswap: link traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- new span for the `handleIncoming` bitswap client `getter` plus events when blocks are received.
+
 ### Changed
 
 - upgrade to `go-libp2p` [v0.44.0](https://github.com/libp2p/go-libp2p/releases/tag/v0.44.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The following emojis are used to highlight certain changes:
 ### Added
 
 - new span for the `handleIncoming` bitswap client `getter` plus events when blocks are received.
+- mark opentelemetry spans, span attributes, and span events as being used by ProbeLab's analysis scripts
 
 ### Changed
 

--- a/bitswap/client/internal/getter/getter.go
+++ b/bitswap/client/internal/getter/getter.go
@@ -98,7 +98,7 @@ func AsyncGetBlocks(ctx, sessctx context.Context, keys []cid.Cid, notif notifica
 // If the context is cancelled or the incoming channel closes, calls cfun with
 // any keys corresponding to blocks that were never received.
 func handleIncoming(ctx, sessctx context.Context, remaining *cid.Set, in <-chan blocks.Block, out chan blocks.Block, cfun func([]cid.Cid)) {
-	ctx, span := internal.StartSpan(ctx, "Getter.handleIncoming")
+	ctx, span := internal.StartSpan(ctx, "Getter.handleIncoming") // ProbeLab: don't delete/change span without notice
 	defer span.End()
 
 	// Clean up before exiting this function, and call the cancel function on
@@ -120,7 +120,7 @@ func handleIncoming(ctx, sessctx context.Context, remaining *cid.Set, in <-chan 
 				return
 			}
 
-			span.AddEvent("received block", trace.WithAttributes(attribute.String("cid", blk.Cid().String())))
+			span.AddEvent("received block", trace.WithAttributes(attribute.String("cid", blk.Cid().String()))) // ProbeLab: don't delete/change without notice
 
 			remaining.Remove(blk.Cid())
 			select {

--- a/bitswap/client/internal/getter/getter.go
+++ b/bitswap/client/internal/getter/getter.go
@@ -10,6 +10,8 @@ import (
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	logging "github.com/ipfs/go-log/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var log = logging.Logger("bitswap/client/getter")
@@ -96,6 +98,9 @@ func AsyncGetBlocks(ctx, sessctx context.Context, keys []cid.Cid, notif notifica
 // If the context is cancelled or the incoming channel closes, calls cfun with
 // any keys corresponding to blocks that were never received.
 func handleIncoming(ctx, sessctx context.Context, remaining *cid.Set, in <-chan blocks.Block, out chan blocks.Block, cfun func([]cid.Cid)) {
+	ctx, span := internal.StartSpan(ctx, "Getter.handleIncoming")
+	defer span.End()
+
 	// Clean up before exiting this function, and call the cancel function on
 	// any remaining keys
 	defer func() {
@@ -114,6 +119,8 @@ func handleIncoming(ctx, sessctx context.Context, remaining *cid.Set, in <-chan 
 			if !ok {
 				return
 			}
+
+			span.AddEvent("received block", trace.WithAttributes(attribute.String("cid", blk.Cid().String())))
 
 			remaining.Remove(blk.Cid())
 			select {

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -358,7 +358,7 @@ func (s *Session) run(ctx context.Context) {
 			}
 		case <-s.idleTick.C:
 			// The session hasn't received blocks for a while, broadcast
-			opCtx, span := internal.StartSpan(ctx, "Session.IdleBroadcast")
+			opCtx, span := internal.StartSpan(ctx, "Session.IdleBroadcast") // ProbeLab: don't delete/change span without notice
 			s.broadcast(opCtx, nil)
 			span.End()
 		case <-periodicSearchTimer.C:

--- a/bitswap/client/internal/tracing.go
+++ b/bitswap/client/internal/tracing.go
@@ -8,7 +8,7 @@ import (
 )
 
 func StartSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return startSpan(ctx, "Bitswap.Client."+name, opts...)
+	return startSpan(ctx, "Bitswap.Client."+name, opts...) // ProbeLab: don't delete/change the prefix without notice
 }
 
 // outline logic so the string concatenation can be inlined and executed at compile time

--- a/routing/providerquerymanager/providerquerymanager.go
+++ b/routing/providerquerymanager/providerquerymanager.go
@@ -192,7 +192,9 @@ func (pqm *ProviderQueryManager) FindProvidersAsync(sessionCtx context.Context, 
 	inProgressRequestChan := make(chan inProgressRequest)
 
 	var span trace.Span
-	sessionCtx, span = otel.Tracer("routing").Start(sessionCtx, "ProviderQueryManager.FindProvidersAsync", trace.WithAttributes(attribute.Stringer("cid", k)))
+	sessionCtx, span = otel.Tracer("routing").Start(sessionCtx, "ProviderQueryManager.FindProvidersAsync", // ProbeLab: don't delete/change name without notice
+		trace.WithAttributes(attribute.Stringer("cid", k)), // ProbeLab: don't delete/change key/value without notice
+	)
 
 	select {
 	case pqm.providerQueryMessages <- &newProvideQueryMessage{
@@ -381,7 +383,7 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 						return
 					}
 
-					span.AddEvent("FoundProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID)))
+					span.AddEvent("FoundProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID))) // ProbeLab: don't delete/change name without notice
 					if retrievalState != nil {
 						retrievalState.ProvidersFound.Add(1)
 						retrievalState.AddFoundProvider(p.ID)
@@ -398,7 +400,7 @@ func (pqm *ProviderQueryManager) findProviderWorker() {
 						}
 						return
 					}
-					span.AddEvent("ConnectedToProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID)))
+					span.AddEvent("ConnectedToProvider", trace.WithAttributes(attribute.Stringer("peer", p.ID))) // ProbeLab: don't delete/change name without notice
 					if retrievalState != nil {
 						retrievalState.ProvidersConnected.Add(1)
 					}


### PR DESCRIPTION
**Changelog:**

- added a new span to bitswap's `handleIncoming` plus `received block` events
- marked the spans/attributes/events that we at ProbeLab use for our analysis