### PR TITLE
feat(gateway): configurable fallback timeout for the gateway handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The following emojis are used to highlight certain changes:
 - `routing/http`: `GET /routing/v1/dht/closest/peers/{key}` per [IPIP-476](https://github.com/ipfs/specs/pull/476)
 - upgrade to `go-libp2p-kad-dht` [v0.36.0](https://github.com/libp2p/go-libp2p-kad-dht/releases/tag/v0.36.0)
 - `ipld/merkledag`: Added fetched node size reporting to the progress tracker. See [kubo#8915](https://github.com/ipfs/kubo/issues/8915)
+- `gateway`: Added a configurable fallback timeout for the gateway handler, defaulting to 1 hour. Configurable via `MaxRequestDuration` in the gateway config.
 
 ### Changed
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -137,8 +137,10 @@ type Config struct {
 	// (e.g., Cloudflare's 5GB limit). A value of 0 disables this limit.
 	MaxRangeRequestFileSize int64
 
-	// MaxRequestDuration per-request timeout for the gateway handler. It
-	// defaults to DefaultMaxRequestDuration.
+	// MaxRequestDuration is the maximum total time a request can take.
+	// Unlike RetrievalTimeout (which resets on each data write and catches
+	// stalled transfers), this is an absolute deadline for the entire request.
+	// Zero or negative values will use DefaultMaxRequestDuration (1 hour).
 	MaxRequestDuration time.Duration
 
 	// MetricsRegistry is the Prometheus registry to use for metrics.
@@ -159,7 +161,7 @@ func validateConfig(c Config) Config {
 
 	if c.MaxRequestDuration <= 0 {
 		if c.MaxRequestDuration < 0 {
-			log.Errorf("invalid MaxRequestDuratio %s, using default %s", c.MaxRequestDuration.String(), DefaultMaxRequestDuration.String())
+			log.Errorf("invalid MaxRequestDuration %s, using default %s", c.MaxRequestDuration.String(), DefaultMaxRequestDuration.String())
 		}
 		c.MaxRequestDuration = DefaultMaxRequestDuration
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -34,6 +34,10 @@ const (
 	// See the MaxConcurrentRequests field documentation for detailed tuning guidance.
 	DefaultMaxConcurrentRequests = 4096
 
+	// DefaultMaxRequestDuration is the default per-request timeout for the
+	// gateway handler.
+	DefaultMaxRequestDuration = time.Hour
+
 	// DefaultDiagnosticServiceURL is the default URL for CID diagnostic service
 	DefaultDiagnosticServiceURL = "https://check.ipfs.network"
 )
@@ -133,6 +137,10 @@ type Config struct {
 	// (e.g., Cloudflare's 5GB limit). A value of 0 disables this limit.
 	MaxRangeRequestFileSize int64
 
+	// MaxRequestDuration per-request timeout for the gateway handler. It
+	// defaults to DefaultMaxRequestDuration.
+	MaxRequestDuration time.Duration
+
 	// MetricsRegistry is the Prometheus registry to use for metrics.
 	// If nil, prometheus.DefaultRegisterer will be used.
 	MetricsRegistry prometheus.Registerer
@@ -147,6 +155,13 @@ func validateConfig(c Config) Config {
 			log.Errorf("invalid DiagnosticServiceURL %q: %v, disabling diagnostic service", c.DiagnosticServiceURL, err)
 			c.DiagnosticServiceURL = ""
 		}
+	}
+
+	if c.MaxRequestDuration <= 0 {
+		if c.MaxRequestDuration < 0 {
+			log.Errorf("invalid MaxRequestDuratio %s, using default %s", c.MaxRequestDuration.String(), DefaultMaxRequestDuration.String())
+		}
+		c.MaxRequestDuration = DefaultMaxRequestDuration
 	}
 
 	// Future validations can be added here

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 	mh "github.com/multiformats/go-multihash"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -1473,5 +1474,112 @@ func TestMaxRangeRequestFileSize(t *testing.T) {
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Equal(t, "fnord", string(body))
+	})
+}
+
+func TestValidateConfig_MaxRequestDuration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    time.Duration
+		expected time.Duration
+	}{
+		{"zero uses default", 0, DefaultMaxRequestDuration},
+		{"negative uses default", -1 * time.Second, DefaultMaxRequestDuration},
+		{"positive value preserved", 30 * time.Minute, 30 * time.Minute},
+		{"very short duration preserved", 1 * time.Millisecond, 1 * time.Millisecond},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			c := validateConfig(Config{MaxRequestDuration: tc.input})
+			assert.Equal(t, tc.expected, c.MaxRequestDuration)
+		})
+	}
+}
+
+// slowMockBackend is a backend that waits before responding, respecting context cancellation.
+type slowMockBackend struct {
+	delay time.Duration
+}
+
+func (mb *slowMockBackend) Get(ctx context.Context, path path.ImmutablePath, getRange ...ByteRange) (ContentPathMetadata, *GetResponse, error) {
+	return mb.waitAndReturnError(ctx)
+}
+
+func (mb *slowMockBackend) GetAll(ctx context.Context, path path.ImmutablePath) (ContentPathMetadata, files.Node, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return ContentPathMetadata{}, nil, err
+}
+
+func (mb *slowMockBackend) GetBlock(ctx context.Context, path path.ImmutablePath) (ContentPathMetadata, files.File, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return ContentPathMetadata{}, nil, err
+}
+
+func (mb *slowMockBackend) Head(ctx context.Context, path path.ImmutablePath) (ContentPathMetadata, *HeadResponse, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return ContentPathMetadata{}, nil, err
+}
+
+func (mb *slowMockBackend) GetCAR(ctx context.Context, path path.ImmutablePath, params CarParams) (ContentPathMetadata, io.ReadCloser, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return ContentPathMetadata{}, nil, err
+}
+
+func (mb *slowMockBackend) ResolveMutable(ctx context.Context, p path.Path) (path.ImmutablePath, time.Duration, time.Time, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return path.ImmutablePath{}, 0, time.Time{}, err
+}
+
+func (mb *slowMockBackend) GetIPNSRecord(ctx context.Context, c cid.Cid) ([]byte, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return nil, err
+}
+
+func (mb *slowMockBackend) GetDNSLinkRecord(ctx context.Context, hostname string) (path.Path, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return nil, err
+}
+
+func (mb *slowMockBackend) IsCached(ctx context.Context, p path.Path) bool {
+	return false
+}
+
+func (mb *slowMockBackend) ResolvePath(ctx context.Context, path path.ImmutablePath) (ContentPathMetadata, error) {
+	_, _, err := mb.waitAndReturnError(ctx)
+	return ContentPathMetadata{}, err
+}
+
+func (mb *slowMockBackend) waitAndReturnError(ctx context.Context) (ContentPathMetadata, *GetResponse, error) {
+	select {
+	case <-time.After(mb.delay):
+		return ContentPathMetadata{}, nil, errors.New("backend completed but should have timed out")
+	case <-ctx.Done():
+		return ContentPathMetadata{}, nil, ctx.Err()
+	}
+}
+
+func TestMaxRequestDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("request times out when backend is slow", func(t *testing.T) {
+		t.Parallel()
+
+		backend := &slowMockBackend{delay: 500 * time.Millisecond}
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses: true,
+			MaxRequestDuration:    50 * time.Millisecond,
+			MetricsRegistry:       prometheus.NewRegistry(),
+		})
+
+		req := mustNewRequest(t, http.MethodGet, ts.URL+"/ipfs/bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e", nil)
+		res := mustDo(t, req)
+		defer res.Body.Close()
+
+		// context.DeadlineExceeded from backend results in 504 Gateway Timeout
+		require.Equal(t, http.StatusGatewayTimeout, res.StatusCode)
 	})
 }

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -159,7 +159,7 @@ func (i *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer panicHandler(w)
 
 	// the hour is a hard fallback, we don't expect it to happen, but just in case
-	ctx, cancel := context.WithTimeout(r.Context(), time.Hour)
+	ctx, cancel := context.WithTimeout(r.Context(), i.config.MaxRequestDuration)
 	defer cancel()
 
 	if withCtxWrap, ok := i.backend.(WithContextHint); ok {

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -158,7 +158,8 @@ func (w *errRecordingResponseWriter) ReadFrom(r io.Reader) (n int64, err error) 
 func (i *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer panicHandler(w)
 
-	// the hour is a hard fallback, we don't expect it to happen, but just in case
+	// MaxRequestDuration is an absolute deadline for the entire request.
+	// This context deadline propagates to all backend operations.
 	ctx, cancel := context.WithTimeout(r.Context(), i.config.MaxRequestDuration)
 	defer cancel()
 


### PR DESCRIPTION
Added a configurable fallback timeout for the gateway handler, defaulting to 1 hour. Configurable via `MaxRequestDuration` in the gateway config.

Replaces #1069
