### PR TITLE
fix(routing): fix unknown record bytes unmarshalling

### DIFF
--- a/routing/http/types/record_unknown.go
+++ b/routing/http/types/record_unknown.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"encoding/json"
 
 	"github.com/ipfs/boxo/routing/http/internal/drjson"
@@ -30,7 +31,7 @@ func (ur *UnknownRecord) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	ur.Schema = v.Schema
-	ur.Bytes = b
+	ur.Bytes = bytes.Clone(b)
 	return nil
 }
 


### PR DESCRIPTION
Might be too small to bother with a changelog (although fine to add one).

This change clones the bytes into the `Bytes` field so that in the event the caller hasn't themselves cloned the data before passing it to Unmarshal the struct won't covertly get modified after being initialized.