### PR TITLE
bitswap/httpnet: improve "Connect"/testCid check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ The following emojis are used to highlight certain changes:
 - `gateway`: Fixed duplicate peer IDs appearing in retrieval timeout error messages
 - `bitswap/client`: fix tracing by using context to pass trace and retrieval state to session [#1059](https://github.com/ipfs/boxo/pull/1059)
   - `bitswap/client`: propagate trace state when calling GetBlocks [#1060](https://github.com/ipfs/boxo/pull/1060)
+- `bitswap/network/httpnet`: improved error detection on HTTP and block fetches:
+  - Do not attempt to GET a test CID if the endpoint returns 429 to the test HEAD request.
+  - Unify error parsing and handling of http statues and content.
+
 
 ### Security
 

--- a/bitswap/message/message.go
+++ b/bitswap/message/message.go
@@ -192,12 +192,7 @@ func newMessageFromProto(pbm *pb.Message) (BitSwapMessage, error) {
 			return nil, err
 		}
 
-		c, err := pref.Sum(b.GetData())
-		if err != nil {
-			return nil, err
-		}
-
-		blk, err := blocks.NewBlockWithCid(b.GetData(), c)
+		blk, err := NewWantlistBlock(b.GetData(), cid.Undef, pref)
 		if err != nil {
 			return nil, err
 		}
@@ -410,6 +405,20 @@ func FromMsgReader(r msgio.Reader) (BitSwapMessage, int, error) {
 		return nil, 0, err
 	}
 	return m, len(msg), nil
+}
+
+// NewWantlistBlock makes a block from a payload.
+func NewWantlistBlock(bs []byte, c cid.Cid, prefix cid.Prefix) (blocks.Block, error) {
+	blockCid, err := prefix.Sum(bs)
+	if err != nil {
+		return nil, err
+	}
+	if c.Defined() {
+		if !blockCid.Equals(c) {
+			return nil, blocks.ErrWrongHash
+		}
+	}
+	return blocks.NewBlockWithCid(bs, blockCid)
 }
 
 func (m *impl) ToProtoV0() *pb.Message {

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -542,12 +542,16 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	supportsHead := true
 	for _, u := range urls {
 		// If head works we assume GET works too.
-		err := ht.connectToURL(ctx, pi.ID, u, "HEAD")
+		status, err := ht.connectToURL(ctx, pi.ID, u, "HEAD")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
 			// abort if context cancelled
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return errors.Join(errs...)
+			}
+
+			if status == http.StatusTooManyRequests {
+				continue // do not try GET, just move on.
 			}
 		} else {
 			workingAddrs = append(workingAddrs, u.Multiaddress)
@@ -557,7 +561,7 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		// HEAD did not work. Try GET.
 		supportsHead = false
 
-		err = ht.connectToURL(ctx, pi.ID, u, "GET")
+		_, err = ht.connectToURL(ctx, pi.ID, u, "GET")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
 			if ctxErr := ctx.Err(); ctxErr != nil {
@@ -591,17 +595,17 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	return nil
 }
 
-func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.ParsedURL, method string) error {
+func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.ParsedURL, method string) (int, error) {
 	req, err := buildRequest(ctx, u, method, pingCid, ht.userAgent)
 	if err != nil {
 		log.Debug(err)
-		return err
+		return 0, err
 	}
 
 	log.Debugf("connect/ping request to %s %s %q", p, method, req.URL)
 	resp, err := ht.client.Do(req)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	// For HTTP, the address can only be a LAN IP as otherwise it would have
@@ -611,14 +615,14 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	if u.URL.Scheme == "https" && resp.Proto != http2proto {
 		err = fmt.Errorf("%s://%q is not using HTTP/2 (%s)", req.URL.Scheme, req.URL.Host, resp.Proto)
 		log.Warn(err)
-		return err
+		return resp.StatusCode, err
 	}
 
 	// probe success.
 	// FIXME: Storacha returns 410 for our probe.
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusGone {
 		log.Debugf("connect/ping request to %s %s succeeded: %d", p, req.URL, resp.StatusCode)
-		return nil
+		return resp.StatusCode, nil
 	}
 
 	if resp.StatusCode == http.StatusInternalServerError {
@@ -629,22 +633,23 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 
 		body, err := io.ReadAll(limReader)
 		if err != nil {
-			return err
+			return resp.StatusCode, err
 		}
 
+		// The endpoint understand ipld.
 		bodyStr := string(body)
 		if strings.HasPrefix(bodyStr, "ipld: could not find node") ||
 			strings.HasPrefix(bodyStr, "peer does not have") ||
 			strings.HasPrefix(bodyStr, "failed to load root node") {
 			log.Debugf("connect/ping request to %s %s succeeded despite status code (known error): %d / %s", p, req.URL, resp.StatusCode, bodyStr)
-			return nil
+			return resp.StatusCode, nil
 		}
 	}
 
 	log.Debugf("connect error: %d <- %q (%s)", resp.StatusCode, req.URL, p)
 	// We made a proper request and got a 5xx back.
 	// We cannot consider this a working connection.
-	return errors.New("response status code is not 200")
+	return resp.StatusCode, errors.New("response status code is not 200")
 }
 
 // DisconnectFrom marks this peer as Disconnected in the connection event

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -636,7 +636,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 			return resp.StatusCode, err
 		}
 
-		// The endpoint understand ipld.
+		// The endpoint understands ipld.
 		bodyStr := string(body)
 		if strings.HasPrefix(bodyStr, "ipld: could not find node") ||
 			strings.HasPrefix(bodyStr, "peer does not have") ||

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -401,6 +401,19 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	}
 }
 
+// isKnownNotFoundError checks if the response body contains a known IPLD-specific
+// error message that indicates the content was not found. Some gateway implementations
+// return 500 (Internal Server Error) with these error messages instead of the more
+// appropriate 404 (Not Found).
+//
+// Following IPFS's robustness principle of "be strict about the outcomes, be tolerant
+// about the methods" (https://specs.ipfs.tech/architecture/principles/#robustness),
+// we recognize these error patterns to enable interoperability with gateways that
+// understand IPLD and bitswap semantics but return non-standard status codes.
+//
+// The strictness comes from verifying the error message proves the server understands
+// IPLD requests (not just any 500 error). The tolerance allows us to work with more
+// gateway implementations without requiring them to change their error codes first.
 func isKnownNotFoundError(body string) bool {
 	return strings.HasPrefix(body, "ipld: could not find node") ||
 		strings.HasPrefix(body, "peer does not have") ||

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -276,10 +276,13 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	statusCode := resp.StatusCode
 	// 1) Observed that some gateway implementation returns 500 instead of
 	// 404.
-	if statusCode == 500 &&
-		(string(body) == "ipld: could not find node" || strings.HasPrefix(string(body), "peer does not have")) {
-		log.Debugf("treating as 404: %q -> %d: %q", req.URL, resp.StatusCode, string(body))
-		statusCode = 404
+	if statusCode == 500 {
+		if strings.HasPrefix(string(body), "ipld: could not find node") ||
+			strings.HasPrefix(string(body), "peer does not have") ||
+			strings.HasPrefix(string(body), "getting pieces containing cid") {
+			log.Debugf("treating as 404: %q -> %d: %q", req.URL, resp.StatusCode, string(body))
+			statusCode = 404
+		}
 	}
 
 	// Calculate full response size with headers and everything.

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -278,7 +278,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	statusCode := resp.StatusCode
 	// 1) Observed that some gateway implementation returns 500 instead of
 	// 404.
-	if statusCode == 500 {
+	if statusCode != 200 {
 		if strings.HasPrefix(string(body), "ipld: could not find node") ||
 			strings.HasPrefix(string(body), "peer does not have") ||
 			strings.HasPrefix(string(body), "getting pieces containing cid") {
@@ -372,7 +372,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 		// It is always better if endpoints keep these errors for
 		// server issues, and simply return 404 when they cannot find
 		// the content but everything else is fine.
-		err := fmt.Errorf("%q -> %d: %q", req.URL, statusCode, string(body))
+		err := fmt.Errorf("%s %q -> %d: %q", req.Method, req.URL, statusCode, string(body))
 		log.Warn(err)
 		retryAfter := resp.Header.Get("Retry-After")
 		cooldownUntil, ok := parseRetryAfter(retryAfter)

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -337,9 +337,9 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 			return nil, nil
 		}
 		// GET
-		b, err := blocks.NewBlockWithCid(body, entry.Cid)
+		b, err := bsmsg.NewWantlistBlock(body, entry.Cid, entry.Cid.Prefix())
 		if err != nil {
-			log.Error("block received for cid %s does not match!", entry.Cid)
+			log.Debugf("error making wantlist block for %s: %s", entry.Cid, err)
 			// avoid entertaining servers that send us wrong data
 			// too much.
 			return nil, &senderError{

--- a/bitswap/network/httpnet/pinger.go
+++ b/bitswap/network/httpnet/pinger.go
@@ -52,7 +52,7 @@ func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 	for _, u := range urls {
 		go func(u network.ParsedURL) {
 			start := time.Now()
-			err := pngr.ht.connectToURL(ctx, p, u, method)
+			_, err := pngr.ht.connectToURL(ctx, p, u, method)
 			if err != nil {
 				log.Debug(err)
 				results <- ping.Result{Error: err}


### PR DESCRIPTION
Now that we have certain safeguards to disconnect from small providers, we can be more open to connect to places that fail the "testCid request". Particularly places that return 500 with known error messages that prove that they understand ipld and that they are a gateway.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
