### PR TITLE
fix(routing): defensive nil checks for multiaddr handling

### DIFF
--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -147,9 +147,13 @@ func readProviderResponses(ctx context.Context, iter iter.ResultIter[types.Recor
 				continue
 			}
 
+			// Filter nil addresses as a defensive measure against corrupted data.
+			// See: https://github.com/ipfs/kubo/issues/11116
 			var addrs []multiaddr.Multiaddr
 			for _, a := range result.Addrs {
-				addrs = append(addrs, a.Multiaddr)
+				if a.Multiaddr != nil {
+					addrs = append(addrs, a.Multiaddr)
+				}
 			}
 
 			select {
@@ -175,9 +179,13 @@ func readProviderResponses(ctx context.Context, iter iter.ResultIter[types.Recor
 				continue
 			}
 
+			// Filter nil addresses as a defensive measure against corrupted data.
+			// See: https://github.com/ipfs/kubo/issues/11116
 			var addrs []multiaddr.Multiaddr
 			for _, a := range result.Addrs {
-				addrs = append(addrs, a.Multiaddr)
+				if a.Multiaddr != nil {
+					addrs = append(addrs, a.Multiaddr)
+				}
 			}
 
 			select {

--- a/routing/http/contentrouter/contentrouter.go
+++ b/routing/http/contentrouter/contentrouter.go
@@ -25,11 +25,17 @@ var logger = logging.Logger("routing/http/contentrouter")
 // entries as a defensive measure against corrupted data.
 // See: https://github.com/ipfs/kubo/issues/11116
 func filterAddrs(in []types.Multiaddr) []multiaddr.Multiaddr {
+	if len(in) == 0 {
+		return nil
+	}
 	out := make([]multiaddr.Multiaddr, 0, len(in))
 	for _, a := range in {
 		if a.Multiaddr != nil {
 			out = append(out, a.Multiaddr)
 		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/routing/http/contentrouter/contentrouter_test.go
+++ b/routing/http/contentrouter/contentrouter_test.go
@@ -175,10 +175,10 @@ func TestFindProvidersAsync(t *testing.T) {
 	}
 
 	expected := []peer.AddrInfo{
-		{ID: p1},
-		{ID: p2},
-		{ID: p3},
-		{ID: p4},
+		{ID: p1, Addrs: []multiaddr.Multiaddr{}},
+		{ID: p2, Addrs: []multiaddr.Multiaddr{}},
+		{ID: p3, Addrs: []multiaddr.Multiaddr{}},
+		{ID: p4, Addrs: []multiaddr.Multiaddr{}},
 	}
 
 	require.Equal(t, expected, actualAIs)

--- a/routing/http/contentrouter/contentrouter_test.go
+++ b/routing/http/contentrouter/contentrouter_test.go
@@ -175,10 +175,10 @@ func TestFindProvidersAsync(t *testing.T) {
 	}
 
 	expected := []peer.AddrInfo{
-		{ID: p1, Addrs: []multiaddr.Multiaddr{}},
-		{ID: p2, Addrs: []multiaddr.Multiaddr{}},
-		{ID: p3, Addrs: []multiaddr.Multiaddr{}},
-		{ID: p4, Addrs: []multiaddr.Multiaddr{}},
+		{ID: p1},
+		{ID: p2},
+		{ID: p3},
+		{ID: p4},
 	}
 
 	require.Equal(t, expected, actualAIs)

--- a/routing/http/types/ipfs.go
+++ b/routing/http/types/ipfs.go
@@ -27,6 +27,16 @@ func (c *CID) UnmarshalJSON(b []byte) error {
 
 type Multiaddr struct{ multiaddr.Multiaddr }
 
+// MarshalJSON returns null for nil Multiaddr as a defensive measure.
+// This prevents panics if corrupted data contains nil addresses.
+// See: https://github.com/ipfs/kubo/issues/11116
+func (m Multiaddr) MarshalJSON() ([]byte, error) {
+	if m.Multiaddr == nil {
+		return []byte("null"), nil
+	}
+	return json.Marshal(m.Multiaddr.String())
+}
+
 func (m *Multiaddr) UnmarshalJSON(b []byte) error {
 	var s string
 	err := json.Unmarshal(b, &s)


### PR DESCRIPTION
Belt-and-suspenders defense against corrupted address data:
- contentrouter: filters nil addresses when building AddrInfo
- types/ipfs.go: Multiaddr.MarshalJSON returns null for nil (should never happen, but just in case, this will produce loud and clear error)

Should help with https://github.com/ipfs/kubo/issues/11116

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
