### PR TITLE
fix(tracing): use context to pass trace and retrieval state to session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `gateway`: Fixed duplicate peer IDs appearing in retrieval timeout error messages
+- `bitswap/client`: fix tracing by using context to pass trace and retrieval state to session [#1059](https://github.com/ipfs/boxo/pull/1059)
 
 ### Security
 

--- a/bitswap/client/internal/session/session.go
+++ b/bitswap/client/internal/session/session.go
@@ -10,7 +10,6 @@ import (
 	notifications "github.com/ipfs/boxo/bitswap/client/internal/notifications"
 	bspm "github.com/ipfs/boxo/bitswap/client/internal/peermanager"
 	bssim "github.com/ipfs/boxo/bitswap/client/internal/sessioninterestmanager"
-	"github.com/ipfs/boxo/retrieval"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
@@ -133,13 +132,11 @@ type Session struct {
 	self peer.ID
 }
 
-// New creates a new bitswap session.
+// New creates a new bitswap session whose lifetime is bounded by the
+// given context.
 //
-// The session maintains its own internal context for operations and is not
-// tied to any external context lifecycle. The caller MUST call Close() when
-// the session is no longer needed to ensure proper cleanup. When sessions are
-// created via Client.NewSession(ctx), automatic cleanup via context.AfterFunc
-// is provided.
+// The caller MUST call Close() or cancel the context when the session is no
+// longer needed to ensure proper cleanup.
 //
 // The retrievalState parameter, if provided, enables diagnostic tracking of
 // the retrieval process. It is attached to the session's internal context and
@@ -147,6 +144,7 @@ type Session struct {
 // phases. This is particularly useful for debugging timeout errors and
 // understanding retrieval performance.
 func New(
+	ctx context.Context,
 	sm SessionManager,
 	id uint64,
 	sprm SessionPeerManager,
@@ -159,14 +157,8 @@ func New(
 	periodicSearchDelay time.Duration,
 	self peer.ID,
 	havesReceivedGauge bspm.Gauge,
-	retrievalState *retrieval.State,
 ) *Session {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	// If a retrieval state is passed in, then keep it in the context.
-	if retrievalState != nil {
-		ctx = context.WithValue(ctx, retrieval.ContextKey, retrievalState)
-	}
+	ctx, cancel := context.WithCancel(ctx)
 
 	s := &Session{
 		sw:                  newSessionWants(broadcastLiveWantsLimit),
@@ -198,14 +190,10 @@ func (s *Session) ID() uint64 {
 	return s.id
 }
 
-// Close terminates the session and cleans up its resources. This method MUST
-// be called when the session is no longer needed to avoid resource leaks.
-// After calling Close, the session should not be used anymore.
-//
-// Session lifecycle is independent of the context used to create requests -
-// canceling a request context does not close the session. When context-based
-// automation is desired, Client.NewSession(ctx) uses context.AfterFunc to
-// automatically close sessions when the context is canceled.
+// Close terminates the session and cleans up its resources. This method must
+// be called, or the context used to create the session must be canceled, when
+// the session is no longer needed to avoid resource leaks. After calling
+// Close, the session should not be used anymore.
 func (s *Session) Close() {
 	s.cancel()
 }

--- a/bitswap/client/internal/sessionmanager/sessionmanager_test.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager_test.go
@@ -12,7 +12,6 @@ import (
 	bspm "github.com/ipfs/boxo/bitswap/client/internal/peermanager"
 	bssession "github.com/ipfs/boxo/bitswap/client/internal/session"
 	bssim "github.com/ipfs/boxo/bitswap/client/internal/sessioninterestmanager"
-	"github.com/ipfs/boxo/retrieval"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	peer "github.com/libp2p/go-libp2p/core/peer"
@@ -84,6 +83,7 @@ func (fpm *fakePeerManager) cancelled() []cid.Cid {
 }
 
 func sessionFactory(
+	ctx context.Context,
 	sm bssession.SessionManager,
 	id uint64,
 	sprm bssession.SessionPeerManager,
@@ -94,7 +94,6 @@ func sessionFactory(
 	provSearchDelay time.Duration,
 	rebroadcastDelay time.Duration,
 	self peer.ID,
-	retrievalState *retrieval.State,
 ) Session {
 	fs := &fakeSession{
 		id:    id,
@@ -102,6 +101,10 @@ func sessionFactory(
 		sm:    sm,
 		notif: notif,
 	}
+	go func() {
+		<-ctx.Done()
+		sm.RemoveSession(fs.id)
+	}()
 	return fs
 }
 
@@ -122,11 +125,11 @@ func TestReceiveFrom(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 
-	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	firstSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer firstSession.Close()
-	secondSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	secondSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer secondSession.Close()
-	thirdSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	thirdSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer thirdSession.Close()
 
 	sim.RecordSessionInterest(firstSession.ID(), []cid.Cid{block.Cid()})
@@ -169,11 +172,11 @@ func TestReceiveBlocksWhenManagerShutdown(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 
-	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	firstSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer firstSession.Close()
-	secondSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	secondSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer secondSession.Close()
-	thirdSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	thirdSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer thirdSession.Close()
 
 	sim.RecordSessionInterest(firstSession.ID(), []cid.Cid{block.Cid()})
@@ -206,11 +209,11 @@ func TestReceiveBlocksWhenSessionContextCancelled(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 
-	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	firstSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer firstSession.Close()
-	secondSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	secondSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer secondSession.Close()
-	thirdSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	thirdSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer thirdSession.Close()
 
 	sim.RecordSessionInterest(firstSession.ID(), []cid.Cid{block.Cid()})
@@ -243,7 +246,7 @@ func TestShutdown(t *testing.T) {
 	p := peer.ID(strconv.Itoa(123))
 	block := blocks.NewBlock([]byte("block"))
 	cids := []cid.Cid{block.Cid()}
-	firstSession := sm.NewSession(time.Second, time.Minute, nil).(*fakeSession)
+	firstSession := sm.NewSession(ctx, time.Second, time.Minute).(*fakeSession)
 	defer firstSession.Close()
 	sim.RecordSessionInterest(firstSession.ID(), cids)
 	sm.ReceiveFrom(ctx, p, []cid.Cid{}, []cid.Cid{}, cids)

--- a/namesys/republisher/repub_test.go
+++ b/namesys/republisher/repub_test.go
@@ -92,9 +92,9 @@ func TestRepublish(t *testing.T) {
 	// Retry in case the record expires before we can fetch it. This can
 	// happen when running the test on a slow machine.
 	var expiration time.Time
-	timeout := time.Second
+	timeout := 2 * time.Second
 	for {
-		expiration = time.Now().Add(time.Second)
+		expiration = time.Now().Add(2 * time.Second)
 		err := rp.Publish(ctx, publisher.privKey, p, namesys.PublishWithEOL(expiration))
 		require.NoError(t, err)
 


### PR DESCRIPTION
Trace state, carried in the context passed to NewSession was not being passed into the session. This is fixed by having session.New accept a context that contains trace and retrieval state.

- Closes #1052
- Reverses part of https://github.com/ipfs/boxo/pull/1011