### PR TITLE
bitswap/client: propagate trace state when calling `GetBlocks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ The following emojis are used to highlight certain changes:
 
 - `gateway`: Fixed duplicate peer IDs appearing in retrieval timeout error messages
 - `bitswap/client`: fix tracing by using context to pass trace and retrieval state to session [#1059](https://github.com/ipfs/boxo/pull/1059)
-  - Fix for `client.GetBlocks`
+  - `bitswap/client`: propagate trace state when calling GetBlocks [#1060](https://github.com/ipfs/boxo/pull/1060)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The following emojis are used to highlight certain changes:
 
 - `gateway`: Fixed duplicate peer IDs appearing in retrieval timeout error messages
 - `bitswap/client`: fix tracing by using context to pass trace and retrieval state to session [#1059](https://github.com/ipfs/boxo/pull/1059)
+  - Fix for `client.GetBlocks`
 
 ### Security
 


### PR DESCRIPTION
- Additional trace fix for bitswap client `GetBlocks` ([context](https://github.com/ipfs/boxo/pull/1059/files#r2466543123))
- Added comments to explain reason for code.