### PR TITLE
fix: raise block size limits from 1MiB to 2MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- 🛠 `chunker`, `ipld/unixfs/importer/helpers`: block size limits raised from 1MiB to 2MiB to match the [bitswap spec](https://specs.ipfs.tech/bitswap-protocol/#block-sizes). Max chunker size is `2MiB - 256 bytes` to leave room for protobuf framing when `--raw-leaves=false`. IPIP-499 profiles use lower chunk sizes (256KiB and 1MiB) and are not affected.
 - 🛠 `chunker`: `DefaultBlockSize` changed from `const` to `var` to allow runtime configuration via global profiles. [#1088](https://github.com/ipfs/boxo/pull/1088), [IPIP-499](https://github.com/ipfs/specs/pull/499)
 - `gateway`: 🛠 ✨ [IPIP-523](https://github.com/ipfs/specs/pull/523) `?format=` URL query parameter now takes precedence over `Accept` HTTP header, ensuring deterministic HTTP cache behavior and allowing browsers to use `?format=` even when they send `Accept` headers with specific content types. [#1074](https://github.com/ipfs/boxo/pull/1074)
 - `gateway`: 🛠 ✨ [IPIP-524](https://github.com/ipfs/specs/pull/524) codec conversions (e.g., dag-pb to dag-json, dag-json to dag-cbor) are no longer performed by default. Requesting a format that differs from the block's codec now returns HTTP 406 Not Acceptable with a hint to fetch raw blocks (`?format=raw`) and convert client-side. Set `Config.AllowCodecConversion` to `true` to restore the old behavior. [#1077](https://github.com/ipfs/boxo/pull/1077)

--- a/chunker/parse.go
+++ b/chunker/parse.go
@@ -15,10 +15,22 @@ import (
 var DefaultBlockSize int64 = 1024 * 256
 
 const (
-	// ChunkSizeLimit is the maximum allowed chunk size.
-	// No leaf block should contain more than 1MiB of payload data (wrapping overhead aside).
-	// See discussion at https://github.com/ipfs/go-ipfs-chunker/pull/21#discussion_r369124879
-	ChunkSizeLimit int = 1048576
+	// BlockSizeLimit is the maximum block size defined by the bitswap spec.
+	// https://specs.ipfs.tech/bitswap-protocol/#block-sizes
+	BlockSizeLimit int = 2 << 20 // 2MiB
+
+	// ChunkOverheadBudget is reserved for protobuf/UnixFS framing overhead
+	// when chunks are wrapped in non-raw leaves (--raw-leaves=false).
+	ChunkOverheadBudget int = 256
+
+	// ChunkSizeLimit is the maximum chunk size accepted by the chunker.
+	// It is set below BlockSizeLimit to leave room for framing overhead
+	// so that serialized blocks stay within the 2MiB wire limit.
+	//
+	// In practice this limit only matters for custom chunker sizes.
+	// The CID-deterministic profiles defined in IPIP-499 use max 1MiB
+	// chunks, well within this limit.
+	ChunkSizeLimit int = BlockSizeLimit - ChunkOverheadBudget
 )
 
 var (

--- a/chunker/parse.go
+++ b/chunker/parse.go
@@ -17,7 +17,7 @@ var DefaultBlockSize int64 = 1024 * 256
 const (
 	// BlockSizeLimit is the maximum block size defined by the bitswap spec.
 	// https://specs.ipfs.tech/bitswap-protocol/#block-sizes
-	BlockSizeLimit int = 2 << 20 // 2MiB
+	BlockSizeLimit int = 2 * 1024 * 1024 // 2MiB
 
 	// ChunkOverheadBudget is reserved for protobuf/UnixFS framing overhead
 	// when chunks are wrapped in non-raw leaves (--raw-leaves=false).

--- a/chunker/parse_test.go
+++ b/chunker/parse_test.go
@@ -10,6 +10,28 @@ const (
 	testTwoThirdsOfChunkLimit = 2 * (float32(ChunkSizeLimit) / float32(3))
 )
 
+func TestBlockSizeConstants(t *testing.T) {
+	t.Parallel()
+
+	if ChunkOverheadBudget <= 0 {
+		t.Fatal("ChunkOverheadBudget must be positive")
+	}
+	if ChunkSizeLimit <= 0 {
+		t.Fatal("ChunkSizeLimit must be positive")
+	}
+	if BlockSizeLimit <= 0 {
+		t.Fatal("BlockSizeLimit must be positive")
+	}
+	if ChunkSizeLimit+ChunkOverheadBudget != BlockSizeLimit {
+		t.Fatalf("ChunkSizeLimit (%d) + ChunkOverheadBudget (%d) != BlockSizeLimit (%d)",
+			ChunkSizeLimit, ChunkOverheadBudget, BlockSizeLimit)
+	}
+	if ChunkSizeLimit >= BlockSizeLimit {
+		t.Fatalf("ChunkSizeLimit (%d) must be less than BlockSizeLimit (%d)",
+			ChunkSizeLimit, BlockSizeLimit)
+	}
+}
+
 func TestParseRabin(t *testing.T) {
 	t.Parallel()
 

--- a/ipld/unixfs/importer/helpers/helpers.go
+++ b/ipld/unixfs/importer/helpers/helpers.go
@@ -2,10 +2,14 @@ package helpers
 
 import (
 	"errors"
+
+	chunker "github.com/ipfs/boxo/chunker"
 )
 
 // BlockSizeLimit specifies the maximum size an imported block can have.
-var BlockSizeLimit = 1048576 // 1 MB
+// Defaults to chunker.BlockSizeLimit (2MiB), the bitswap spec maximum.
+// https://specs.ipfs.tech/bitswap-protocol/#block-sizes
+var BlockSizeLimit = chunker.BlockSizeLimit
 
 // rough estimates on expected sizes
 var (


### PR DESCRIPTION
align chunker and importer block size limits with the bitswap spec (https://specs.ipfs.tech/bitswap-protocol/#block-sizes) which mandates 2MiB as the maximum block size.

the previous 1MiB limit broke things like Kubo's `dag import` of 1MiB-chunked non-raw-leaf data where protobuf wrapping pushes blocks slightly over 1MiB (see https://github.com/ipfs/kubo/pull/8968#issuecomment-3860668059)

max chunker size is set to 2MiB - 256 bytes to leave room for protobuf framing overhead when chunks are wrapped in non-raw leaves. IPIP-499 profiles use lower chunk sizes (256KiB and 1MiB) and are not affected.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


- Used in https://github.com/ipfs/kubo/pull/11185