### PR TITLE
docs: update deprecation comments to reference IPIP-526

### DIFF
--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -339,9 +339,9 @@ func (c *Client) FindProviders(ctx context.Context, key cid.Cid) (providers iter
 	return &measuringIter[iter.Result[types.Record]]{Iter: it, ctx: ctx, m: m}, nil
 }
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 func (c *Client) ProvideBitswap(ctx context.Context, keys []cid.Cid, ttl time.Duration) (time.Duration, error) {
 	if c.identity == nil {
 		return 0, errors.New("cannot provide Bitswap records without an identity")

--- a/routing/http/server/server.go
+++ b/routing/http/server/server.go
@@ -71,9 +71,9 @@ type DelegatedRouter interface {
 	// Limit indicates the maximum amount of results to return; 0 means unbounded.
 	FindProviders(ctx context.Context, cid cid.Cid, limit int) (iter.ResultIter[types.Record], error)
 
-	// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+	// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 	//
-	// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+	// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 	ProvideBitswap(ctx context.Context, req *BitswapWriteProvideRequest) (time.Duration, error)
 
 	// FindPeers searches for peers who have the provided [peer.ID].
@@ -95,9 +95,9 @@ type DelegatedRouter interface {
 // Deprecated: use DelegatedRouter. ContentRouter will be removed in a future version.
 type ContentRouter = DelegatedRouter
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 type BitswapWriteProvideRequest struct {
 	Keys        []cid.Cid
 	Timestamp   time.Time
@@ -106,9 +106,9 @@ type BitswapWriteProvideRequest struct {
 	Addrs       []multiaddr.Multiaddr
 }
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 type WriteProvideRequest struct {
 	Protocol string
 	Schema   string

--- a/routing/http/types/json/requests.go
+++ b/routing/http/types/json/requests.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ipfs/boxo/routing/http/types"
 )
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 type WriteProvidersRequest struct {
 	Providers []types.Record
 }

--- a/routing/http/types/json/responses.go
+++ b/routing/http/types/json/responses.go
@@ -68,9 +68,9 @@ func (r *RecordsArray) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 type WriteProvidersResponse struct {
 	ProvideResults []types.Record
 }

--- a/routing/http/types/record_bitswap.go
+++ b/routing/http/types/record_bitswap.go
@@ -35,9 +35,9 @@ func (br *BitswapRecord) GetSchema() string {
 
 var _ Record = &WriteBitswapRecord{}
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 type WriteBitswapRecord struct {
 	Schema    string
 	Protocol  string
@@ -170,9 +170,9 @@ func (p *WriteBitswapRecord) Verify() error {
 
 var _ Record = &WriteBitswapRecordResponse{}
 
-// Deprecated: protocol-agnostic provide is being worked on in [IPIP-378]:
+// Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
-// [IPIP-378]: https://github.com/ipfs/specs/pull/378
+// [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
 type WriteBitswapRecordResponse struct {
 	Schema      string
 	Protocol    string


### PR DESCRIPTION
This PR only updates godoc, no functional changes.

It replaces references to stalled and now closed IPIP-378 with [IPIP-526](https://github.com/ipfs/specs/pull/526) which documents the historic Bitswap provider publishing API and provides a place for discussing it.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
