### PR TITLE
ensure http response body is closed

### DIFF
--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -624,7 +624,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	// FIXME: Storacha returns 410 for our probe.
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusGone {
 		log.Debugf("connect/ping request to %s %s succeeded: %d", p, req.URL, resp.StatusCode)
-		defer io.Copy(io.Discard, resp.Body) // read all body data so that connection can be reused
+		io.Copy(io.Discard, resp.Body) // read all body data so that connection can be reused
 		return resp.StatusCode, nil
 	}
 

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -624,7 +624,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	// FIXME: Storacha returns 410 for our probe.
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusGone {
 		log.Debugf("connect/ping request to %s %s succeeded: %d", p, req.URL, resp.StatusCode)
-		defer io.Copy(ioutil.Discard, resp.Body) // read all body data so that connection can be reused
+		defer io.Copy(io.Discard, resp.Body) // read all body data so that connection can be reused
 		return resp.StatusCode, nil
 	}
 

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -624,6 +624,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	// FIXME: Storacha returns 410 for our probe.
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusGone {
 		log.Debugf("connect/ping request to %s %s succeeded: %d", p, req.URL, resp.StatusCode)
+		defer io.Copy(ioutil.Discard, resp.Body) // read all body data so that connection can be reused
 		return resp.StatusCode, nil
 	}
 

--- a/gateway/backend_car_fetcher.go
+++ b/gateway/backend_car_fetcher.go
@@ -64,6 +64,8 @@ func (ps *remoteCarFetcher) Fetch(ctx context.Context, path path.ImmutablePath, 
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+	defer io.Copy(ioutil.Discard, resp.Body) // read all body data so that connection can be reused
 
 	if resp.StatusCode != http.StatusOK {
 		errData, err := io.ReadAll(resp.Body)
@@ -75,12 +77,7 @@ func (ps *remoteCarFetcher) Fetch(ctx context.Context, path path.ImmutablePath, 
 		return fmt.Errorf("http error from car gateway: %s: %w", resp.Status, err)
 	}
 
-	err = cb(path, resp.Body)
-	if err != nil {
-		resp.Body.Close()
-		return err
-	}
-	return resp.Body.Close()
+	return cb(path, resp.Body)
 }
 
 func (ps *remoteCarFetcher) getRandomGatewayURL() string {

--- a/gateway/backend_car_fetcher.go
+++ b/gateway/backend_car_fetcher.go
@@ -65,7 +65,7 @@ func (ps *remoteCarFetcher) Fetch(ctx context.Context, path path.ImmutablePath, 
 		return err
 	}
 	defer resp.Body.Close()
-	defer io.Copy(ioutil.Discard, resp.Body) // read all body data so that connection can be reused
+	defer io.Copy(io.Discard, resp.Body) // read all body data so that connection can be reused
 
 	if resp.StatusCode != http.StatusOK {
 		errData, err := io.ReadAll(resp.Body)

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -667,6 +667,7 @@ func (c *Client) GetClosestPeers(ctx context.Context, key cid.Cid) (peers iter.R
 	var skipBodyClose bool
 	defer func() {
 		if !skipBodyClose {
+			io.Copy(io.Discard, resp.Body) // Drain body for connection reuse
 			resp.Body.Close()
 		}
 	}()


### PR DESCRIPTION
When appropriate, consume all body data before close to allow connection reuse.
