### PR TITLE
bitswap: add the requesting peer ID to context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following emojis are used to highlight certain changes:
 - `routing/http`: `GET /routing/v1/dht/closest/peers/{key}` per [IPIP-476](https://github.com/ipfs/specs/pull/476)
 - upgrade to `go-libp2p-kad-dht` [v0.36.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.36.0)
 - `ipld/merkledag`: Added fetched node size reporting to the progress tracker. See [kubo#8915](https://github.com/ipfs/kubo/issues/8915)
+- `bitswap`: Added a way to extract the peer ID of the requesting peer from context in the underlying Bitswap components.
 
 ### Changed
 

--- a/bitswap/bitswap.go
+++ b/bitswap/bitswap.go
@@ -188,6 +188,8 @@ func (bs *Bitswap) ReceiveError(err error) {
 }
 
 func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming message.BitSwapMessage) {
+	ctx = context.WithValue(ctx, peerIDContextKey{}, p)
+
 	if bs.tracer != nil {
 		bs.tracer.MessageReceived(p, incoming)
 	}
@@ -196,4 +198,16 @@ func (bs *Bitswap) ReceiveMessage(ctx context.Context, p peer.ID, incoming messa
 	if bs.Server != nil {
 		bs.Server.ReceiveMessage(ctx, p, incoming)
 	}
+}
+
+type peerIDContextKey struct{}
+
+// PeerIDFromContext extracts the peer ID from the context.
+// It can be useful to access the remote peer ID in the blockstore used by Bitswap.
+func PeerIDFromContext(ctx context.Context) peer.ID {
+	p, ok := ctx.Value(peerIDContextKey{}).(peer.ID)
+	if !ok {
+		return ""
+	}
+	return p
 }


### PR DESCRIPTION
This commit adds the peer.ID of the requesting peer to the context, which can be used downstream in the blockstore or other components used by Bitswap.

This could be very useful for custom logging, or accessing the peer ID in custom block stores.