### PR TITLE
fix(gateway): deduplicate peer IDs in retrieval diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `gateway`: Fixed duplicate peer IDs appearing in retrieval timeout error messages
+
 ### Security
 
 

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -276,6 +276,34 @@ func TestState(t *testing.T) {
 		assert.True(t, hasID1 || hasID2, "Summary should contain at least one of the peer IDs")
 	})
 
+	t.Run("Duplicate peer IDs are filtered out", func(t *testing.T) {
+		rs := NewState()
+		peerID1 := test.RandPeerIDFatal(t)
+		peerID2 := test.RandPeerIDFatal(t)
+
+		// Add the same peer ID multiple times
+		rs.AddFailedProvider(peerID1)
+		rs.AddFailedProvider(peerID1)
+		rs.AddFailedProvider(peerID2)
+		rs.AddFailedProvider(peerID1) // Add peerID1 again
+
+		// Should only contain unique peer IDs
+		failedProviders := rs.GetFailedProviders()
+		assert.Len(t, failedProviders, 2, "Should only contain 2 unique peer IDs")
+		assert.Contains(t, failedProviders, peerID1)
+		assert.Contains(t, failedProviders, peerID2)
+
+		// Also test for found providers
+		rs.AddFoundProvider(peerID1)
+		rs.AddFoundProvider(peerID1)
+		rs.AddFoundProvider(peerID2)
+
+		foundProviders := rs.GetFoundProviders()
+		assert.Len(t, foundProviders, 2, "Should only contain 2 unique peer IDs")
+		assert.Contains(t, foundProviders, peerID1)
+		assert.Contains(t, foundProviders, peerID2)
+	})
+
 	t.Run("SetPhase is thread-safe and maintains monotonic ordering", func(t *testing.T) {
 		rs := NewState()
 		stages := []RetrievalPhase{

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -297,6 +297,8 @@ func TestState(t *testing.T) {
 		rs.AddFoundProvider(peerID1)
 		rs.AddFoundProvider(peerID1)
 		rs.AddFoundProvider(peerID2)
+		rs.AddFoundProvider(peerID1) // Add peerID1 again
+		rs.AddFoundProvider(peerID2) // Add peerID2 again
 
 		foundProviders := rs.GetFoundProviders()
 		assert.Len(t, foundProviders, 2, "Should only contain 2 unique peer IDs")


### PR DESCRIPTION
peer IDs could appear multiple times in timeout errors due to repeated connection failures. add deduplication check. 

cc @aschmahmann (thx for noticing!)

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
