### PR TITLE
refactor: replace `go-clock` with `synctest`

### DIFF
--- a/bitswap/client/internal/messagequeue/donthavetimeoutmgr_test.go
+++ b/bitswap/client/internal/messagequeue/donthavetimeoutmgr_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-test/random"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
@@ -17,12 +17,11 @@ type mockPeerConn struct {
 	err       error
 	latency   time.Duration
 	latencies []time.Duration
-	clock     clock.Clock
 	pinged    chan struct{}
 }
 
 func (pc *mockPeerConn) Ping(ctx context.Context) ping.Result {
-	timer := pc.clock.Timer(pc.latency)
+	timer := time.NewTimer(pc.latency)
 	pc.pinged <- struct{}{}
 	select {
 	case <-timer.C:
@@ -74,448 +73,485 @@ func (tr *timeoutRecorder) clear() {
 
 func TestDontHaveTimeoutMgrTimeout(t *testing.T) {
 	t.Parallel()
-	firstks := random.Cids(2)
-	secondks := append(firstks, random.Cids(3)...)
-	latency := time.Millisecond * 20
-	latMultiplier := 2
-	expProcessTime := 5 * time.Millisecond
-	expectedTimeout := expProcessTime + latency*time.Duration(latMultiplier)
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
-	// Add first set of keys
-	dhtm.AddPending(firstks)
-
-	// Wait for less than the expected timeout
-	clock.Add(expectedTimeout - 10*time.Millisecond)
-
-	// At this stage no keys should have timed out
-	if tr.timedOutCount() > 0 {
-		t.Fatal("expected timeout not to have happened yet")
-	}
-
-	// Add second set of keys
-	dhtm.AddPending(secondks)
-
-	// Wait until after the expected timeout
-	clock.Add(20 * time.Millisecond)
-
-	canRetry := true
-
-retry:
-	select {
-	case <-timeoutsTriggered:
-	case <-time.After(2 * time.Second):
-		if canRetry {
-			canRetry = false
-			clock.Add(10 * time.Millisecond)
-			goto retry
+	synctest.Test(t, func(t *testing.T) {
+		firstks := random.Cids(2)
+		secondks := append(firstks, random.Cids(3)...)
+		latency := time.Millisecond * 20
+		latMultiplier := 2
+		expProcessTime := 5 * time.Millisecond
+		expectedTimeout := expProcessTime + latency*time.Duration(latMultiplier)
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
 		}
-		t.Fatal("timed out waiting for timeouts")
-	}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
+		// Add first set of keys
+		dhtm.AddPending(firstks)
 
-	// At this stage first set of keys should have timed out
-	if tr.timedOutCount() != len(firstks) {
-		t.Fatal("expected timeout", tr.timedOutCount(), len(firstks))
-	}
-	// Clear the recorded timed out keys
-	tr.clear()
+		// Wait for less than the expected timeout
+		time.Sleep(expectedTimeout - 10*time.Millisecond)
 
-	// Sleep until the second set of keys should have timed out
-	clock.Add(expectedTimeout + 10*time.Millisecond)
+		// At this stage no keys should have timed out
+		if tr.timedOutCount() > 0 {
+			t.Fatal("expected timeout not to have happened yet")
+		}
 
-	<-timeoutsTriggered
+		// Add second set of keys
+		dhtm.AddPending(secondks)
 
-	// At this stage all keys should have timed out. The second set included
-	// the first set of keys, but they were added before the first set timed
-	// out, so only the remaining keys should have beed added.
-	if tr.timedOutCount() != len(secondks)-len(firstks) {
-		t.Fatal("expected second set of keys to timeout")
-	}
+		// Wait until after the expected timeout
+		time.Sleep(20 * time.Millisecond)
+		synctest.Wait()
+
+		canRetry := true
+
+	retry:
+		select {
+		case <-timeoutsTriggered:
+		case <-time.After(2 * time.Second):
+			if canRetry {
+				canRetry = false
+				time.Sleep(10 * time.Millisecond)
+				goto retry
+			}
+			t.Fatal("timed out waiting for timeouts")
+		}
+
+		// At this stage first set of keys should have timed out
+		if tr.timedOutCount() != len(firstks) {
+			t.Fatal("expected timeout", tr.timedOutCount(), len(firstks))
+		}
+		// Clear the recorded timed out keys
+		tr.clear()
+
+		// Sleep until the second set of keys should have timed out
+		time.Sleep(expectedTimeout + 10*time.Millisecond)
+
+		<-timeoutsTriggered
+
+		// At this stage all keys should have timed out. The second set included
+		// the first set of keys, but they were added before the first set timed
+		// out, so only the remaining keys should have beed added.
+		if tr.timedOutCount() != len(secondks)-len(firstks) {
+			t.Fatal("expected second set of keys to timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutMgrCancel(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(3)
-	latency := time.Millisecond * 10
-	latMultiplier := 1
-	expProcessTime := time.Duration(0)
-	expectedTimeout := latency
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(3)
+		latency := time.Millisecond * 10
+		latMultiplier := 1
+		expProcessTime := time.Duration(0)
+		expectedTimeout := latency
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
 
-	// Add keys
-	dhtm.AddPending(ks)
-	clock.Add(5 * time.Millisecond)
+		// Add keys
+		dhtm.AddPending(ks)
+		time.Sleep(5 * time.Millisecond)
+		synctest.Wait()
 
-	// Cancel keys
-	cancelCount := 1
-	dhtm.CancelPending(ks[:cancelCount])
+		// Cancel keys
+		cancelCount := 1
+		dhtm.CancelPending(ks[:cancelCount])
 
-	// Wait for the expected timeout
-	clock.Add(expectedTimeout)
+		// Wait for the expected timeout
+		time.Sleep(expectedTimeout)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// At this stage all non-cancelled keys should have timed out
-	if tr.timedOutCount() != len(ks)-cancelCount {
-		t.Fatal("expected timeout")
-	}
+		// At this stage all non-cancelled keys should have timed out
+		if tr.timedOutCount() != len(ks)-cancelCount {
+			t.Fatal("expected timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutWantCancelWant(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(3)
-	latency := time.Millisecond * 20
-	latMultiplier := 1
-	expProcessTime := time.Duration(0)
-	expectedTimeout := latency
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(3)
+		latency := time.Millisecond * 20
+		latMultiplier := 1
+		expProcessTime := time.Duration(0)
+		expectedTimeout := latency
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
 
-	// Add keys
-	dhtm.AddPending(ks)
+		// Add keys
+		dhtm.AddPending(ks)
 
-	// Wait for a short time
-	clock.Add(expectedTimeout - 10*time.Millisecond)
+		// Wait for a short time
+		time.Sleep(expectedTimeout - 10*time.Millisecond)
+		synctest.Wait()
 
-	// Cancel two keys
-	dhtm.CancelPending(ks[:2])
+		// Cancel two keys
+		dhtm.CancelPending(ks[:2])
 
-	clock.Add(5 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
+		synctest.Wait()
 
-	// Add back one cancelled key
-	dhtm.AddPending(ks[:1])
+		// Add back one cancelled key
+		dhtm.AddPending(ks[:1])
 
-	// Wait till after initial timeout
-	clock.Add(10 * time.Millisecond)
+		// Wait till after initial timeout
+		time.Sleep(10 * time.Millisecond)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// At this stage only the key that was never cancelled should have timed out
-	if tr.timedOutCount() != 1 {
-		t.Fatal("expected one key to timeout")
-	}
+		// At this stage only the key that was never cancelled should have timed out
+		if tr.timedOutCount() != 1 {
+			t.Fatal("expected one key to timeout")
+		}
 
-	// Wait till after added back key should time out
-	clock.Add(latency)
+		// Wait till after added back key should time out
+		time.Sleep(latency)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// At this stage the key that was added back should also have timed out
-	if tr.timedOutCount() != 2 {
-		t.Fatal("expected added back key to timeout")
-	}
+		// At this stage the key that was added back should also have timed out
+		if tr.timedOutCount() != 2 {
+			t.Fatal("expected added back key to timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutRepeatedAddPending(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(10)
-	latency := time.Millisecond * 5
-	latMultiplier := 1
-	expProcessTime := time.Duration(0)
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(10)
+		latency := time.Millisecond * 5
+		latMultiplier := 1
+		expProcessTime := time.Duration(0)
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
 
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
 
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
 
-	// Add keys repeatedly
-	for _, c := range ks {
-		dhtm.AddPending([]cid.Cid{c})
-	}
+		// Add keys repeatedly
+		for _, c := range ks {
+			dhtm.AddPending([]cid.Cid{c})
+		}
 
-	// Wait for the expected timeout
-	clock.Add(latency + 5*time.Millisecond)
+		// Wait for the expected timeout
+		time.Sleep(latency + 5*time.Millisecond)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// At this stage all keys should have timed out
-	if tr.timedOutCount() != len(ks) {
-		t.Fatal("expected timeout")
-	}
+		// At this stage all keys should have timed out
+		if tr.timedOutCount() != len(ks) {
+			t.Fatal("expected timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutMgrMessageLatency(t *testing.T) {
 	t.Parallel()
 	ks := random.Cids(2)
-	latency := time.Millisecond * 40
-	latMultiplier := 1
-	expProcessTime := time.Duration(0)
-	msgLatencyMultiplier := 1
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		latency := time.Millisecond * 40
+		latMultiplier := 1
+		expProcessTime := time.Duration(0)
+		msgLatencyMultiplier := 1
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
 
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MessageLatencyMultiplier = msgLatencyMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MessageLatencyMultiplier = msgLatencyMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
 
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
-	// Add keys
-	dhtm.AddPending(ks)
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
+		// Add keys
+		dhtm.AddPending(ks)
 
-	// expectedTimeout
-	// = expProcessTime + latency*time.Duration(latMultiplier)
-	// = 0 + 40ms * 1
-	// = 40ms
+		// expectedTimeout
+		// = expProcessTime + latency*time.Duration(latMultiplier)
+		// = 0 + 40ms * 1
+		// = 40ms
 
-	// Wait for less than the expected timeout
-	clock.Add(25 * time.Millisecond)
+		// Wait for less than the expected timeout
+		time.Sleep(25 * time.Millisecond)
+		synctest.Wait()
 
-	// Receive two message latency updates
-	dhtm.UpdateMessageLatency(time.Millisecond * 20)
-	dhtm.UpdateMessageLatency(time.Millisecond * 10)
+		// Receive two message latency updates
+		dhtm.UpdateMessageLatency(time.Millisecond * 20)
+		dhtm.UpdateMessageLatency(time.Millisecond * 10)
 
-	// alpha is 0.5 so timeout should be
-	// = (20ms * alpha) + (10ms * (1 - alpha))
-	// = (20ms * 0.5) + (10ms * 0.5)
-	// = 15ms
-	// We've already slept for 25ms so with the new 15ms timeout
-	// the keys should have timed out
+		// alpha is 0.5 so timeout should be
+		// = (20ms * alpha) + (10ms * (1 - alpha))
+		// = (20ms * 0.5) + (10ms * 0.5)
+		// = 15ms
+		// We've already slept for 25ms so with the new 15ms timeout
+		// the keys should have timed out
 
-	// Give the queue some time to process the updates
-	clock.Add(5 * time.Millisecond)
+		// Give the queue some time to process the updates
+		time.Sleep(5 * time.Millisecond)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	if tr.timedOutCount() != len(ks) {
-		t.Fatal("expected keys to timeout")
-	}
+		if tr.timedOutCount() != len(ks) {
+			t.Fatal("expected keys to timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutMgrMessageLatencyMax(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(2)
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: time.Second, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	msgLatencyMultiplier := 1
-	testMaxTimeout := time.Millisecond * 10
-	timeoutsTriggered := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(2)
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: time.Second,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		msgLatencyMultiplier := 1
+		testMaxTimeout := time.Millisecond * 10
+		timeoutsTriggered := make(chan struct{})
 
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.MessageLatencyMultiplier = msgLatencyMultiplier
-	cfg.MaxTimeout = testMaxTimeout
-	cfg.MinTimeout = 10 * time.Millisecond
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.MessageLatencyMultiplier = msgLatencyMultiplier
+		cfg.MaxTimeout = testMaxTimeout
+		cfg.MinTimeout = 10 * time.Millisecond
 
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
-	// Add keys
-	dhtm.AddPending(ks)
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
+		// Add keys
+		dhtm.AddPending(ks)
 
-	// Receive a message latency update that would make the timeout greater
-	// than the maximum timeout
-	dhtm.UpdateMessageLatency(testMaxTimeout * 4)
+		// Receive a message latency update that would make the timeout greater
+		// than the maximum timeout
+		dhtm.UpdateMessageLatency(testMaxTimeout * 4)
 
-	// Sleep until just after the maximum timeout
-	clock.Add(testMaxTimeout + 5*time.Millisecond)
+		// Sleep until just after the maximum timeout
+		time.Sleep(testMaxTimeout + 5*time.Millisecond)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// Keys should have timed out
-	if tr.timedOutCount() != len(ks) {
-		t.Fatal("expected keys to timeout")
-	}
+		// Keys should have timed out
+		if tr.timedOutCount() != len(ks) {
+			t.Fatal("expected keys to timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfPingError(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(2)
-	latency := time.Millisecond
-	latMultiplier := 2
-	expProcessTime := 2 * time.Millisecond
-	defaultTimeout := 10 * time.Millisecond
-	expectedTimeout := expProcessTime + defaultTimeout
-	tr := timeoutRecorder{}
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged, err: errors.New("ping error")}
-	timeoutsTriggered := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(2)
+		latency := time.Millisecond
+		latMultiplier := 2
+		expProcessTime := 2 * time.Millisecond
+		defaultTimeout := 10 * time.Millisecond
+		expectedTimeout := expProcessTime + defaultTimeout
+		tr := timeoutRecorder{}
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+			err:     errors.New("ping error"),
+		}
+		timeoutsTriggered := make(chan struct{})
 
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.DontHaveTimeout = defaultTimeout
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.DontHaveTimeout = defaultTimeout
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
 
-	// Add keys
-	dhtm.AddPending(ks)
+		// Add keys
+		dhtm.AddPending(ks)
 
-	// Sleep for less than the expected timeout
-	clock.Add(expectedTimeout - 5*time.Millisecond)
+		// Sleep for less than the expected timeout
+		time.Sleep(expectedTimeout - 5*time.Millisecond)
+		synctest.Wait()
 
-	// At this stage no timeout should have happened yet
-	if tr.timedOutCount() > 0 {
-		t.Fatal("expected timeout not to have happened yet")
-	}
+		// At this stage no timeout should have happened yet
+		if tr.timedOutCount() > 0 {
+			t.Fatal("expected timeout not to have happened yet")
+		}
 
-	// Sleep until after the expected timeout
-	clock.Add(10 * time.Millisecond)
+		// Sleep until after the expected timeout
+		time.Sleep(10 * time.Millisecond)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// Now the keys should have timed out
-	if tr.timedOutCount() != len(ks) {
-		t.Fatal("expected timeout")
-	}
+		// Now the keys should have timed out
+		if tr.timedOutCount() != len(ks) {
+			t.Fatal("expected timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutMgrUsesDefaultTimeoutIfLatencyLonger(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(2)
-	latency := time.Millisecond * 200
-	latMultiplier := 1
-	expProcessTime := time.Duration(0)
-	defaultTimeout := 100 * time.Millisecond
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(2)
+		latency := time.Millisecond * 200
+		latMultiplier := 1
+		expProcessTime := time.Duration(0)
+		defaultTimeout := 100 * time.Millisecond
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
 
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.DontHaveTimeout = defaultTimeout
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.DontHaveTimeout = defaultTimeout
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
 
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
 
-	// Add keys
-	dhtm.AddPending(ks)
+		// Add keys
+		dhtm.AddPending(ks)
 
-	// Sleep for less than the default timeout
-	clock.Add(defaultTimeout - 50*time.Millisecond)
+		// Sleep for less than the default timeout
+		time.Sleep(defaultTimeout - 50*time.Millisecond)
+		synctest.Wait()
 
-	// At this stage no timeout should have happened yet
-	if tr.timedOutCount() > 0 {
-		t.Fatal("expected timeout not to have happened yet")
-	}
+		// At this stage no timeout should have happened yet
+		if tr.timedOutCount() > 0 {
+			t.Fatal("expected timeout not to have happened yet")
+		}
 
-	// Sleep until after the default timeout
-	clock.Add(defaultTimeout * 2)
+		// Sleep until after the default timeout
+		time.Sleep(defaultTimeout * 2)
 
-	<-timeoutsTriggered
+		<-timeoutsTriggered
 
-	// Now the keys should have timed out
-	if tr.timedOutCount() != len(ks) {
-		t.Fatal("expected timeout")
-	}
+		// Now the keys should have timed out
+		if tr.timedOutCount() != len(ks) {
+			t.Fatal("expected timeout")
+		}
+	})
 }
 
 func TestDontHaveTimeoutNoTimeoutAfterShutdown(t *testing.T) {
 	t.Parallel()
-	ks := random.Cids(2)
-	latency := time.Millisecond * 10
-	latMultiplier := 1
-	expProcessTime := time.Duration(0)
-	clock := clock.NewMock()
-	pinged := make(chan struct{})
-	pc := &mockPeerConn{latency: latency, clock: clock, pinged: pinged}
-	tr := timeoutRecorder{}
-	timeoutsTriggered := make(chan struct{})
+	synctest.Test(t, func(t *testing.T) {
+		ks := random.Cids(2)
+		latency := time.Millisecond * 10
+		latMultiplier := 1
+		expProcessTime := time.Duration(0)
+		pinged := make(chan struct{})
+		pc := &mockPeerConn{
+			latency: latency,
+			pinged:  pinged,
+		}
+		tr := timeoutRecorder{}
+		timeoutsTriggered := make(chan struct{})
 
-	cfg := DefaultDontHaveTimeoutConfig()
-	cfg.PingLatencyMultiplier = latMultiplier
-	cfg.MaxExpectedWantProcessTime = expProcessTime
-	cfg.MinTimeout = 10 * time.Millisecond
-	cfg.timeoutsSignal = timeoutsTriggered
-	cfg.clock = clock
-	dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
-	dhtm.Start()
-	defer dhtm.Shutdown()
-	<-pinged
+		cfg := DefaultDontHaveTimeoutConfig()
+		cfg.PingLatencyMultiplier = latMultiplier
+		cfg.MaxExpectedWantProcessTime = expProcessTime
+		cfg.MinTimeout = 10 * time.Millisecond
+		cfg.timeoutsSignal = timeoutsTriggered
+		dhtm := newDontHaveTimeoutMgr(pc, tr.onTimeout, cfg)
+		dhtm.Start()
+		defer dhtm.Shutdown()
+		<-pinged
 
-	// Add keys
-	dhtm.AddPending(ks)
+		// Add keys
+		dhtm.AddPending(ks)
 
-	// Wait less than the timeout
-	clock.Add(latency - 5*time.Millisecond)
+		// Wait less than the timeout
+		time.Sleep(latency - 5*time.Millisecond)
+		synctest.Wait()
 
-	// Shutdown the manager
-	dhtm.Shutdown()
+		// Shutdown the manager
+		dhtm.Shutdown()
 
-	// Wait for the expected timeout
-	clock.Add(10 * time.Millisecond)
+		// Wait for the expected timeout
+		time.Sleep(10 * time.Millisecond)
+		synctest.Wait()
 
-	// Manager was shut down so timeout should not have fired
-	if tr.timedOutCount() != 0 {
-		t.Fatal("expected no timeout after shutdown")
-	}
+		// Manager was shut down so timeout should not have fired
+		if tr.timedOutCount() != 0 {
+			t.Fatal("expected no timeout after shutdown")
+		}
+	})
 }

--- a/bitswap/client/internal/messagequeue/donthavetimeoutmgr_test.go
+++ b/bitswap/client/internal/messagequeue/donthavetimeoutmgr_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25
+
 package messagequeue
 
 import (

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25
+
 package messagequeue
 
 import (

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -7,9 +7,9 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	bsmsg "github.com/ipfs/boxo/bitswap/message"
 	pb "github.com/ipfs/boxo/bitswap/message/pb"
 	bsnet "github.com/ipfs/boxo/bitswap/network"
@@ -430,104 +430,109 @@ func TestWantOverridesPendingCancels(t *testing.T) {
 
 func TestWantlistRebroadcast(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	messagesSent := make(chan []bsmsg.Entry)
-	resetChan := make(chan struct{}, 1)
-	fakeSender := newFakeMessageSender(resetChan, messagesSent, true)
-	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
-	peerID := random.Peers(1)[0]
-	dhtm := &fakeDontHaveTimeoutMgr{}
-	clock := clock.NewMock()
-	events := make(chan messageEvent, 1)
-	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, clock, events)
-	bcstwh := random.Cids(10)
-	wantHaves := random.Cids(10)
-	wantBlocks := random.Cids(10)
+	synctest.Test(t, func(t *testing.T) {
+		ctx := context.Background()
+		messagesSent := make(chan []bsmsg.Entry)
+		resetChan := make(chan struct{}, 1)
+		fakeSender := newFakeMessageSender(resetChan, messagesSent, true)
+		fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
+		peerID := random.Peers(1)[0]
+		dhtm := &fakeDontHaveTimeoutMgr{}
+		events := make(chan messageEvent, 1)
+		messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, events)
+		bcstwh := random.Cids(10)
+		wantHaves := random.Cids(10)
+		wantBlocks := random.Cids(10)
 
-	// Add some broadcast want-haves
-	messageQueue.Startup()
-	defer messageQueue.Shutdown()
-	messageQueue.AddBroadcastWantHaves(bcstwh)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	message := <-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		// Add some broadcast want-haves
+		messageQueue.Startup()
+		defer messageQueue.Shutdown()
+		messageQueue.AddBroadcastWantHaves(bcstwh)
 
-	// All broadcast want-haves should have been sent
-	if len(message) != len(bcstwh) {
-		t.Fatal("wrong number of wants")
-	}
+		time.Sleep(maxSendMessageDelay)
 
-	messageQueue.RebroadcastNow()
-	message = <-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		expectEvent(t, events, messageQueued)
+		message := <-messagesSent
+		expectEvent(t, events, messageFinishedSending)
 
-	// All the want-haves should have been rebroadcast
-	if len(message) != len(bcstwh) {
-		t.Fatal("did not rebroadcast all wants")
-	}
-
-	// Send out some regular wants and collect them
-	messageQueue.AddWants(wantBlocks, wantHaves)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	clock.Add(10 * time.Millisecond)
-	message = <-messagesSent
-	expectEvent(t, events, messageFinishedSending)
-
-	// All new wants should have been sent
-	if len(message) != len(wantHaves)+len(wantBlocks) {
-		t.Fatal("wrong number of wants")
-	}
-
-	select {
-	case <-messagesSent:
-		t.Fatal("should only be one message in queue")
-	default:
-	}
-
-	messageQueue.RebroadcastNow()
-	message = <-messagesSent
-	expectEvent(t, events, messageFinishedSending)
-
-	// Both original and new wants should have been rebroadcast
-	totalWants := len(bcstwh) + len(wantHaves) + len(wantBlocks)
-	if len(message) != totalWants {
-		t.Fatal("did not rebroadcast all wants")
-	}
-
-	// Cancel some of the wants
-	cancels := append([]cid.Cid{bcstwh[0]}, wantHaves[0], wantBlocks[0])
-	messageQueue.AddCancels(cancels)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	clock.Add(10 * time.Millisecond)
-	message = <-messagesSent
-	expectEvent(t, events, messageFinishedSending)
-
-	select {
-	case <-messagesSent:
-		t.Fatal("should only be one message in queue")
-	default:
-	}
-
-	// Cancels for each want should have been sent
-	if len(message) != len(cancels) {
-		t.Fatal("wrong number of cancels")
-	}
-	for _, entry := range message {
-		if !entry.Cancel {
-			t.Fatal("expected cancels")
+		// All broadcast want-haves should have been sent
+		if len(message) != len(bcstwh) {
+			t.Fatal("wrong number of wants")
 		}
-	}
 
-	messageQueue.RebroadcastNow()
-	message = <-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		messageQueue.RebroadcastNow()
+		message = <-messagesSent
+		expectEvent(t, events, messageFinishedSending)
 
-	if len(message) != totalWants-len(cancels) {
-		t.Fatal("did not rebroadcast all wants")
-	}
+		// All the want-haves should have been rebroadcast
+		if len(message) != len(bcstwh) {
+			t.Fatal("did not rebroadcast all wants")
+		}
+
+		// Send out some regular wants and collect them
+		messageQueue.AddWants(wantBlocks, wantHaves)
+		time.Sleep(maxSendMessageDelay)
+
+		expectEvent(t, events, messageQueued)
+		time.Sleep(10 * time.Millisecond)
+
+		message = <-messagesSent
+		expectEvent(t, events, messageFinishedSending)
+
+		// All new wants should have been sent
+		if len(message) != len(wantHaves)+len(wantBlocks) {
+			t.Fatal("wrong number of wants")
+		}
+
+		select {
+		case <-messagesSent:
+			t.Fatal("should only be one message in queue")
+		default:
+		}
+
+		messageQueue.RebroadcastNow()
+		message = <-messagesSent
+		expectEvent(t, events, messageFinishedSending)
+
+		// Both original and new wants should have been rebroadcast
+		totalWants := len(bcstwh) + len(wantHaves) + len(wantBlocks)
+		if len(message) != totalWants {
+			t.Fatal("did not rebroadcast all wants")
+		}
+
+		// Cancel some of the wants
+		cancels := append([]cid.Cid{bcstwh[0]}, wantHaves[0], wantBlocks[0])
+		messageQueue.AddCancels(cancels)
+		time.Sleep(maxSendMessageDelay)
+		expectEvent(t, events, messageQueued)
+		time.Sleep(10 * time.Millisecond)
+		message = <-messagesSent
+		expectEvent(t, events, messageFinishedSending)
+
+		select {
+		case <-messagesSent:
+			t.Fatal("should only be one message in queue")
+		default:
+		}
+
+		// Cancels for each want should have been sent
+		if len(message) != len(cancels) {
+			t.Fatal("wrong number of cancels")
+		}
+		for _, entry := range message {
+			if !entry.Cancel {
+				t.Fatal("expected cancels")
+			}
+		}
+
+		messageQueue.RebroadcastNow()
+		message = <-messagesSent
+		expectEvent(t, events, messageFinishedSending)
+
+		if len(message) != totalWants-len(cancels) {
+			t.Fatal("did not rebroadcast all wants")
+		}
+	})
 }
 
 func TestSendingLargeMessages(t *testing.T) {
@@ -543,7 +548,7 @@ func TestSendingLargeMessages(t *testing.T) {
 	wantBlocks := random.Cids(10)
 	entrySize := 44
 	maxMsgSize := entrySize * 3 // 3 wants
-	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMsgSize, sendErrorBackoff, maxValidLatency, dhtm, clock.New(), nil)
+	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMsgSize, sendErrorBackoff, maxValidLatency, dhtm, nil)
 
 	messageQueue.Startup()
 	defer messageQueue.Shutdown()
@@ -627,7 +632,7 @@ func TestSendToPeerThatDoesntSupportHaveMonitorsTimeouts(t *testing.T) {
 	peerID := random.Peers(1)[0]
 
 	dhtm := &fakeDontHaveTimeoutMgr{}
-	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, clock.New(), nil)
+	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, nil)
 	messageQueue.Startup()
 	defer messageQueue.Shutdown()
 
@@ -652,54 +657,56 @@ func TestSendToPeerThatDoesntSupportHaveMonitorsTimeouts(t *testing.T) {
 
 func TestResponseReceived(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	messagesSent := make(chan []bsmsg.Entry)
-	resetChan := make(chan struct{}, 1)
-	fakeSender := newFakeMessageSender(resetChan, messagesSent, false)
-	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
-	peerID := random.Peers(1)[0]
+	synctest.Test(t, func(*testing.T) {
+		ctx := context.Background()
+		messagesSent := make(chan []bsmsg.Entry)
+		resetChan := make(chan struct{}, 1)
+		fakeSender := newFakeMessageSender(resetChan, messagesSent, false)
+		fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
+		peerID := random.Peers(1)[0]
 
-	dhtm := &fakeDontHaveTimeoutMgr{}
-	clock := clock.NewMock()
-	events := make(chan messageEvent)
-	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, clock, events)
-	messageQueue.Startup()
-	defer messageQueue.Shutdown()
+		dhtm := &fakeDontHaveTimeoutMgr{}
+		events := make(chan messageEvent)
+		messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, events)
+		messageQueue.Startup()
+		defer messageQueue.Shutdown()
 
-	cids := random.Cids(10)
+		cids := random.Cids(10)
 
-	// Add some wants
-	messageQueue.AddWants(cids[:5], nil)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	<-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		// Add some wants
+		messageQueue.AddWants(cids[:5], nil)
+		time.Sleep(maxSendMessageDelay)
+		expectEvent(t, events, messageQueued)
+		<-messagesSent
+		expectEvent(t, events, messageFinishedSending)
 
-	// simulate 10 milliseconds passing
-	clock.Add(10 * time.Millisecond)
+		// simulate 10 milliseconds passing
+		time.Sleep(10 * time.Millisecond)
+		synctest.Wait()
 
-	// Add some wants and wait another 10ms
-	messageQueue.AddWants(cids[5:8], nil)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	clock.Add(10 * time.Millisecond)
-	<-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		// Add some wants and wait another 10ms
+		messageQueue.AddWants(cids[5:8], nil)
+		time.Sleep(maxSendMessageDelay)
+		expectEvent(t, events, messageQueued)
+		time.Sleep(10 * time.Millisecond)
+		<-messagesSent
+		expectEvent(t, events, messageFinishedSending)
 
-	// Receive a response for some of the wants from both groups
-	messageQueue.ResponseReceived([]cid.Cid{cids[0], cids[6], cids[9]})
+		// Receive a response for some of the wants from both groups
+		messageQueue.ResponseReceived([]cid.Cid{cids[0], cids[6], cids[9]})
 
-	// Check that message queue informs DHTM of received responses
-	expectEvent(t, events, latenciesRecorded)
-	upds := dhtm.latencyUpdates()
-	if len(upds) != 1 {
-		t.Fatal("expected one latency update")
-	}
-	// Elapsed time should be between when the first want was sent and the
-	// response received (about 20ms)
-	if upds[0] != maxSendMessageDelay+20*time.Millisecond {
-		t.Fatalf("expected latency to be time since oldest message sent, was %s", upds[0].String())
-	}
+		// Check that message queue informs DHTM of received responses
+		expectEvent(t, events, latenciesRecorded)
+		upds := dhtm.latencyUpdates()
+		if len(upds) != 1 {
+			t.Fatal("expected one latency update")
+		}
+		// Elapsed time should be between when the first want was sent and the
+		// response received (about 20ms)
+		if upds[0] != maxSendMessageDelay+20*time.Millisecond {
+			t.Fatalf("expected latency to be time since oldest message sent, was %s", upds[0].String())
+		}
+	})
 }
 
 func TestResponseReceivedAppliesForFirstResponseOnly(t *testing.T) {
@@ -712,7 +719,7 @@ func TestResponseReceivedAppliesForFirstResponseOnly(t *testing.T) {
 	peerID := random.Peers(1)[0]
 
 	dhtm := &fakeDontHaveTimeoutMgr{}
-	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, clock.New(), nil)
+	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, nil)
 	messageQueue.Startup()
 	defer messageQueue.Shutdown()
 
@@ -750,55 +757,58 @@ func TestResponseReceivedAppliesForFirstResponseOnly(t *testing.T) {
 
 func TestResponseReceivedDiscardsOutliers(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
-	messagesSent := make(chan []bsmsg.Entry)
-	resetChan := make(chan struct{}, 1)
-	fakeSender := newFakeMessageSender(resetChan, messagesSent, false)
-	fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
-	peerID := random.Peers(1)[0]
+	synctest.Test(t, func(*testing.T) {
+		ctx := context.Background()
+		messagesSent := make(chan []bsmsg.Entry)
+		resetChan := make(chan struct{}, 1)
+		fakeSender := newFakeMessageSender(resetChan, messagesSent, false)
+		fakenet := &fakeMessageNetwork{nil, nil, fakeSender}
+		peerID := random.Peers(1)[0]
 
-	maxValLatency := 30 * time.Millisecond
-	dhtm := &fakeDontHaveTimeoutMgr{}
-	clock := clock.NewMock()
-	events := make(chan messageEvent)
-	messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValLatency, dhtm, clock, events)
-	messageQueue.Startup()
-	defer messageQueue.Shutdown()
+		maxValLatency := 30 * time.Millisecond
+		dhtm := &fakeDontHaveTimeoutMgr{}
+		events := make(chan messageEvent)
+		messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValLatency, dhtm, events)
+		messageQueue.Startup()
+		defer messageQueue.Shutdown()
 
-	cids := random.Cids(4)
+		cids := random.Cids(4)
 
-	// Add some wants and wait 20ms
-	messageQueue.AddWants(cids[:2], nil)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	<-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		// Add some wants and wait 20ms
+		messageQueue.AddWants(cids[:2], nil)
+		time.Sleep(maxSendMessageDelay)
+		expectEvent(t, events, messageQueued)
+		<-messagesSent
+		expectEvent(t, events, messageFinishedSending)
 
-	clock.Add(20 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
+		synctest.Wait()
 
-	// Add some more wants and wait long enough that the first wants will be
-	// outside the maximum valid latency, but the second wants will be inside
-	messageQueue.AddWants(cids[2:], nil)
-	clock.Add(maxSendMessageDelay)
-	expectEvent(t, events, messageQueued)
-	<-messagesSent
-	expectEvent(t, events, messageFinishedSending)
+		// Add some more wants and wait long enough that the first wants will be
+		// outside the maximum valid latency, but the second wants will be inside
+		messageQueue.AddWants(cids[2:], nil)
+		time.Sleep(maxSendMessageDelay)
+		expectEvent(t, events, messageQueued)
+		<-messagesSent
+		expectEvent(t, events, messageFinishedSending)
+		time.Sleep(maxValLatency - 10*time.Millisecond)
+		synctest.Wait()
 
-	clock.Add(maxValLatency - 10*time.Millisecond)
-	// Receive a response for the wants
-	messageQueue.ResponseReceived(cids)
+		// Receive a response for the wants
+		messageQueue.ResponseReceived(cids)
 
-	// Check that the latency calculation excludes the first wants
-	// (because they're older than max valid latency)
-	expectEvent(t, events, latenciesRecorded)
-	upds := dhtm.latencyUpdates()
-	if len(upds) != 1 {
-		t.Fatalf("expected one latency update, got %d", len(upds))
-	}
-	// Elapsed time should not include outliers
-	if upds[0] > maxValLatency {
-		t.Fatal("expected latency calculation to discard outliers")
-	}
+		// Check that the latency calculation excludes the first wants
+		// (because they're older than max valid latency)
+		expectEvent(t, events, latenciesRecorded)
+		upds := dhtm.latencyUpdates()
+		if len(upds) != 1 {
+			t.Fatalf("expected one latency update, got %d", len(upds))
+		}
+		// Elapsed time should not include outliers
+		if upds[0] > maxValLatency {
+			t.Fatal("expected latency calculation to discard outliers")
+		}
+	})
 }
 
 func filterWantTypes(wantlist []bsmsg.Entry) ([]cid.Cid, []cid.Cid, []cid.Cid) {
@@ -829,7 +839,7 @@ func BenchmarkMessageQueue(b *testing.B) {
 		dhtm := &fakeDontHaveTimeoutMgr{}
 		peerID := random.Peers(1)[0]
 
-		messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, clock.New(), nil)
+		messageQueue := newMessageQueue(ctx, peerID, fakenet, maxMessageSize, sendErrorBackoff, maxValidLatency, dhtm, nil)
 		messageQueue.Startup()
 
 		go func() {

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -1044,14 +1044,6 @@ func (e *Engine) sendAsBlock(wantType pb.Message_Wantlist_WantType, blockSize in
 	return wantType == pb.Message_Wantlist_Block || blockSize <= e.wantHaveReplaceSize
 }
 
-func (e *Engine) numBytesSentTo(p peer.ID) uint64 {
-	return e.LedgerForPeer(p).Sent
-}
-
-func (e *Engine) numBytesReceivedFrom(p peer.ID) uint64 {
-	return e.LedgerForPeer(p).Recv
-}
-
 func (e *Engine) signalNewWork() {
 	// Signal task generation to restart (if stopped!)
 	select {

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25
+
 package decision
 
 import (
@@ -27,6 +29,16 @@ import (
 	libp2ptest "github.com/libp2p/go-libp2p/core/test"
 	mh "github.com/multiformats/go-multihash"
 )
+
+// numBytesSentTo returns the total bytes sent to peer p according to the ledger.
+func (e *Engine) numBytesSentTo(p peer.ID) uint64 {
+	return e.LedgerForPeer(p).Sent
+}
+
+// numBytesReceivedFrom returns the total bytes received from peer p according to the ledger.
+func (e *Engine) numBytesReceivedFrom(p peer.ID) uint64 {
+	return e.LedgerForPeer(p).Recv
+}
 
 type peerTag struct {
 	done  chan struct{}

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	wl "github.com/ipfs/boxo/bitswap/client/wantlist"
 	message "github.com/ipfs/boxo/bitswap/message"
 	pb "github.com/ipfs/boxo/bitswap/message/pb"
@@ -95,13 +95,13 @@ type engineSet struct {
 }
 
 func newTestEngine(idStr string, opts ...Option) engineSet {
-	return newTestEngineWithSampling(idStr, shortTerm, nil, clock.New(), opts...)
+	return newTestEngineWithSampling(idStr, shortTerm, nil, opts...)
 }
 
-func newTestEngineWithSampling(idStr string, peerSampleInterval time.Duration, sampleCh chan struct{}, clock clock.Clock, opts ...Option) engineSet {
+func newTestEngineWithSampling(idStr string, peerSampleInterval time.Duration, sampleCh chan struct{}, opts ...Option) engineSet {
 	fpt := &fakePeerTagger{}
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
-	e := newEngineForTesting(bs, fpt, "localhost", 0, append(opts[:len(opts):len(opts)], WithScoreLedger(NewTestScoreLedger(peerSampleInterval, sampleCh, clock)), WithBlockstoreWorkerCount(4))...)
+	e := newEngineForTesting(bs, fpt, "localhost", 0, append(opts[:len(opts):len(opts)], WithScoreLedger(NewTestScoreLedger(peerSampleInterval, sampleCh)), WithBlockstoreWorkerCount(4))...)
 	return engineSet{
 		Peer:       peer.ID(idStr),
 		PeerTagger: fpt,
@@ -188,7 +188,7 @@ func newEngineForTesting(
 
 func TestOutboxClosedWhenEngineClosed(t *testing.T) {
 	t.SkipNow() // TODO implement *Engine.Close
-	e := newEngineForTesting(blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore())), &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+	e := newEngineForTesting(blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore())), &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 	defer e.Close()
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -516,7 +516,7 @@ func TestPartnerWantHaveWantBlockNonActive(t *testing.T) {
 		testCases = onlyTestCases
 	}
 
-	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 	defer e.Close()
 	for i, testCase := range testCases {
 		t.Logf("Test case %d:", i)
@@ -672,7 +672,7 @@ func TestPartnerWantHaveWantBlockActive(t *testing.T) {
 		testCases = onlyTestCases
 	}
 
-	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 	defer e.Close()
 
 	var next envChan
@@ -856,7 +856,7 @@ func TestPartnerWantsThenCancels(t *testing.T) {
 
 	for i := 0; i < numRounds; i++ {
 		expected := make([][]string, 0, len(testcases))
-		e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+		e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 		defer e.Close()
 		for _, testcase := range testcases {
 			set := testcase[0]
@@ -881,7 +881,7 @@ func TestSendReceivedBlocksToPeersThatWantThem(t *testing.T) {
 	partner := libp2ptest.RandPeerIDFatal(t)
 	otherPeer := libp2ptest.RandPeerIDFatal(t)
 
-	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 	defer e.Close()
 
 	blks := random.BlocksOfSize(4, 8*1024)
@@ -925,7 +925,7 @@ func TestSendDontHave(t *testing.T) {
 	partner := libp2ptest.RandPeerIDFatal(t)
 	otherPeer := libp2ptest.RandPeerIDFatal(t)
 
-	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 	defer e.Close()
 
 	blks := random.BlocksOfSize(4, 8*1024)
@@ -988,7 +988,7 @@ func TestWantlistForPeer(t *testing.T) {
 	partner := libp2ptest.RandPeerIDFatal(t)
 	otherPeer := libp2ptest.RandPeerIDFatal(t)
 
-	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4))
+	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4))
 	defer e.Close()
 
 	blks := random.BlocksOfSize(4, 8*1024)
@@ -1030,7 +1030,7 @@ func TestTaskComparator(t *testing.T) {
 	}
 
 	fpt := &fakePeerTagger{}
-	sl := NewTestScoreLedger(shortTerm, nil, clock.New())
+	sl := NewTestScoreLedger(shortTerm, nil)
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -1090,7 +1090,7 @@ func TestPeerBlockFilter(t *testing.T) {
 
 	// Setup the main peer
 	fpt := &fakePeerTagger{}
-	sl := NewTestScoreLedger(shortTerm, nil, clock.New())
+	sl := NewTestScoreLedger(shortTerm, nil)
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -1245,7 +1245,7 @@ func TestPeerBlockFilterMutability(t *testing.T) {
 
 	// Setup the main peer
 	fpt := &fakePeerTagger{}
-	sl := NewTestScoreLedger(shortTerm, nil, clock.New())
+	sl := NewTestScoreLedger(shortTerm, nil)
 	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -1432,58 +1432,60 @@ func TestTaggingPeers(t *testing.T) {
 func TestTaggingUseful(t *testing.T) {
 	const peerSampleIntervalHalf = 10 * time.Millisecond
 
-	sampleCh := make(chan struct{})
-	mockClock := clock.NewMock()
-	me := newTestEngineWithSampling("engine", peerSampleIntervalHalf*2, sampleCh, mockClock)
-	defer me.Engine.Close()
-	mockClock.Add(1 * time.Millisecond)
-	friend := peer.ID("friend")
+	synctest.Test(t, func(t *testing.T) {
+		sampleCh := make(chan struct{})
+		me := newTestEngineWithSampling("engine", peerSampleIntervalHalf*2, sampleCh)
+		defer me.Engine.Close()
+		time.Sleep(1 * time.Millisecond)
+		friend := peer.ID("friend")
 
-	block := blocks.NewBlock([]byte("foobar"))
-	msg := message.New(false)
-	msg.AddBlock(block)
+		block := blocks.NewBlock([]byte("foobar"))
+		msg := message.New(false)
+		msg.AddBlock(block)
 
-	for i := 0; i < 3; i++ {
-		if untagged := me.PeerTagger.count(me.Engine.tagUseful); untagged != 0 {
-			t.Fatalf("%d peers should be untagged but weren't", untagged)
+		for i := 0; i < 3; i++ {
+			if untagged := me.PeerTagger.count(me.Engine.tagUseful); untagged != 0 {
+				t.Fatalf("%d peers should be untagged but weren't", untagged)
+			}
+			time.Sleep(peerSampleIntervalHalf)
+			synctest.Wait()
+			me.Engine.MessageSent(friend, msg)
+
+			time.Sleep(peerSampleIntervalHalf)
+			<-sampleCh
+
+			if tagged := me.PeerTagger.count(me.Engine.tagUseful); tagged != 1 {
+				t.Fatalf("1 peer should be tagged, but %d were", tagged)
+			}
+
+			for j := 0; j < longTermRatio; j++ {
+				time.Sleep(peerSampleIntervalHalf * 2)
+				<-sampleCh
+			}
 		}
-		mockClock.Add(peerSampleIntervalHalf)
-		me.Engine.MessageSent(friend, msg)
 
-		mockClock.Add(peerSampleIntervalHalf)
-		<-sampleCh
-
-		if tagged := me.PeerTagger.count(me.Engine.tagUseful); tagged != 1 {
-			t.Fatalf("1 peer should be tagged, but %d were", tagged)
+		if me.PeerTagger.count(me.Engine.tagUseful) == 0 {
+			t.Fatal("peers should still be tagged due to long-term usefulness")
 		}
 
 		for j := 0; j < longTermRatio; j++ {
-			mockClock.Add(peerSampleIntervalHalf * 2)
+			time.Sleep(peerSampleIntervalHalf * 2)
 			<-sampleCh
 		}
-	}
 
-	if me.PeerTagger.count(me.Engine.tagUseful) == 0 {
-		t.Fatal("peers should still be tagged due to long-term usefulness")
-	}
+		if me.PeerTagger.count(me.Engine.tagUseful) == 0 {
+			t.Fatal("peers should still be tagged due to long-term usefulness")
+		}
 
-	for j := 0; j < longTermRatio; j++ {
-		mockClock.Add(peerSampleIntervalHalf * 2)
-		<-sampleCh
-	}
+		for j := 0; j < longTermRatio; j++ {
+			time.Sleep(peerSampleIntervalHalf * 2)
+			<-sampleCh
+		}
 
-	if me.PeerTagger.count(me.Engine.tagUseful) == 0 {
-		t.Fatal("peers should still be tagged due to long-term usefulness")
-	}
-
-	for j := 0; j < longTermRatio; j++ {
-		mockClock.Add(peerSampleIntervalHalf * 2)
-		<-sampleCh
-	}
-
-	if me.PeerTagger.count(me.Engine.tagUseful) != 0 {
-		t.Fatal("peers should finally be untagged")
-	}
+		if me.PeerTagger.count(me.Engine.tagUseful) != 0 {
+			t.Fatal("peers should finally be untagged")
+		}
+	})
 }
 
 func partnerWantBlocks(e *Engine, wantBlocks []string, partner peer.ID) {
@@ -1722,7 +1724,7 @@ func TestWantlistBlocked(t *testing.T) {
 	}
 
 	fpt := &fakePeerTagger{}
-	e := newEngineForTesting(bs, fpt, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4), WithMaxQueuedWantlistEntriesPerPeer(limit))
+	e := newEngineForTesting(bs, fpt, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4), WithMaxQueuedWantlistEntriesPerPeer(limit))
 	defer e.Close()
 
 	warsaw := engineSet{
@@ -1807,7 +1809,7 @@ func TestWantlistOverflow(t *testing.T) {
 	}
 
 	fpt := &fakePeerTagger{}
-	e := newEngineForTesting(bs, fpt, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil, clock.New())), WithBlockstoreWorkerCount(4), WithMaxQueuedWantlistEntriesPerPeer(limit))
+	e := newEngineForTesting(bs, fpt, "localhost", 0, WithScoreLedger(NewTestScoreLedger(shortTerm, nil)), WithBlockstoreWorkerCount(4), WithMaxQueuedWantlistEntriesPerPeer(limit))
 	defer e.Close()
 	warsaw := engineSet{
 		Peer:       peer.ID("warsaw"),

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/boxo/examples
 
-go 1.25
+go 1.24.6
 
 require (
 	github.com/ipfs/boxo v0.35.2

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/boxo/examples
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/ipfs/boxo v0.35.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/boxo
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b
@@ -8,7 +8,6 @@ require (
 	github.com/crackcomm/go-gitignore v0.0.0-20241020182519-7843d2ba8fdf
 	github.com/cskr/pubsub v1.0.2
 	github.com/dustin/go-humanize v1.0.1
-	github.com/filecoin-project/go-clock v0.1.0
 	github.com/gabriel-vasile/mimetype v1.4.10
 	github.com/gammazero/chanqueue v1.1.1
 	github.com/gammazero/deque v1.2.0
@@ -86,6 +85,7 @@ require (
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/filecoin-project/go-clock v0.1.0 // indirect
 	github.com/flynn/noise v1.1.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/boxo
 
-go 1.25
+go 1.24.6
 
 require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	ipns "github.com/ipfs/boxo/ipns"
 	"github.com/ipfs/boxo/routing/http/contentrouter"
 	"github.com/ipfs/boxo/routing/http/filters"
@@ -68,7 +67,6 @@ const (
 type Client struct {
 	baseURL    string
 	httpClient httpClient
-	clock      clock.Clock
 	accepts    string
 
 	peerID   peer.ID
@@ -207,7 +205,6 @@ func New(baseURL string, opts ...Option) (*Client, error) {
 	client := &Client{
 		baseURL:        normalizedURL,
 		httpClient:     newDefaultHTTPClient(defaultUserAgent),
-		clock:          clock.New(),
 		accepts:        strings.Join([]string{mediaTypeNDJSON, mediaTypeJSON}, ","),
 		protocolFilter: DefaultProtocolFilter, // can be customized via WithProtocolFilter
 	}
@@ -271,11 +268,11 @@ func (c *Client) FindProviders(ctx context.Context, key cid.Cid) (providers iter
 
 	m.host = req.Host
 
-	start := c.clock.Now()
+	start := time.Now()
 	resp, err := c.httpClient.Do(req)
 
 	m.err = err
-	m.latency = c.clock.Since(start)
+	m.latency = time.Since(start)
 
 	if err != nil {
 		m.record(ctx)
@@ -355,7 +352,7 @@ func (c *Client) ProvideBitswap(ctx context.Context, keys []cid.Cid, ttl time.Du
 		ks[i] = types.CID{Cid: c}
 	}
 
-	now := c.clock.Now()
+	now := time.Now()
 
 	req := types.WriteBitswapRecord{
 		Protocol: "transport-bitswap",
@@ -457,11 +454,11 @@ func (c *Client) FindPeers(ctx context.Context, pid peer.ID) (peers iter.ResultI
 
 	m.host = req.Host
 
-	start := c.clock.Now()
+	start := time.Now()
 	resp, err := c.httpClient.Do(req)
 
 	m.err = err
-	m.latency = c.clock.Since(start)
+	m.latency = time.Since(start)
 
 	if err != nil {
 		m.record(ctx)
@@ -657,9 +654,9 @@ func (c *Client) GetClosestPeers(ctx context.Context, key cid.Cid) (peers iter.R
 	req.Header.Set("Accept", c.accepts)
 
 	m.host = req.Host
-	start := c.clock.Now()
+	start := time.Now()
 	resp, err := c.httpClient.Do(req)
-	m.latency = c.clock.Since(start)
+	m.latency = time.Since(start)
 	m.err = err
 
 	if err != nil {

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -1,3 +1,5 @@
+//go:build go1.25
+
 package client
 
 import (

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -9,9 +9,9 @@ import (
 	"net/http/httptest"
 	"runtime"
 	"testing"
+	"testing/synctest"
 	"time"
 
-	"github.com/filecoin-project/go-clock"
 	ipns "github.com/ipfs/boxo/ipns"
 	"github.com/ipfs/boxo/path"
 	"github.com/ipfs/boxo/routing/http/server"
@@ -466,72 +466,70 @@ func TestClient_Provide(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			deps := makeTestDeps(t, nil, nil)
-			client := deps.client
-			router := deps.router
+			synctest.Test(t, func(t *testing.T) {
+				deps := makeTestDeps(t, nil, nil)
+				client := deps.client
+				router := deps.router
 
-			if c.noIdentity {
-				client.identity = nil
-			}
-			if c.noProviderInfo {
-				client.peerID = ""
-				client.addrs = nil
-			}
+				if c.noIdentity {
+					client.identity = nil
+				}
+				if c.noProviderInfo {
+					client.peerID = ""
+					client.addrs = nil
+				}
 
-			clock := clock.NewMock()
-			clock.Set(time.Now())
-			client.clock = clock
+				ctx := context.Background()
 
-			ctx := context.Background()
+				if c.manglePath {
+					client.baseURL += "/foo"
+				}
+				if c.stopServer {
+					deps.server.Close()
+				}
+				if c.mangleSignature {
+					//nolint:staticcheck
+					//lint:ignore SA1019 // ignore staticcheck
+					client.afterSignCallback = func(req *types.WriteBitswapRecord) {
+						mh, err := multihash.Encode([]byte("boom"), multihash.SHA2_256)
+						require.NoError(t, err)
+						mb, err := multibase.Encode(multibase.Base64, mh)
+						require.NoError(t, err)
 
-			if c.manglePath {
-				client.baseURL += "/foo"
-			}
-			if c.stopServer {
-				deps.server.Close()
-			}
-			if c.mangleSignature {
+						req.Signature = mb
+					}
+				}
+
 				//nolint:staticcheck
 				//lint:ignore SA1019 // ignore staticcheck
-				client.afterSignCallback = func(req *types.WriteBitswapRecord) {
-					mh, err := multihash.Encode([]byte("boom"), multihash.SHA2_256)
-					require.NoError(t, err)
-					mb, err := multibase.Encode(multibase.Base64, mh)
-					require.NoError(t, err)
-
-					req.Signature = mb
+				expectedProvReq := &server.BitswapWriteProvideRequest{
+					Keys:        c.cids,
+					Timestamp:   time.Now().Truncate(time.Millisecond),
+					AdvisoryTTL: c.ttl,
+					Addrs:       drAddrsToAddrs(client.addrs),
+					ID:          client.peerID,
 				}
-			}
 
-			//nolint:staticcheck
-			//lint:ignore SA1019 // ignore staticcheck
-			expectedProvReq := &server.BitswapWriteProvideRequest{
-				Keys:        c.cids,
-				Timestamp:   clock.Now().Truncate(time.Millisecond),
-				AdvisoryTTL: c.ttl,
-				Addrs:       drAddrsToAddrs(client.addrs),
-				ID:          client.peerID,
-			}
+				router.On("ProvideBitswap", mock.Anything, expectedProvReq).
+					Return(c.routerAdvisoryTTL, c.routerErr)
 
-			router.On("ProvideBitswap", mock.Anything, expectedProvReq).
-				Return(c.routerAdvisoryTTL, c.routerErr)
+				advisoryTTL, err := client.ProvideBitswap(ctx, c.cids, c.ttl)
 
-			advisoryTTL, err := client.ProvideBitswap(ctx, c.cids, c.ttl)
+				var errorString string
+				if runtime.GOOS == "windows" && c.expWinErrContains != "" {
+					errorString = c.expWinErrContains
+				} else {
+					errorString = c.expErrContains
+				}
 
-			var errorString string
-			if runtime.GOOS == "windows" && c.expWinErrContains != "" {
-				errorString = c.expWinErrContains
-			} else {
-				errorString = c.expErrContains
-			}
+				if errorString != "" {
+					require.ErrorContains(t, err, errorString)
+				} else {
+					require.NoError(t, err)
+				}
 
-			if errorString != "" {
-				require.ErrorContains(t, err, errorString)
-			} else {
-				require.NoError(t, err)
-			}
-
-			assert.Equal(t, c.expAdvisoryTTL, advisoryTTL)
+				assert.Equal(t, c.expAdvisoryTTL, advisoryTTL)
+			})
 		})
 	}
 }


### PR DESCRIPTION
- Replace `go-clock` in `bitswap/client/internal/messagequeue`
- Replace `go-clock` in `bitswap/server`
- Replace `go-clock` in `routing/http/client`

blocked: waiting until go 1.25 is required
