### PR TITLE
refactor: modernize code

### DIFF
--- a/.github/workflows/gateway-sharness.yml
+++ b/.github/workflows/gateway-sharness.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.26.x
       - name: Checkout boxo
         uses: actions/checkout@v3
         with:

--- a/bitswap/benchmarks_test.go
+++ b/bitswap/benchmarks_test.go
@@ -161,7 +161,7 @@ func BenchmarkFetchFromOldBitswap(b *testing.B) {
 				instances = append(instances, inst)
 			}
 			// Create old nodes (just seeds)
-			for i := 0; i < oldSeedCount; i++ {
+			for range oldSeedCount {
 				inst := oldNodeGenerator.Next()
 				instances = append(instances, inst)
 			}
@@ -631,7 +631,7 @@ func unixfsFileFetchLarge(b *testing.B, bs *bitswap.Bitswap, ks []cid.Cid) {
 func printResults(rs []runStats) {
 	nameOrder := make([]string, 0)
 	names := make(map[string]struct{})
-	for i := 0; i < len(rs); i++ {
+	for i := range rs {
 		if _, ok := names[rs[i].Name]; !ok {
 			nameOrder = append(nameOrder, rs[i].Name)
 			names[rs[i].Name] = struct{}{}
@@ -646,7 +646,7 @@ func printResults(rs []runStats) {
 		dups := 0.0
 		blks := 0.0
 		elpd := 0.0
-		for i := 0; i < len(rs); i++ {
+		for i := range rs {
 			if rs[i].Name == name {
 				count++
 				sent += float64(rs[i].MsgSent)

--- a/bitswap/bitswap_test.go
+++ b/bitswap/bitswap_test.go
@@ -521,8 +521,7 @@ func TestDoubleGet(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx2, cancel2 := context.WithCancel(context.Background())
-	defer cancel2()
+	ctx2 := t.Context()
 
 	blkch2, err := instances[1].Exchange.GetBlocks(ctx2, []cid.Cid{blocks[0].Cid()})
 	if err != nil {

--- a/bitswap/client/bitswap_with_sessions_test.go
+++ b/bitswap/client/bitswap_with_sessions_test.go
@@ -48,8 +48,7 @@ func addBlock(t *testing.T, ctx context.Context, inst testinstance.Instance, blk
 }
 
 func TestBasicSessions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	vnet := getVirtualNetwork()
 	router := mockrouting.NewServer()
@@ -133,8 +132,7 @@ func TestCustomProviderQueryManager(t *testing.T) {
 	}
 	defer pqm.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	bs := bitswap.New(ctx, a.Adapter, pqm, a.Blockstore,
 		bitswap.WithClientOption(client.WithDefaultProviderQueryManager(false)),
@@ -173,8 +171,7 @@ func TestCustomProviderQueryManager(t *testing.T) {
 }
 
 func TestSessionBetweenPeers(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	vnet := tn.VirtualNetwork(delay.Fixed(time.Millisecond))
 	router := mockrouting.NewServer()
@@ -212,7 +209,7 @@ func TestSessionBetweenPeers(t *testing.T) {
 	cids = cids[1:]
 
 	// Fetch blocks with the session, 10 at a time
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ch, err := ses.GetBlocks(ctx, cids[i*10:(i+1)*10])
 		if err != nil {
 			t.Fatal(err)
@@ -242,8 +239,7 @@ func TestSessionBetweenPeers(t *testing.T) {
 }
 
 func TestSessionSplitFetch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	vnet := getVirtualNetwork()
 	router := mockrouting.NewServer()
@@ -254,7 +250,7 @@ func TestSessionSplitFetch(t *testing.T) {
 
 	// Add 10 distinct blocks to each of 10 peers
 	blks := random.BlocksOfSize(100, blockSize)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		if err := inst[i].Blockstore.PutMany(ctx, blks[i*10:(i+1)*10]); err != nil {
 			t.Fatal(err)
 		}
@@ -269,7 +265,7 @@ func TestSessionSplitFetch(t *testing.T) {
 	ses := inst[10].Exchange.NewSession(ctx).(*session.Session)
 	ses.SetBaseTickDelay(time.Millisecond * 10)
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		ch, err := ses.GetBlocks(ctx, cids[i*10:(i+1)*10])
 		if err != nil {
 			t.Fatal(err)
@@ -371,7 +367,7 @@ func TestFetchAfterDisconnect(t *testing.T) {
 
 	// Should get first 5 blocks
 	var got []blocks.Block
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		b := <-ch
 		got = append(got, b)
 	}
@@ -397,7 +393,7 @@ func TestFetchAfterDisconnect(t *testing.T) {
 	// Peer B should call FindProviders() and find Peer A
 
 	// Should get last 5 blocks
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		select {
 		case b := <-ch:
 			got = append(got, b)
@@ -411,8 +407,7 @@ func TestFetchAfterDisconnect(t *testing.T) {
 }
 
 func TestInterestCacheOverflow(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	vnet := getVirtualNetwork()
 	router := mockrouting.NewServer()
@@ -461,8 +456,7 @@ func TestInterestCacheOverflow(t *testing.T) {
 }
 
 func TestPutAfterSessionCacheEvict(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	vnet := getVirtualNetwork()
 	router := mockrouting.NewServer()
@@ -499,8 +493,7 @@ func TestPutAfterSessionCacheEvict(t *testing.T) {
 }
 
 func TestMultipleSessions(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	vnet := getVirtualNetwork()
 	router := mockrouting.NewServer()
@@ -597,8 +590,7 @@ func TestDontHaveTimeoutConfig(t *testing.T) {
 	}
 	defer pqm.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	bs := bitswap.New(ctx, a.Adapter, pqm, a.Blockstore,
 		bitswap.WithClientOption(client.WithDontHaveTimeoutConfig(cfg)))

--- a/bitswap/client/internal/messagequeue/messagequeue_test.go
+++ b/bitswap/client/internal/messagequeue/messagequeue_test.go
@@ -857,7 +857,7 @@ func BenchmarkMessageQueue(b *testing.B) {
 
 	// Create a handful of message queues to start with
 	var qs []*MessageQueue
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		qs = append(qs, createQueue())
 	}
 

--- a/bitswap/client/internal/peermanager/peermanager_test.go
+++ b/bitswap/client/internal/peermanager/peermanager_test.go
@@ -354,7 +354,7 @@ func BenchmarkPeerManager(b *testing.B) {
 
 	// Create a bunch of connections
 	connected := 0
-	for i := 0; i < len(peers); i++ {
+	for i := range peers {
 		peerManager.Connected(peers[i])
 		connected++
 	}

--- a/bitswap/client/internal/session/cidqueue.go
+++ b/bitswap/client/internal/session/cidqueue.go
@@ -50,7 +50,7 @@ func (cq *cidQueue) len() int {
 func (cq *cidQueue) gc() {
 	if cq.elems.Len() > cq.eset.Len() {
 		n := cq.elems.Len()
-		for i := 0; i < n; i++ {
+		for range n {
 			c := cq.elems.PopFront()
 			if cq.eset.Has(c) {
 				cq.elems.PushBack(c)

--- a/bitswap/client/internal/session/peerresponsetracker_test.go
+++ b/bitswap/client/internal/session/peerresponsetracker_test.go
@@ -30,7 +30,7 @@ func TestPeerResponseTrackerProbabilityUnknownPeers(t *testing.T) {
 
 	choices := []int{0, 0, 0, 0}
 	count := 1000
-	for i := 0; i < count; i++ {
+	for range count {
 		p := prt.choose(peers)
 		if p == peers[0] {
 			choices[0]++
@@ -61,7 +61,7 @@ func TestPeerResponseTrackerProbabilityOneKnownOneUnknownPeer(t *testing.T) {
 
 	chooseFirst := 0
 	chooseSecond := 0
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		p := prt.choose(peers)
 		if p == peers[0] {
 			chooseFirst++
@@ -95,7 +95,7 @@ func TestPeerResponseTrackerProbabilityProportional(t *testing.T) {
 		choices = append(choices, 0)
 	}
 
-	for i := 0; i < count; i++ {
+	for range count {
 		p := prt.choose(peers)
 		if p == peers[0] {
 			choices[0]++

--- a/bitswap/client/internal/session/sessionwants_test.go
+++ b/bitswap/client/internal/session/sessionwants_test.go
@@ -125,7 +125,7 @@ func TestPrepareBroadcast(t *testing.T) {
 	sw.GetNextWants()
 
 	// Broadcast should contain wants in order
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ws := sw.PrepareBroadcast()
 		if len(ws) != 3 {
 			t.Fatal("should broadcast all live wants")
@@ -155,7 +155,7 @@ func TestPrepareBroadcast(t *testing.T) {
 
 	// Broadcast should contain wants in order
 	cids = cids[1:]
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ws := sw.PrepareBroadcast()
 		if len(ws) != 3 {
 			t.Fatal("should broadcast live wants up to limit", len(ws), len(cids))

--- a/bitswap/client/internal/session/sessionwantsender_test.go
+++ b/bitswap/client/internal/session/sessionwantsender_test.go
@@ -1,6 +1,7 @@
 package session
 
 import (
+	"maps"
 	"sync"
 	"testing"
 	"time"
@@ -102,9 +103,7 @@ func (pm *mockPeerManager) waitNextWants() map[peer.ID]*sentWants {
 	defer pm.lk.Unlock()
 
 	nw := make(map[peer.ID]*sentWants, len(pm.peerSends))
-	for p, sentWants := range pm.peerSends {
-		nw[p] = sentWants
-	}
+	maps.Copy(nw, pm.peerSends)
 	return nw
 }
 

--- a/bitswap/client/internal/sessionmanager/sessionmanager_test.go
+++ b/bitswap/client/internal/sessionmanager/sessionmanager_test.go
@@ -113,8 +113,7 @@ func peerManagerFactory(id uint64) bssession.SessionPeerManager {
 }
 
 func TestReceiveFrom(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	notif := notifications.New(false)
 	defer notif.Shutdown()
 	sim := bssim.New()
@@ -160,8 +159,7 @@ func TestReceiveFrom(t *testing.T) {
 }
 
 func TestReceiveBlocksWhenManagerShutdown(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	notif := notifications.New(false)
 	defer notif.Shutdown()
 	sim := bssim.New()
@@ -197,8 +195,7 @@ func TestReceiveBlocksWhenManagerShutdown(t *testing.T) {
 }
 
 func TestReceiveBlocksWhenSessionContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	notif := notifications.New(false)
 	defer notif.Shutdown()
 	sim := bssim.New()
@@ -234,8 +231,7 @@ func TestReceiveBlocksWhenSessionContextCancelled(t *testing.T) {
 }
 
 func TestShutdown(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	notif := notifications.New(false)
 	defer notif.Shutdown()
 	sim := bssim.New()

--- a/bitswap/network/bsnet/ipfs_impl_test.go
+++ b/bitswap/network/bsnet/ipfs_impl_test.go
@@ -556,7 +556,7 @@ func testNetworkCounters(t *testing.T, n1 int, n2 int) {
 
 	h1, bsnet1, h2, bsnet2, msg := prepareNetwork(t, ctx, p1, r1, p2, r2)
 
-	for n := 0; n < n1; n++ {
+	for range n1 {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		err := bsnet1.SendMessage(ctx, p2.ID(), msg)
 		if err != nil {
@@ -566,7 +566,7 @@ func testNetworkCounters(t *testing.T, n1 int, n2 int) {
 		case <-ctx.Done():
 			t.Fatal("p2 did not receive message sent")
 		case <-r2.messageReceived:
-			for j := 0; j < 2; j++ {
+			for range 2 {
 				err := bsnet2.SendMessage(ctx, p1.ID(), msg)
 				if err != nil {
 					t.Fatal(err)
@@ -587,7 +587,7 @@ func testNetworkCounters(t *testing.T, n1 int, n2 int) {
 			t.Fatal(err)
 		}
 		defer ms.Reset()
-		for n := 0; n < n2; n++ {
+		for range n2 {
 			ctx, cancel := context.WithTimeout(ctx, time.Second)
 			err = ms.SendMsg(ctx, msg)
 			if err != nil {
@@ -597,7 +597,7 @@ func testNetworkCounters(t *testing.T, n1 int, n2 int) {
 			case <-ctx.Done():
 				t.Fatal("p2 did not receive message sent")
 			case <-r2.messageReceived:
-				for j := 0; j < 2; j++ {
+				for range 2 {
 					err := bsnet2.SendMessage(ctx, p1.ID(), msg)
 					if err != nil {
 						t.Fatal(err)
@@ -708,7 +708,7 @@ func testNetworkCounters(t *testing.T, n1 int, n2 int) {
 }
 
 func TestNetworkCounters(t *testing.T) {
-	for n := 0; n < 11; n++ {
+	for n := range 11 {
 		testNetworkCounters(t, 10-n, n)
 	}
 }

--- a/bitswap/network/httpnet/error_tracker_test.go
+++ b/bitswap/network/httpnet/error_tracker_test.go
@@ -73,14 +73,12 @@ func TestErrorTracker_ConcurrentAccess(t *testing.T) {
 	numRoutines := 10
 	threshold := 100
 
-	for i := 0; i < numRoutines; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range numRoutines {
+		wg.Go(func() {
 			for j := 0; j < threshold/numRoutines; j++ {
 				et.logErrors(p, 1, threshold)
 			}
-		}()
+		})
 	}
 
 	wg.Wait()

--- a/bitswap/network/httpnet/httpnet_test.go
+++ b/bitswap/network/httpnet/httpnet_test.go
@@ -144,7 +144,7 @@ func makeBlocks(t *testing.T, start, end int) []blocks.Block {
 
 	var blks []blocks.Block
 	for i := start; i < end; i++ {
-		blks = append(blks, blocks.NewBlock([]byte(fmt.Sprintf("%d", i))))
+		blks = append(blks, blocks.NewBlock(fmt.Appendf(nil, "%d", i)))
 	}
 	return blks
 }
@@ -334,7 +334,7 @@ func TestBestURL(t *testing.T) {
 		t.Fatal(err)
 	}
 	var urls []*url.URL
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		baseurl.Host = fmt.Sprintf("127.0.0.1:%d", 1000+i)
 		u, _ := url.Parse(baseurl.String())
 		urls = append(urls, u)

--- a/bitswap/network/httpnet/pinger.go
+++ b/bitswap/network/httpnet/pinger.go
@@ -66,7 +66,7 @@ func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 
 	var result ping.Result
 	var errs []error
-	for i := 0; i < len(urls); i++ {
+	for range urls {
 		r := <-results
 		if r.Error != nil {
 			errs = append(errs, r.Error)

--- a/bitswap/server/internal/decision/blockstoremanager_test.go
+++ b/bitswap/server/internal/decision/blockstoremanager_test.go
@@ -80,7 +80,7 @@ func TestBlockstoreManager(t *testing.T) {
 
 	exp := make(map[cid.Cid]blocks.Block)
 	var blks []blocks.Block
-	for i := 0; i < 32; i++ {
+	for i := range 32 {
 		buf := make([]byte, 1024*(i+1))
 		_, _ = rand.Read(buf)
 		b := blocks.NewBlock(buf)
@@ -168,7 +168,7 @@ func TestBlockstoreManagerConcurrency(t *testing.T) {
 
 	// Create more concurrent requests than the number of workers
 	wg := sync.WaitGroup{}
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		wg.Add(1)
 
 		go func(t *testing.T) {

--- a/bitswap/testinstance/testinstance.go
+++ b/bitswap/testinstance/testinstance.go
@@ -66,7 +66,7 @@ func (g *InstanceGenerator) Next() Instance {
 // them to each other
 func (g *InstanceGenerator) Instances(n int) []Instance {
 	var instances []Instance
-	for j := 0; j < n; j++ {
+	for range n {
 		inst := g.Next()
 		instances = append(instances, inst)
 	}

--- a/bitswap/testnet/internet_latency_delay_generator_test.go
+++ b/bitswap/testnet/internet_latency_delay_generator_test.go
@@ -32,7 +32,7 @@ func TestInternetLatencyDelayNextWaitTimeDistribution(t *testing.T) {
 
 	// strategy here is rather than mock randomness, just use enough samples to
 	// get approximately the distribution you'd expect
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		next := internetLatencyDistributionDelay.NextWaitTime(initialValue)
 		if math.Abs((next - initialValue).Seconds()) <= deviation.Seconds() {
 			buckets["fast"]++

--- a/blockservice/blockservice_test.go
+++ b/blockservice/blockservice_test.go
@@ -350,8 +350,7 @@ func TestContextSession(t *testing.T) {
 	t.Parallel()
 	a := assert.New(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	blks := random.BlocksOfSize(2, blockSize)
 	block1 := blks[0]

--- a/blockservice/test/blocks_test.go
+++ b/blockservice/test/blocks_test.go
@@ -57,8 +57,8 @@ func TestBlocks(t *testing.T) {
 
 func makeObjects(n int) []blocks.Block {
 	var out []blocks.Block
-	for i := 0; i < n; i++ {
-		out = append(out, newObject([]byte(fmt.Sprintf("object %d", i))))
+	for i := range n {
+		out = append(out, newObject(fmt.Appendf(nil, "object %d", i)))
 	}
 	return out
 }

--- a/blockstore/blockstore_test.go
+++ b/blockstore/blockstore_test.go
@@ -170,8 +170,8 @@ func newBlockStoreWithKeys(t *testing.T, d ds.Datastore, N int) (Blockstore, []c
 	bs := NewBlockstore(ds_sync.MutexWrap(d))
 
 	keys := make([]cid.Cid, N)
-	for i := 0; i < N; i++ {
-		block := blocks.NewBlock([]byte(fmt.Sprintf("some data %d", i)))
+	for i := range N {
+		block := blocks.NewBlock(fmt.Appendf(nil, "some data %d", i))
 		err := bs.Put(bg, block)
 		if err != nil {
 			t.Fatal(err)

--- a/blockstore/bloom_cache_test.go
+++ b/blockstore/bloom_cache_test.go
@@ -98,8 +98,8 @@ func TestHasIsBloomCached(t *testing.T) {
 	cd := &callbackDatastore{f: func() {}, ds: ds.NewMapDatastore()}
 	bs := NewBlockstore(syncds.MutexWrap(cd))
 
-	for i := 0; i < 1000; i++ {
-		bs.Put(bg, blocks.NewBlock([]byte(fmt.Sprintf("data: %d", i))))
+	for i := range 1000 {
+		bs.Put(bg, blocks.NewBlock(fmt.Appendf(nil, "data: %d", i)))
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
@@ -118,8 +118,8 @@ func TestHasIsBloomCached(t *testing.T) {
 		cacheFails++
 	})
 
-	for i := 0; i < 1000; i++ {
-		cachedbs.Has(bg, blocks.NewBlock([]byte(fmt.Sprintf("data: %d", i+2000))).Cid())
+	for i := range 1000 {
+		cachedbs.Has(bg, blocks.NewBlock(fmt.Appendf(nil, "data: %d", i+2000)).Cid())
 	}
 
 	if float64(cacheFails)/float64(1000) > float64(0.05) {

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -17,7 +17,7 @@ import (
 func TestRandomizeAddressList(t *testing.T) {
 	var ps []peer.AddrInfo
 	sizeofSlice := 10
-	for i := 0; i < sizeofSlice; i++ {
+	for range sizeofSlice {
 		pid, err := test.RandPeerID()
 		if err != nil {
 			t.Fatal(err)

--- a/chunker/benchmark_test.go
+++ b/chunker/benchmark_test.go
@@ -75,7 +75,7 @@ func benchmarkFilesAlloc(b *testing.B, ns newSplitter) {
 	var res uint64
 
 	for i := 0; i < b.N; i++ {
-		for j := 0; j < fileCount; j++ {
+		for range fileCount {
 			fileSize := rng.Intn(maxDataSize-minDataSize) + minDataSize
 			r := ns(bytes.NewReader(data[:fileSize]))
 			for {

--- a/chunker/buzhash_test.go
+++ b/chunker/buzhash_test.go
@@ -78,7 +78,7 @@ func BenchmarkBuzhash2(b *testing.B) {
 func TestBuzhashBitsHashBias(t *testing.T) {
 	counts := make([]byte, 32)
 	for _, h := range bytehash {
-		for i := 0; i < 32; i++ {
+		for i := range 32 {
 			if h&1 == 1 {
 				counts[i]++
 			}

--- a/chunker/gen/main.go
+++ b/chunker/gen/main.go
@@ -12,12 +12,12 @@ func main() {
 	rnd := rand.New(rand.NewSource(0))
 
 	lut := make([]uint32, 256)
-	for i := 0; i < 256/2; i++ {
+	for i := range 256 / 2 {
 		lut[i] = 1<<32 - 1
 	}
 
-	for r := 0; r < nRounds; r++ {
-		for b := uint32(0); b < 32; b++ {
+	for range nRounds {
+		for b := range uint32(32) {
 			mask := uint32(1) << b
 			nmask := ^mask
 			for i, j := range rnd.Perm(256) {

--- a/chunker/splitting_test.go
+++ b/chunker/splitting_test.go
@@ -70,7 +70,7 @@ func TestSizeSplitterIsDeterministic(t *testing.T) {
 		}
 	}
 
-	for run := 0; run < 1; run++ { // crank this up to satisfy yourself.
+	for range 1 { // crank this up to satisfy yourself.
 		test()
 	}
 }

--- a/examples/bitswap-transfer/main_test.go
+++ b/examples/bitswap-transfer/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -10,8 +9,7 @@ import (
 )
 
 func TestBitswapFetch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	server, err := makeHost(0, 0)
 	if err != nil {
 		t.Fatal(err)

--- a/examples/gateway/proxy-blocks/main_test.go
+++ b/examples/gateway/proxy-blocks/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -83,8 +82,7 @@ func TestTraceContext(t *testing.T) {
 		traceFlags    = "00"
 	)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	tp, err := common.SetupTracing(ctx, "Proxy Test")
 	assert.NoError(t, err)

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/boxo/examples
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/ipfs/boxo v0.35.2

--- a/files/multipartfile.go
+++ b/files/multipartfile.go
@@ -216,12 +216,12 @@ func fileInfo(name string, part *multipart.Part) os.FileInfo {
 	fi := multiPartFileInfo{name: filepath.Base(name)}
 	formName := part.FormName()
 
-	i := strings.IndexByte(formName, '?')
-	if i == -1 {
+	_, after, ok := strings.Cut(formName, "?")
+	if !ok {
 		return &fi
 	}
 
-	params, err := url.ParseQuery(formName[i+1:])
+	params, err := url.ParseQuery(after)
 	if err != nil {
 		return nil
 	}
@@ -277,8 +277,8 @@ func (it *multipartIterator) Next() bool {
 
 		// Check if we need to create a fake directory (more than one
 		// path component).
-		if idx := strings.IndexByte(name, '/'); idx >= 0 {
-			it.curName = name[:idx]
+		if before, _, ok := strings.Cut(name, "/"); ok {
+			it.curName = before
 			it.curFile = &multipartDirectory{
 				path:   path.Join(it.f.path, it.curName),
 				walker: it.f.walker,

--- a/filestore/filestore_test.go
+++ b/filestore/filestore_test.go
@@ -66,7 +66,7 @@ func TestBasicFilestore(t *testing.T) {
 			fname := makeFile(t, dir, buf)
 
 			var cids []cid.Cid
-			for i := 0; i < 100; i++ {
+			for i := range 100 {
 				n := &posinfo.FilestoreNode{
 					PosInfo: &posinfo.PosInfo{
 						FullPath: fname,

--- a/gateway/assets/templates.go
+++ b/gateway/assets/templates.go
@@ -25,7 +25,7 @@ func iconFromExt(filename string) string {
 }
 
 // args is a helper function to allow sending more than one object to a template.
-func args(args ...interface{}) []any {
+func args(args ...any) []any {
 	return args
 }
 

--- a/gateway/assets/test/main.go
+++ b/gateway/assets/test/main.go
@@ -158,7 +158,7 @@ func runTemplate(w http.ResponseWriter, filename string, data any) {
 	}
 	err = tpl.Execute(w, data)
 	if err != nil {
-		_, _ = w.Write([]byte(fmt.Sprintf("error during body generation: %v", err)))
+		_, _ = w.Write(fmt.Appendf(nil, "error during body generation: %v", err))
 	}
 }
 

--- a/gateway/backend_car_test.go
+++ b/gateway/backend_car_test.go
@@ -33,8 +33,7 @@ import (
 var dirWithMultiblockHAMTandFiles []byte
 
 func TestCarBackendTar(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Map of expected requests to their response blocks
 	// This allows requests to arrive in any order, fixing race conditions
@@ -208,8 +207,7 @@ func TestCarBackendTar(t *testing.T) {
 }
 
 func TestCarBackendTarAtEndOfPath(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	requestNum := 0
 	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -397,8 +395,7 @@ func sendBlocks(ctx context.Context, carFixture []byte, writer io.Writer, cidStr
 }
 
 func TestCarBackendGetFile(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	requestNum := 0
 	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -505,8 +502,7 @@ func TestCarBackendGetFile(t *testing.T) {
 }
 
 func TestCarBackendGetFileRangeRequest(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	requestNum := 0
 	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -617,8 +613,7 @@ func TestCarBackendGetFileRangeRequest(t *testing.T) {
 }
 
 func TestCarBackendGetFileWithBadBlockReturned(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	requestNum := 0
 	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -719,8 +714,7 @@ func TestCarBackendGetFileWithBadBlockReturned(t *testing.T) {
 }
 
 func TestCarBackendGetHAMTDirectory(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	requestNum := 0
 	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -819,8 +813,7 @@ func TestCarBackendGetHAMTDirectory(t *testing.T) {
 }
 
 func TestCarBackendGetCAR(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	requestNum := 0
 	s := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
@@ -942,7 +935,7 @@ func TestCarBackendGetCAR(t *testing.T) {
 		"bafkreidqhbqn5htm5qejxpb3hps7dookudo3nncfn6al6niqibi5lq6fee", // exampleC
 	}
 
-	for i := 0; i < len(responseCarBlock); i++ {
+	for i := range responseCarBlock {
 		expectedCid := cid.MustParse(responseCarBlock[i])
 		blk, err := blkReader.Next()
 		require.NoError(t, err)

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -26,8 +26,7 @@ import (
 func TestGatewayGet(t *testing.T) {
 	ts, backend, root := newTestServerAndNode(t, "fixtures.car")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	p, err := path.Join(path.FromCid(root), "subdir", "fnord")
 	require.NoError(t, err)
@@ -1551,8 +1550,7 @@ func TestMaxRangeRequestFileSize(t *testing.T) {
 	p, err := path.Join(path.FromCid(root), "subdir", "fnord")
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	k, err := backend.resolvePathNoRootsReturned(ctx, p)
 	require.NoError(t, err)

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime"
 	"net/http"
 	"net/textproto"
@@ -697,7 +698,7 @@ func customResponseFormat(r *http.Request) (mediaType string, params map[string]
 	var acceptMediaType string
 	var acceptParams map[string]string
 	for _, header := range r.Header.Values("Accept") {
-		for _, value := range strings.Split(header, ",") {
+		for value := range strings.SplitSeq(header, ",") {
 			accept := strings.TrimSpace(value)
 			// respond to the very first matching content type
 			if strings.HasPrefix(accept, "application/vnd.ipld") ||
@@ -765,9 +766,7 @@ func addContentLocation(r *http.Request, w http.ResponseWriter, rq *requestData)
 
 	// Copy all existing query parameters.
 	query := url.Values{}
-	for k, v := range r.URL.Query() {
-		query[k] = v
-	}
+	maps.Copy(query, r.URL.Query())
 	query.Set("format", format)
 
 	// Set response params as query elements, but only if URL doesn't already

--- a/gateway/handler_codec_test.go
+++ b/gateway/handler_codec_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"html"
 	"io"
 	"net/http"
@@ -27,8 +26,7 @@ func TestDagJsonCborPreview(t *testing.T) {
 		DeserializedResponses: true,
 	})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	p, err := path.Join(path.FromCid(root), "subdir", "dag-cbor-document")
 	require.NoError(t, err)

--- a/gateway/handler_defaults.go
+++ b/gateway/handler_defaults.go
@@ -173,7 +173,7 @@ func parseRangeWithoutLength(s string) ([]ByteRange, error) {
 		return nil, errors.New("invalid range")
 	}
 	var ranges []ByteRange
-	for _, ra := range strings.Split(s[len(b):], ",") {
+	for ra := range strings.SplitSeq(s[len(b):], ",") {
 		ra = textproto.TrimString(ra)
 		if ra == "" {
 			continue

--- a/gateway/handler_unixfs_dir_test.go
+++ b/gateway/handler_unixfs_dir_test.go
@@ -1,7 +1,6 @@
 package gateway
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -14,8 +13,7 @@ func TestIPNSHostnameBacklinks(t *testing.T) {
 	// Test if directory listing on DNSLink Websites have correct backlinks.
 	ts, backend, root := newTestServerAndNode(t, "dir-special-chars.car")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// create /ipns/example.net/foo/
 	p2, err := path.Join(path.FromCid(root), "foo? #<'")

--- a/gateway/headers.go
+++ b/gateway/headers.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"maps"
 	"net/http"
 	"slices"
 )
@@ -85,9 +86,7 @@ func (h *Headers) ApplyCors() *Headers {
 // Wrap wraps the given [http.Handler] with the headers middleware.
 func (h *Headers) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for k, v := range h.headers {
-			w.Header()[k] = v
-		}
+		maps.Copy(w.Header(), h.headers)
 
 		next.ServeHTTP(w, r)
 	})

--- a/gateway/serve_http_content.go
+++ b/gateway/serve_http_content.go
@@ -388,7 +388,7 @@ func parseRange(s string, size int64) ([]httpRange, error) {
 	}
 	var ranges []httpRange
 	noOverlap := false
-	for _, ra := range strings.Split(s[len(b):], ",") {
+	for ra := range strings.SplitSeq(s[len(b):], ",") {
 		ra = textproto.TrimString(ra)
 		if ra == "" {
 			continue

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ipfs/boxo
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b

--- a/ipld/merkledag/coding.go
+++ b/ipld/merkledag/coding.go
@@ -47,7 +47,7 @@ func fromImmutableNode(encoded *immutableProtoNode) *ProtoNode {
 	// as-serialized state
 	n.links = make([]*format.Link, numLinks)
 	linkAllocs := make([]format.Link, numLinks)
-	for i := int64(0); i < numLinks; i++ {
+	for i := range numLinks {
 		next := n.encoded.Links.Lookup(i)
 		name := ""
 		if next.FieldName().Exists() {

--- a/ipld/merkledag/coding_test.go
+++ b/ipld/merkledag/coding_test.go
@@ -19,7 +19,7 @@ func init() {
 
 	node := &merkledag.ProtoNode{}
 	node.SetData(someData)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		node.AddRawLink(strconv.Itoa(i), &ipld.Link{
 			Size: 10,
 			Cid:  someCid,

--- a/ipld/merkledag/dagutils/diffenum_test.go
+++ b/ipld/merkledag/dagutils/diffenum_test.go
@@ -128,8 +128,7 @@ func TestNameMatching2(t *testing.T) {
 }
 
 func TestDiffEnumBasic(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nds := mkGraph(tg1)
 
 	ds := mdtest.Mock()
@@ -196,8 +195,7 @@ func assertCidList(a, b []cid.Cid) error {
 }
 
 func TestDiffEnumFail(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nds := mkGraph(tg2)
 
 	ds := mdtest.Mock()
@@ -222,8 +220,7 @@ func TestDiffEnumFail(t *testing.T) {
 }
 
 func TestDiffEnumRecurse(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nds := mkGraph(tg3)
 
 	ds := mdtest.Mock()

--- a/ipld/merkledag/dagutils/utils_test.go
+++ b/ipld/merkledag/dagutils/utils_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAddLink(t *testing.T) {
-	ctx, context := context.WithCancel(context.Background())
-	defer context()
+	ctx := t.Context()
 
 	ds := mdtest.Mock()
 	fishnode := dag.NodeWithData([]byte("fishcakes!"))

--- a/ipld/merkledag/merkledag.go
+++ b/ipld/merkledag/merkledag.go
@@ -533,9 +533,7 @@ func parallelWalkDepth(ctx context.Context, getLinks GetLinks, root cid.Cid, vis
 	defer wg.Wait()
 	defer cancel()
 	for range options.Concurrency {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for cdepth := range feed {
 				ci := cdepth.cid
 				depth := cdepth.depth
@@ -587,7 +585,7 @@ func parallelWalkDepth(ctx context.Context, getLinks GetLinks, root cid.Cid, vis
 				case <-fetchersCtx.Done():
 				}
 			}
-		}()
+		})
 	}
 	defer close(feed)
 

--- a/ipld/merkledag/merkledag_test.go
+++ b/ipld/merkledag/merkledag_test.go
@@ -615,7 +615,7 @@ func TestFetchFailure(t *testing.T) {
 	ds_bad := dstest.Mock()
 
 	top := new(ProtoNode)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		nd := NodeWithData([]byte{byte('a' + i)})
 		err := ds.Add(ctx, nd)
 		if err != nil {
@@ -628,7 +628,7 @@ func TestFetchFailure(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		nd := NodeWithData([]byte{'f', 'a' + byte(i)})
 		err := ds_bad.Add(ctx, nd)
 		if err != nil {
@@ -1204,7 +1204,7 @@ func mkDag(ds ipld.DAGService, depth int) (cid.Cid, int, uint64) {
 		return p
 	}
 
-	for i := 0; i < depth; i++ {
+	for range depth {
 		thisf := f
 		f = func() *ProtoNode {
 			pn := mkNodeWithChildren(thisf, 10)
@@ -1234,7 +1234,7 @@ func mkDag(ds ipld.DAGService, depth int) (cid.Cid, int, uint64) {
 func mkNodeWithChildren(getChild func() *ProtoNode, width int) *ProtoNode {
 	cur := new(ProtoNode)
 
-	for i := 0; i < width; i++ {
+	for i := range width {
 		c := getChild()
 		if err := cur.AddNodeLink(strconv.Itoa(i), c); err != nil {
 			panic(err)

--- a/ipld/merkledag/test/dag_generator.go
+++ b/ipld/merkledag/test/dag_generator.go
@@ -52,7 +52,7 @@ func (dg *DAGGenerator) generate(adder func(ctx context.Context, node format.Nod
 		return c, size, []cid.Cid{c}, nil
 	}
 	links := make([]*format.Link, fanout)
-	for i := uint(0); i < fanout; i++ {
+	for i := range fanout {
 		root, size, children, err := dg.generate(adder, fanout, depth-1)
 		if err != nil {
 			return cid.Undef, 0, nil, err

--- a/ipld/merkledag/test/dag_generator_test.go
+++ b/ipld/merkledag/test/dag_generator_test.go
@@ -43,7 +43,7 @@ func TestNodesAreDifferent(t *testing.T) {
 
 	const nbDag = 5
 
-	for i := 0; i < nbDag; i++ {
+	for range nbDag {
 		c, cids, err := gen.MakeDagNode(dserv.Add, 5, 3)
 		if err != nil {
 			t.Fatal(err)

--- a/ipld/unixfs/hamt/hamt.go
+++ b/ipld/unixfs/hamt/hamt.go
@@ -519,7 +519,7 @@ func parallelShardWalk(ctx context.Context, root *Shard, dserv ipld.DAGService, 
 	out := make(chan *listCidsAndShards)
 	done := make(chan struct{})
 
-	for i := 0; i < concurrency; i++ {
+	for range concurrency {
 		grp.Go(func() error {
 			for feedChildren := range feed {
 				for _, nextShard := range feedChildren.shards {

--- a/ipld/unixfs/hamt/hamt_stress_test.go
+++ b/ipld/unixfs/hamt/hamt_stress_test.go
@@ -15,7 +15,7 @@ import (
 
 func getNames(prefix string, count int) []string {
 	out := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		out[i] = fmt.Sprintf("%s%d", prefix, i)
 	}
 	return out

--- a/ipld/unixfs/hamt/hamt_test.go
+++ b/ipld/unixfs/hamt/hamt_test.go
@@ -20,7 +20,7 @@ import (
 
 func shuffle(seed int64, arr []string) {
 	r := rand.New(rand.NewSource(seed))
-	for i := 0; i < len(arr); i++ {
+	for range arr {
 		a := r.Intn(len(arr))
 		b := r.Intn(len(arr))
 		arr[a], arr[b] = arr[b], arr[a]
@@ -40,7 +40,7 @@ func makeDirWidth(ds ipld.DAGService, size, width int) ([]string, *Shard, error)
 	}
 
 	var dirs []string
-	for i := 0; i < size; i++ {
+	for i := range size {
 		dirs = append(dirs, fmt.Sprintf("DIRNAME%d", i))
 	}
 
@@ -182,8 +182,7 @@ func TestDirBuilding(t *testing.T) {
 func TestShardReload(t *testing.T) {
 	ds := mdtest.Mock()
 	_, _ = NewShard(ds, 256)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	_, s, err := makeDir(ds, 200)
 	if err != nil {
@@ -242,7 +241,7 @@ func TestRemoveElems(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		err := s.Remove(ctx, fmt.Sprintf("NOTEXIST%d", rand.Int()))
 		if err != os.ErrNotExist {
 			t.Fatal("shouldnt be able to remove things that don't exist")
@@ -340,7 +339,7 @@ func TestSetAfterMarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		empty := ft.EmptyDirNode()
 		err := nds.Set(ctx, fmt.Sprintf("moredirs%d", i), empty)
 		if err != nil {
@@ -504,7 +503,7 @@ func TestFindNonExisting(t *testing.T) {
 	}
 	ctx := context.Background()
 
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		_, err := s.Find(ctx, fmt.Sprintf("notfound%d", i))
 		if err != os.ErrNotExist {
 			t.Fatal("expected ErrNotExist")
@@ -690,7 +689,7 @@ func BenchmarkHAMTWalk(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	for j := 0; j < 1000; j++ {
+	for j := range 1000 {
 		err = s.Set(ctx, strconv.Itoa(j), ft.EmptyDirNode())
 		if err != nil {
 			b.Fatal(err)

--- a/ipld/unixfs/hamt/util_test.go
+++ b/ipld/unixfs/hamt/util_test.go
@@ -19,7 +19,7 @@ func TestHashBitsOverflow(t *testing.T) {
 	buf := []byte{255}
 	hb := hashBits{b: buf}
 
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		bit, err := hb.Next(1)
 		if err != nil {
 			t.Fatalf("got %d bits back, expected 8: %s", i, err)

--- a/ipld/unixfs/importer/balanced/balanced_test.go
+++ b/ipld/unixfs/importer/balanced/balanced_test.go
@@ -278,7 +278,7 @@ func TestSeekingStress(t *testing.T) {
 	}
 
 	testbuf := make([]byte, nbytes)
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		offset := mrand.Intn(int(nbytes))
 		l := int(nbytes) - offset
 		n, err := rs.Seek(int64(offset), io.SeekStart)

--- a/ipld/unixfs/importer/trickle/trickle_test.go
+++ b/ipld/unixfs/importer/trickle/trickle_test.go
@@ -415,7 +415,7 @@ func testSeekingStress(t *testing.T, rawLeaves UseRawLeaves) {
 	}
 
 	testbuf := make([]byte, nbytes)
-	for i := 0; i < 50; i++ {
+	for range 50 {
 		offset := mrand.Intn(int(nbytes))
 		l := int(nbytes) - offset
 		n, err := rs.Seek(int64(offset), io.SeekStart)
@@ -579,7 +579,7 @@ func testMultipleAppends(t *testing.T, rawLeaves UseRawLeaves) {
 	spl := chunker.SizeSplitterGen(500)
 
 	ctx := context.Background()
-	for i := 0; i < len(should); i++ {
+	for i := range should {
 
 		db, err := dbp.New(spl(bytes.NewReader(should[i : i+1])))
 		if err != nil {

--- a/ipld/unixfs/io/completehamt_test.go
+++ b/ipld/unixfs/io/completehamt_test.go
@@ -51,7 +51,7 @@ func CreateCompleteHAMT(ds ipld.DAGService, treeHeight int, childsPerNode int) (
 		return nil, errors.New("childsPerNode * treeHeight should be multiple of 8")
 	}
 	bytesInKey := log2ofChilds * treeHeight / 8
-	for i := 0; i < totalChildren; i++ {
+	for i := range totalChildren {
 		var hashbuf [8]byte
 		binary.LittleEndian.PutUint64(hashbuf[:], uint64(i))
 		var oldLink *ipld.Link

--- a/ipld/unixfs/io/dagreader_test.go
+++ b/ipld/unixfs/io/dagreader_test.go
@@ -2,7 +2,6 @@ package io
 
 import (
 	"bytes"
-	context "context"
 	"io"
 	"strings"
 	"testing"
@@ -15,8 +14,7 @@ import (
 func TestBasicRead(t *testing.T) {
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024, testu.UseProtoBufLeaves)
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	reader, err := NewDagReader(ctx, node, dserv)
 	if err != nil {
@@ -42,8 +40,7 @@ func TestSeekAndRead(t *testing.T) {
 	}
 
 	node := testu.GetNode(t, dserv, inbuf, testu.UseProtoBufLeaves)
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	reader, err := NewDagReader(ctx, node, dserv)
 	if err != nil {
@@ -71,12 +68,11 @@ func TestSeekAndRead(t *testing.T) {
 
 func TestSeekWithoutBlocksizes(t *testing.T) {
 	dserv := testu.GetDAGServ()
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	inbuf := make([]byte, 1024)
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		inbuf[i*4] = byte(i)
 	}
 
@@ -136,12 +132,11 @@ func TestSeekWithoutBlocksizes(t *testing.T) {
 
 func TestRelativeSeek(t *testing.T) {
 	dserv := testu.GetDAGServ()
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	inbuf := make([]byte, 1024)
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		inbuf[i*4] = byte(i)
 	}
 
@@ -153,7 +148,7 @@ func TestRelativeSeek(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		if getOffset(reader) != int64(i*4) {
 			t.Fatalf("offset should be %d, was %d", i*4, getOffset(reader))
 		}
@@ -174,7 +169,7 @@ func TestRelativeSeek(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 256; i++ {
+	for i := range 256 {
 		if getOffset(reader) != int64(1020-i*4) {
 			t.Fatalf("offset should be %d, was %d", 1020-i*4, getOffset(reader))
 		}
@@ -188,8 +183,7 @@ func TestRelativeSeek(t *testing.T) {
 
 func TestTypeFailures(t *testing.T) {
 	dserv := testu.GetDAGServ()
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	node := unixfs.EmptyDirNode()
 	if _, err := NewDagReader(ctx, node, dserv); err != ErrIsDir {
@@ -209,8 +203,7 @@ func TestTypeFailures(t *testing.T) {
 
 func TestBadPBData(t *testing.T) {
 	dserv := testu.GetDAGServ()
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	node := mdag.NodeWithData([]byte{42})
 	_, err := NewDagReader(ctx, node, dserv)
@@ -220,8 +213,7 @@ func TestBadPBData(t *testing.T) {
 }
 
 func TestMetadataNode(t *testing.T) {
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	dserv := testu.GetDAGServ()
 	rdata, rnode := testu.GetRandomNode(t, dserv, 512, testu.UseProtoBufLeaves)
@@ -265,8 +257,7 @@ func TestMetadataNode(t *testing.T) {
 func TestWriteTo(t *testing.T) {
 	dserv := testu.GetDAGServ()
 	inbuf, node := testu.GetRandomNode(t, dserv, 1024, testu.UseProtoBufLeaves)
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	reader, err := NewDagReader(ctx, node, dserv)
 	if err != nil {
@@ -286,8 +277,7 @@ func TestReaderSzie(t *testing.T) {
 	dserv := testu.GetDAGServ()
 	size := int64(1024)
 	_, node := testu.GetRandomNode(t, dserv, size, testu.UseProtoBufLeaves)
-	ctx, closer := context.WithCancel(context.Background())
-	defer closer()
+	ctx := t.Context()
 
 	reader, err := NewDagReader(ctx, node, dserv)
 	if err != nil {

--- a/ipld/unixfs/io/directory_test.go
+++ b/ipld/unixfs/io/directory_test.go
@@ -68,7 +68,7 @@ func TestDirectoryGrowth(t *testing.T) {
 		require.True(t, l.Cid.Equals(dirc), "link wasnt correct")
 	}
 
-	for i := 0; i < nelems; i++ {
+	for i := range nelems {
 		dn := fmt.Sprintf("dir%d", i)
 		if !names[dn] {
 			t.Fatal("didnt find directory: ", dn)
@@ -216,7 +216,7 @@ func TestProductionLinkSize(t *testing.T) {
 	ds := mdtest.Mock()
 	basicDir, err := NewBasicDirectory(ds)
 	assert.NoError(t, err)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		basicDir.AddChild(context.Background(), strconv.FormatUint(uint64(i), 10), ft.EmptyFileNode())
 	}
 	basicDirNode, err := basicDir.GetNode()
@@ -292,7 +292,7 @@ func TestIntegrityOfDirectorySwitch(t *testing.T) {
 	assert.NoError(t, err)
 	hamtDir, err := NewHAMTDirectory(ds, 0, WithMaxLinks(DefaultShardWidth))
 	assert.NoError(t, err)
-	for i := 0; i < 1000; i++ {
+	for i := range 1000 {
 		basicDir.AddChild(ctx, strconv.FormatUint(uint64(i), 10), child)
 		hamtDir.AddChild(ctx, strconv.FormatUint(uint64(i), 10), child)
 	}
@@ -446,7 +446,7 @@ func TestDirBuilder(t *testing.T) {
 
 	count := 5000
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		err = dir.AddChild(ctx, fmt.Sprintf("entry %d", i), child)
 		require.NoError(t, err)
 	}
@@ -490,7 +490,7 @@ func TestDirBuilder(t *testing.T) {
 		asyncLinks = append(asyncLinks, linkResult.Link)
 	}
 
-	for i := 0; i < count; i++ {
+	for i := range count {
 		n := fmt.Sprintf("entry %d", i)
 		if !asyncNames[n] {
 			t.Fatal("COULDNT FIND: ", n)
@@ -581,7 +581,7 @@ func TestHAMTDirectoryWithMaxLinks(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure we have at least 2 levels of HAMT by adding many nodes
-	for i := 0; i < 300; i++ {
+	for i := range 300 {
 		child := ft.EmptyDirNode()
 		require.NoError(t, ds.Add(ctx, child))
 		err := dir.AddChild(ctx, fmt.Sprintf("entry%d", i), child)
@@ -612,7 +612,7 @@ func TestDynamicDirectoryWithMaxLinks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		child := ft.EmptyDirNode()
 		require.NoError(t, ds.Add(ctx, child))
 		err := dir.AddChild(ctx, fmt.Sprintf("entry%d", i), child)

--- a/ipld/unixfs/mod/dagmodifier_test.go
+++ b/ipld/unixfs/mod/dagmodifier_test.go
@@ -167,7 +167,7 @@ func testMultiWrite(t *testing.T, opts testu.NodeOpts) {
 	data := make([]byte, 4000)
 	random.NewRand().Read(data)
 
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		n, err := dagmod.WriteAt(data[i:i+1], int64(i))
 		if err != nil {
 			t.Fatal(err)
@@ -211,7 +211,7 @@ func testMultiWriteAndFlush(t *testing.T, opts testu.NodeOpts) {
 	data := make([]byte, 20)
 	random.NewRand().Read(data)
 
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		n, err := dagmod.WriteAt(data[i:i+1], int64(i))
 		if err != nil {
 			t.Fatal(err)
@@ -283,7 +283,7 @@ func testMultiWriteCoal(t *testing.T, opts testu.NodeOpts) {
 	data := make([]byte, 1000)
 	random.NewRand().Read(data)
 
-	for i := 0; i < len(data); i++ {
+	for i := range data {
 		n, err := dagmod.WriteAt(data[:i+1], 0)
 		if err != nil {
 			fmt.Println("FAIL AT ", i)
@@ -323,7 +323,7 @@ func testLargeWriteChunks(t *testing.T, opts testu.NodeOpts) {
 
 	random.NewRand().Read(data)
 
-	for i := 0; i < datasize/wrsize; i++ {
+	for i := range datasize / wrsize {
 		n, err := dagmod.WriteAt(data[i*wrsize:(i+1)*wrsize], int64(i*wrsize))
 		if err != nil {
 			t.Fatal(err)
@@ -428,8 +428,7 @@ func TestDagSync(t *testing.T) {
 	dserv := testu.GetDAGServ()
 	nd := dag.NodeWithData(unixfs.FilePBData(nil, 0))
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dagmod, err := NewDagModifier(ctx, nd, dserv, testu.SizeSplitterGen(512))
 	if err != nil {
@@ -706,7 +705,7 @@ func testRelativeSeek(t *testing.T, opts testu.NodeOpts) {
 		dagmod.RawLeaves = true
 	}
 
-	for i := 0; i < 64; i++ {
+	for i := range 64 {
 		dagmod.Write([]byte{byte(i)})
 		if _, err := dagmod.Seek(1, io.SeekCurrent); err != nil {
 			t.Fatal(err)
@@ -843,7 +842,7 @@ func testReadAndSeek(t *testing.T, opts testu.NodeOpts) {
 		t.Fatalf("expected length of 4 got %d", c)
 	}
 
-	for i := byte(0); i < 4; i++ {
+	for i := range byte(4) {
 		if readBuf[i] != i {
 			t.Fatalf("wrong value %d [at index %d]", readBuf[i], i)
 		}
@@ -865,7 +864,7 @@ func testReadAndSeek(t *testing.T, opts testu.NodeOpts) {
 		t.Fatalf("expected length of 3 got %d", c)
 	}
 
-	for i := byte(0); i < 3; i++ {
+	for i := range byte(3) {
 		if readBuf[i] != i+5 {
 			t.Fatalf("wrong value %d [at index %d]", readBuf[i], i)
 		}
@@ -914,8 +913,7 @@ func BenchmarkDagmodWrite(b *testing.B) {
 	b.StopTimer()
 	dserv := testu.GetDAGServ()
 	n := testu.GetEmptyNode(b, dserv, testu.UseProtoBufLeaves)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 
 	const wrsize = 4096
 
@@ -1579,8 +1577,7 @@ func TestRawNodeGrowthConversion(t *testing.T) {
 
 func TestRawLeavesCollapse(t *testing.T) {
 	t.Run("single-block file collapses to RawNode when RawLeaves enabled", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		dserv := testu.GetDAGServ()
 
@@ -1625,8 +1622,7 @@ func TestRawLeavesCollapse(t *testing.T) {
 	})
 
 	t.Run("multi-block file stays as ProtoNode", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		dserv := testu.GetDAGServ()
 
@@ -1682,8 +1678,7 @@ func TestRawLeavesCollapse(t *testing.T) {
 
 	for _, tc := range metadataTests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			dserv := testu.GetDAGServ()
 
@@ -1754,8 +1749,7 @@ func TestRawLeavesCollapse(t *testing.T) {
 	}
 
 	t.Run("RawLeaves=false keeps ProtoNode", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		dserv := testu.GetDAGServ()
 

--- a/ipld/unixfs/test/utils.go
+++ b/ipld/unixfs/test/utils.go
@@ -108,7 +108,7 @@ func PrintDag(nd *mdag.ProtoNode, ds ipld.DAGService, indent int) {
 		panic(err)
 	}
 
-	for i := 0; i < indent; i++ {
+	for range indent {
 		fmt.Print(" ")
 	}
 	fmt.Printf("{size = %d, type = %s, children = %d", fsn.FileSize(), fsn.Type().String(), fsn.NumChildren())
@@ -123,7 +123,7 @@ func PrintDag(nd *mdag.ProtoNode, ds ipld.DAGService, indent int) {
 		PrintDag(child.(*mdag.ProtoNode), ds, indent+1)
 	}
 	if len(nd.Links()) > 0 {
-		for i := 0; i < indent; i++ {
+		for range indent {
 			fmt.Print(" ")
 		}
 	}

--- a/ipld/unixfs/unixfs_test.go
+++ b/ipld/unixfs/unixfs_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestFSNode(t *testing.T) {
 	fsn := NewFSNode(TFile)
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		fsn.AddBlockSize(100)
 	}
 	fsn.RemoveBlockSize(15)

--- a/ipns/record.go
+++ b/ipns/record.go
@@ -394,7 +394,7 @@ func recordDataForSignatureV1(e *ipns_pb.IpnsRecord) []byte {
 	return bytes.Join([][]byte{
 		e.Value,
 		e.Validity,
-		[]byte(fmt.Sprint(e.GetValidityType())),
+		fmt.Append(nil, e.GetValidityType()),
 	},
 		[]byte{})
 }

--- a/ipns/validation_test.go
+++ b/ipns/validation_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func shuffle[T any](a []T) {
-	for n := 0; n < 5; n++ {
+	for range 5 {
 		for i := range a {
 			j := rand.Intn(len(a))
 			a[i], a[j] = a[j], a[i]

--- a/mfs/mfs_test.go
+++ b/mfs/mfs_test.go
@@ -131,7 +131,7 @@ func compStrArrs(a, b []string) bool {
 		return false
 	}
 
-	for i := 0; i < len(a); i++ {
+	for i := range a {
 		if a[i] != b[i] {
 			return false
 		}
@@ -232,8 +232,7 @@ func setupRoot(ctx context.Context, t testing.TB) (ipld.DAGService, *Root) {
 }
 
 func TestBasic(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	rootdir := rt.GetDirectory()
@@ -262,8 +261,7 @@ func TestBasic(t *testing.T) {
 }
 
 func TestMkdir(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	_, rt := setupRoot(ctx, t)
 
 	rootdir := rt.GetDirectory()
@@ -300,8 +298,7 @@ func TestMkdir(t *testing.T) {
 }
 
 func TestDirectoryLoadFromDag(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	rootdir := rt.GetDirectory()
@@ -392,8 +389,7 @@ func TestDirectoryLoadFromDag(t *testing.T) {
 }
 
 func TestMvFile(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dagService, rt := setupRoot(ctx, t)
 	rootDir := rt.GetDirectory()
 
@@ -416,8 +412,7 @@ func TestMvFile(t *testing.T) {
 }
 
 func TestMvFileToSubdir(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dagService, rt := setupRoot(ctx, t)
 	rootDir := rt.GetDirectory()
 
@@ -442,8 +437,7 @@ func TestMvFileToSubdir(t *testing.T) {
 }
 
 func TestMvFileToSubdirWithRename(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dagService, rt := setupRoot(ctx, t)
 	rootDir := rt.GetDirectory()
 
@@ -468,8 +462,7 @@ func TestMvFileToSubdirWithRename(t *testing.T) {
 }
 
 func TestMvDir(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dagService, rt := setupRoot(ctx, t)
 	rootDir := rt.GetDirectory()
 
@@ -500,8 +493,7 @@ func TestMvDir(t *testing.T) {
 }
 
 func TestMfsFile(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	rootdir := rt.GetDirectory()
@@ -652,8 +644,7 @@ func TestMfsFile(t *testing.T) {
 }
 
 func TestMfsModeAndModTime(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ds, rt := setupRoot(ctx, t)
 	rootdir := rt.GetDirectory()
@@ -803,8 +794,7 @@ func TestMfsModeAndModTime(t *testing.T) {
 }
 
 func TestMfsRawNodeSetModeAndMtime(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	_, rt := setupRoot(ctx, t)
 	rootdir := rt.GetDirectory()
@@ -879,8 +869,7 @@ func TestMfsRawNodeSetModeAndMtime(t *testing.T) {
 }
 
 func TestMfsDirListNames(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	rootdir := rt.GetDirectory()
@@ -888,7 +877,7 @@ func TestMfsDirListNames(t *testing.T) {
 	total := rand.Intn(10) + 1
 	fNames := make([]string, 0, total)
 
-	for i := 0; i < total; i++ {
+	for range total {
 		fn := randomName()
 		fNames = append(fNames, fn)
 		nd := getRandFile(t, ds, rand.Int63n(1000)+1)
@@ -904,13 +893,7 @@ func TestMfsDirListNames(t *testing.T) {
 	}
 
 	for _, lName := range list {
-		found := false
-		for _, fName := range fNames {
-			if lName == fName {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(fNames, lName)
 		if !found {
 			t.Fatal(lName + " not found in directory listing")
 		}
@@ -918,7 +901,7 @@ func TestMfsDirListNames(t *testing.T) {
 }
 
 func randomWalk(d *Directory, n int) (*Directory, error) {
-	for i := 0; i < n; i++ {
+	for range n {
 		dirents, err := d.List(context.Background())
 		if err != nil {
 			return nil, err
@@ -949,12 +932,12 @@ func randomWalk(d *Directory, n int) (*Directory, error) {
 func randomName() string {
 	set := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890_"
 	length := rand.Intn(10) + 2
-	var out string
-	for i := 0; i < length; i++ {
+	var out strings.Builder
+	for range length {
 		j := rand.Intn(len(set))
-		out += set[j : j+1]
+		out.WriteString(set[j : j+1])
 	}
-	return out
+	return out.String()
 }
 
 func actorMakeFile(d *Directory) error {
@@ -1099,7 +1082,7 @@ func actorReadFile(d *Directory) error {
 
 func testActor(rt *Root, iterations int, errs chan error) {
 	d := rt.GetDirectory()
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		switch rand.Intn(5) {
 		case 0:
 			if err := actorMkdir(d); err != nil {
@@ -1127,18 +1110,17 @@ func testActor(rt *Root, iterations int, errs chan error) {
 }
 
 func TestMfsStress(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	_, rt := setupRoot(ctx, t)
 
 	numroutines := 10
 
 	errs := make(chan error)
-	for i := 0; i < numroutines; i++ {
+	for range numroutines {
 		go testActor(rt, 50, errs)
 	}
 
-	for i := 0; i < numroutines; i++ {
+	for range numroutines {
 		err := <-errs
 		if err != nil {
 			t.Fatal(err)
@@ -1147,11 +1129,10 @@ func TestMfsStress(t *testing.T) {
 }
 
 func TestMfsHugeDir(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	_, rt := setupRoot(ctx, t)
 
-	for i := 0; i < 10000; i++ {
+	for i := range 10000 {
 		err := Mkdir(rt, fmt.Sprintf("/dir%d", i), MkdirOpts{Mkparents: false, Flush: false})
 		if err != nil {
 			t.Fatal(err)
@@ -1160,8 +1141,7 @@ func TestMfsHugeDir(t *testing.T) {
 }
 
 func TestMkdirP(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	_, rt := setupRoot(ctx, t)
 
 	err := Mkdir(rt, "/a/b/c/d/e/f", MkdirOpts{Mkparents: true, Flush: true})
@@ -1171,8 +1151,7 @@ func TestMkdirP(t *testing.T) {
 }
 
 func TestConcurrentWriteAndFlush(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	d := mkdirP(t, rt.GetDirectory(), "foo/bar/baz")
@@ -1185,19 +1164,17 @@ func TestConcurrentWriteAndFlush(t *testing.T) {
 	nloops := 500
 
 	wg := new(sync.WaitGroup)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		for i := 0; i < nloops; i++ {
+	wg.Go(func() {
+		for range nloops {
 			err := writeFile(rt, "/foo/bar/baz/file", func(_ []byte) []byte { return []byte("STUFF") })
 			if err != nil {
 				t.Error("file write failed: ", err)
 				return
 			}
 		}
-	}()
+	})
 
-	for i := 0; i < nloops; i++ {
+	for range nloops {
 		_, err := rt.GetDirectory().GetNode()
 		if err != nil {
 			t.Fatal(err)
@@ -1208,8 +1185,7 @@ func TestConcurrentWriteAndFlush(t *testing.T) {
 }
 
 func TestFlushing(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	_, rt := setupRoot(ctx, t)
 
 	dir := rt.GetDirectory()
@@ -1312,8 +1288,7 @@ func readFile(rt *Root, path string, offset int64, buf []byte) error {
 }
 
 func TestConcurrentReads(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ds, rt := setupRoot(ctx, t)
 
@@ -1334,12 +1309,12 @@ func TestConcurrentReads(t *testing.T) {
 
 	var wg sync.WaitGroup
 	nloops := 100
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		wg.Add(1)
 		go func(me int) {
 			defer wg.Done()
 			mybuf := make([]byte, len(buf))
-			for j := 0; j < nloops; j++ {
+			for range nloops {
 				offset := rand.Intn(len(buf))
 				length := rand.Intn(len(buf) - offset)
 
@@ -1403,8 +1378,7 @@ func writeFile(rt *Root, path string, transform func([]byte) []byte) error {
 }
 
 func TestConcurrentWrites(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ds, rt := setupRoot(ctx, t)
 
@@ -1422,12 +1396,10 @@ func TestConcurrentWrites(t *testing.T) {
 	var wg sync.WaitGroup
 	nloops := 100
 	errs := make(chan error, 1000)
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 10 {
+		wg.Go(func() {
 			var lastSeen uint64
-			for j := 0; j < nloops; j++ {
+			for range nloops {
 				err := writeFile(rt, "a/b/c/afile", func(buf []byte) []byte {
 					if len(buf) == 0 {
 						if lastSeen > 0 {
@@ -1457,7 +1429,7 @@ func TestConcurrentWrites(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errs)
@@ -1476,8 +1448,7 @@ func TestConcurrentWrites(t *testing.T) {
 }
 
 func TestFileDescriptors(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	ds, rt := setupRoot(ctx, t)
 	dir := rt.GetDirectory()
@@ -1583,8 +1554,7 @@ func TestFileDescriptors(t *testing.T) {
 }
 
 func TestTruncateAtSize(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	dir := rt.GetDirectory()
@@ -1609,8 +1579,7 @@ func TestTruncateAtSize(t *testing.T) {
 }
 
 func TestTruncateAndWrite(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	dir := rt.GetDirectory()
@@ -1627,7 +1596,7 @@ func TestTruncateAndWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer fd.Close()
-	for i := 0; i < 200; i++ {
+	for i := range 200 {
 		err = fd.Truncate(0)
 		if err != nil {
 			t.Fatal(err)
@@ -1656,8 +1625,7 @@ func TestTruncateAndWrite(t *testing.T) {
 }
 
 func TestFSNodeType(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds, rt := setupRoot(ctx, t)
 
 	// check for IsDir
@@ -1830,8 +1798,7 @@ func FuzzMkdirAndWriteConcurrently(f *testing.F) {
 // TestRootOptionChunker verifies that WithChunker sets the chunker factory
 // for files created in the MFS, producing the exact expected block count and sizes.
 func TestRootOptionChunker(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use 512-byte chunks (non-default: default is 256KB = 262144 bytes).
@@ -1910,8 +1877,7 @@ func TestRootOptionChunker(t *testing.T) {
 // TestRootOptionMaxLinks verifies that WithMaxLinks triggers HAMT sharding
 // when directory entries exceed the configured maximum.
 func TestRootOptionMaxLinks(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use MaxLinks=3 (non-default: default is ~174 from helpers.DefaultLinksPerBlock).
@@ -2005,8 +1971,7 @@ func TestRootOptionMaxLinks(t *testing.T) {
 // TestRootOptionSizeEstimationMode verifies that WithSizeEstimationMode
 // propagates correctly to child directories, including after reload from DAG.
 func TestRootOptionSizeEstimationMode(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use SizeEstimationDisabled (non-default: default is SizeEstimationLinks=0).
@@ -2127,8 +2092,7 @@ func TestRootOptionSizeEstimationMode(t *testing.T) {
 // TestChunkerInheritance verifies that the chunker setting propagates
 // through nested subdirectories to files created deep in the hierarchy.
 func TestChunkerInheritance(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use 256-byte chunks (non-default: default is 256KB = 262144 bytes).
@@ -2213,8 +2177,7 @@ func TestChunkerInheritance(t *testing.T) {
 // TestRootOptionMaxHAMTFanout verifies that WithMaxHAMTFanout propagates
 // to directories and affects HAMT shard width.
 func TestRootOptionMaxHAMTFanout(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use custom fanout of 64 (non-default: default is 256).
@@ -2291,8 +2254,7 @@ func TestRootOptionMaxHAMTFanout(t *testing.T) {
 // TestRootOptionHAMTShardingSize verifies that WithHAMTShardingSize propagates
 // to directories and affects HAMT conversion threshold.
 func TestRootOptionHAMTShardingSize(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use very small threshold of 100 bytes (non-default: default is 256KiB).
@@ -2374,8 +2336,7 @@ func TestRootOptionHAMTShardingSize(t *testing.T) {
 // TestHAMTShardingSizeInheritance verifies that HAMTShardingSize propagates
 // through nested subdirectories and after reload from DAG.
 func TestHAMTShardingSizeInheritance(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	ds := getDagserv(t)
 
 	// Use very small threshold

--- a/namesys/ipns_publisher_test.go
+++ b/namesys/ipns_publisher_test.go
@@ -81,8 +81,7 @@ func TestIPNSPublisher(t *testing.T) {
 func TestAsyncDS(t *testing.T) {
 	t.Parallel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	rt := mockrouting.NewServer().Client(testutil.RandIdentityOrFatal(t))
 	ds := &checkSyncDS{

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -116,7 +116,7 @@ func NewNameSystem(r routing.ValueStore, opts ...Option) (NameSystem, error) {
 	// IPFS_NS_MAP="dnslink-test.example.com:/ipfs/bafkreicysg23kiwv34eg2d7qweipxwosdo2py4ldv42nbauguluen5v6am"
 	if list := os.Getenv("IPFS_NS_MAP"); list != "" {
 		staticMap = make(map[string]*cacheEntry)
-		for _, pair := range strings.Split(list, ",") {
+		for pair := range strings.SplitSeq(list, ",") {
 			mapping := strings.SplitN(pair, ":", 2)
 			key := mapping[0]
 			value, err := path.NewPath(mapping[1])

--- a/namesys/republisher/repub_test.go
+++ b/namesys/republisher/repub_test.go
@@ -59,12 +59,11 @@ func getMockNode(t *testing.T, ctx context.Context) *mockNode {
 func TestRepublish(t *testing.T) {
 	// set cache life to zero for testing low-period repubs
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var nsystems []namesys.NameSystem
 	var nodes []*mockNode
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n := getMockNode(t, ctx)
 		ns, err := namesys.NewNameSystem(n.dht, namesys.WithDatastore(n.store))
 		require.NoError(t, err)
@@ -136,12 +135,11 @@ func TestRepublish(t *testing.T) {
 func TestLongEOLRepublish(t *testing.T) {
 	// set cache life to zero for testing low-period repubs
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var nsystems []namesys.NameSystem
 	var nodes []*mockNode
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		n := getMockNode(t, ctx)
 		ns, err := namesys.NewNameSystem(n.dht, namesys.WithDatastore(n.store))
 		require.NoError(t, err)

--- a/path/resolver/resolver_test.go
+++ b/path/resolver/resolver_test.go
@@ -182,8 +182,7 @@ func TestResolveToLastNode_NoUnnecessaryFetching(t *testing.T) {
 }
 
 func TestPathRemainder(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	bsrv := dagmock.Bserv()
 
 	nb := basicnode.Prototype.Any.NewBuilder()
@@ -223,8 +222,7 @@ func TestPathRemainder(t *testing.T) {
 }
 
 func TestResolveToLastNode_MixedSegmentTypes(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	bsrv := dagmock.Bserv()
 	a := randNode()

--- a/peering/peering_test.go
+++ b/peering/peering_test.go
@@ -27,8 +27,7 @@ func newNode(t *testing.T) host.Host {
 }
 
 func TestPeeringService(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	h1 := newNode(t)
 	ps1 := NewPeeringService(h1)
@@ -153,7 +152,7 @@ func TestPeeringService(t *testing.T) {
 
 func TestNextBackoff(t *testing.T) {
 	minMaxBackoff := (100 - maxBackoffJitter) / 100 * maxBackoff
-	for x := 0; x < 1000; x++ {
+	for range 1000 {
 		ph := peerHandler{nextDelay: time.Second}
 		for min, max := time.Second*3/2, time.Second*5/2; min < minMaxBackoff; min, max = min*3/2, max*5/2 {
 			b := ph.nextBackoff()
@@ -161,7 +160,7 @@ func TestNextBackoff(t *testing.T) {
 				t.Errorf("expected backoff %s to be between %s and %s", b, min, max)
 			}
 		}
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			b := ph.nextBackoff()
 			if b < minMaxBackoff || b > maxBackoff {
 				t.Fatal("failed to stay within max bounds")

--- a/pinning/pinner/dsindex/indexer_test.go
+++ b/pinning/pinner/dsindex/indexer_test.go
@@ -21,8 +21,7 @@ func createIndexer() Indexer {
 }
 
 func TestAdd(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 	err := nameIndex.Add(ctx, "someone", "s1")
 	if err != nil {
@@ -45,8 +44,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestHasValue(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 
 	ok, err := nameIndex.HasValue(ctx, "bob", "b1")
@@ -77,8 +75,7 @@ func TestHasValue(t *testing.T) {
 }
 
 func TestHasAny(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 
 	ok, err := nameIndex.HasAny(ctx, "nothere")
@@ -117,8 +114,7 @@ func TestHasAny(t *testing.T) {
 }
 
 func TestForEach(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 
 	found := make(map[string]struct{})
@@ -164,8 +160,7 @@ func TestForEach(t *testing.T) {
 }
 
 func TestSearch(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 
 	ids, err := nameIndex.Search(ctx, "bob")
@@ -202,8 +197,7 @@ func TestSearch(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 
 	err := nameIndex.Delete(ctx, "bob", "b3")
@@ -238,8 +232,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestSyncIndex(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	nameIndex := createIndexer()
 
 	dstore := ds.NewMapDatastore()

--- a/pinning/pinner/dspinner/pin_test.go
+++ b/pinning/pinner/dspinner/pin_test.go
@@ -99,8 +99,7 @@ func allPins(t *testing.T, ch <-chan ipfspin.StreamedPin) (pins []ipfspin.Pinned
 }
 
 func TestPinnerBasic(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
@@ -331,8 +330,7 @@ func TestPinnerBasic(t *testing.T) {
 }
 
 func TestAddLoadPin(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
@@ -438,8 +436,7 @@ func TestIsPinnedLookup(t *testing.T) {
 	// pinned and once they have been unpinned.
 	aBranchLen := 6
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
@@ -481,8 +478,7 @@ func TestIsPinnedLookup(t *testing.T) {
 }
 
 func TestDuplicateSemantics(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
@@ -520,8 +516,7 @@ func TestDuplicateSemantics(t *testing.T) {
 }
 
 func TestFlush(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
 	bserv := bs.New(bstore, offline.Exchange(bstore))
@@ -589,8 +584,7 @@ func TestPinRecursiveFail(t *testing.T) {
 }
 
 func TestPinUpdate(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
@@ -657,8 +651,7 @@ func TestPinUpdate(t *testing.T) {
 }
 
 func TestLoadDirty(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dstore := dssync.MutexWrap(ds.NewMapDatastore())
 	bstore := blockstore.NewBlockstore(dstore)
@@ -815,7 +808,7 @@ func makeTree(ctx context.Context, aBranchLen int, dserv ipld.DAGService, p ipfs
 
 	aNodes := make([]*mdag.ProtoNode, aBranchLen)
 	aKeys = make([]cid.Cid, aBranchLen)
-	for i := 0; i < aBranchLen; i++ {
+	for i := range aBranchLen {
 		a, _ := randNode()
 		if i >= 1 {
 			if err = a.AddNodeLink("child", aNodes[i-1]); err != nil {
@@ -884,7 +877,7 @@ func makeNodes(count int, dserv ipld.DAGService) []ipld.Node {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	nodes := make([]ipld.Node, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		n, _ := randNode()
 		err := dserv.Add(ctx, n)
 		if err != nil {
@@ -951,8 +944,7 @@ func makeStore() (ds.Datastore, ipld.DAGService) {
 // compares the load time when rebuilding indexes to loading without rebuilding
 // indexes.
 func BenchmarkLoad(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 
 	dstore, dserv := makeStore()
 	pinner, err := New(ctx, dstore, dserv)
@@ -1152,8 +1144,7 @@ func benchmarkPinAll(b *testing.B, count int, pinner ipfspin.Pinner, dserv ipld.
 }
 
 func BenchmarkRebuild(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := b.Context()
 
 	dstore, dserv := makeStore()
 	pinIncr := 32768
@@ -1184,8 +1175,7 @@ func BenchmarkRebuild(b *testing.B) {
 }
 
 func TestCidIndex(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dstore, dserv := makeStore()
 	pinner, err := New(ctx, dstore, dserv)
@@ -1290,8 +1280,7 @@ func TestCidIndex(t *testing.T) {
 }
 
 func TestRebuild(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	dstore, dserv := makeStore()
 	pinner, err := New(ctx, dstore, dserv)

--- a/pinning/pinner/dspinner/pin_withtype_test.go
+++ b/pinning/pinner/dspinner/pin_withtype_test.go
@@ -161,8 +161,8 @@ func TestCheckIfPinnedWithType(t *testing.T) {
 	t.Run("Context cancellation during indirect check with many pins", func(t *testing.T) {
 		// Create many recursive pins to ensure we can hit the cancellation
 		nodes := make([]cid.Cid, 50)
-		for i := 0; i < 50; i++ {
-			node := mdag.NodeWithData([]byte(fmt.Sprintf("recursive node %d", i)))
+		for i := range 50 {
+			node := mdag.NodeWithData(fmt.Appendf(nil, "recursive node %d", i))
 			err = dserv.Add(ctx, node)
 			require.NoError(t, err)
 			nodes[i] = node.Cid()

--- a/pinning/remote/client/client.go
+++ b/pinning/remote/client/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/ipfs/boxo/pinning/remote/client/openapi"
@@ -82,13 +83,7 @@ func (pinLsOpts) FilterName(name string) LsOption {
 func (pinLsOpts) FilterStatus(statuses ...Status) LsOption {
 	return func(options *lsSettings) error {
 		for _, s := range statuses {
-			valid := false
-			for _, existing := range validStatuses {
-				if existing == s {
-					valid = true
-					break
-				}
-			}
+			valid := slices.Contains(validStatuses, s)
 			if !valid {
 				return fmt.Errorf("invalid status %s", s)
 			}
@@ -263,7 +258,7 @@ func (c *Client) lsInternal(ctx context.Context, settings *lsSettings) (pinResul
 	}
 	if len(settings.status) > 0 {
 		statuses := make([]openapi.Status, len(settings.status))
-		for i := 0; i < len(statuses); i++ {
+		for i := range statuses {
 			statuses[i] = openapi.Status(settings.status[i])
 		}
 		getter = getter.Status(statuses)

--- a/pinning/remote/client/openapi/api_pins.go
+++ b/pinning/remote/client/openapi/api_pins.go
@@ -95,7 +95,7 @@ Execute executes the request
 func (r apiPinsGetRequest) Execute() (PinResults, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
-		localVarPostBody     interface{}
+		localVarPostBody     any
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
@@ -230,7 +230,7 @@ Execute executes the request
 func (r apiPinsPostRequest) Execute() (PinStatus, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
-		localVarPostBody     interface{}
+		localVarPostBody     any
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
@@ -345,7 +345,7 @@ Execute executes the request
 func (r apiPinsRequestidDeleteRequest) Execute() (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
-		localVarPostBody     interface{}
+		localVarPostBody     any
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
@@ -447,7 +447,7 @@ Execute executes the request
 func (r apiPinsRequestidGetRequest) Execute() (PinStatus, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
-		localVarPostBody     interface{}
+		localVarPostBody     any
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte
@@ -565,7 +565,7 @@ Execute executes the request
 func (r apiPinsRequestidPostRequest) Execute() (PinStatus, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
-		localVarPostBody     interface{}
+		localVarPostBody     any
 		localVarFormFileName string
 		localVarFileName     string
 		localVarFileBytes    []byte

--- a/pinning/remote/client/openapi/client.go
+++ b/pinning/remote/client/openapi/client.go
@@ -105,7 +105,7 @@ func contains(haystack []string, needle string) bool {
 }
 
 // parameterToString convert interface{} parameters to string, using a delimiter if format is provided.
-func parameterToString(obj interface{}, collectionFormat string) string {
+func parameterToString(obj any, collectionFormat string) string {
 	var delimiter string
 
 	switch collectionFormat {
@@ -163,7 +163,7 @@ func (c *APIClient) GetConfig() *Configuration {
 func (c *APIClient) prepareRequest(
 	ctx context.Context,
 	path string, method string,
-	postBody interface{},
+	postBody any,
 	headerParams map[string]string,
 	queryParams url.Values,
 	formParams url.Values,
@@ -321,7 +321,7 @@ func (c *APIClient) prepareRequest(
 	return localVarRequest, nil
 }
 
-func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err error) {
+func (c *APIClient) decode(v any, b []byte, contentType string) (err error) {
 	if len(b) == 0 {
 		return nil
 	}
@@ -336,7 +336,7 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 		return nil
 	}
 	if jsonCheck.MatchString(contentType) {
-		if actualObj, ok := v.(interface{ GetActualInstance() interface{} }); ok { // oneOf, anyOf schemas
+		if actualObj, ok := v.(interface{ GetActualInstance() any }); ok { // oneOf, anyOf schemas
 			if unmarshalObj, ok := actualObj.(interface{ UnmarshalJSON([]byte) error }); ok { // make sure it has UnmarshalJSON defined
 				if err = unmarshalObj.UnmarshalJSON(b); err != nil {
 					return err
@@ -370,12 +370,12 @@ func addFile(w *multipart.Writer, fieldName, path string) error {
 }
 
 // Prevent trying to import "fmt"
-func reportError(format string, a ...interface{}) error {
+func reportError(format string, a ...any) error {
 	return fmt.Errorf(format, a...)
 }
 
 // Set request body from an interface{}
-func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err error) {
+func setBody(body any, contentType string) (bodyBuf *bytes.Buffer, err error) {
 	if bodyBuf == nil {
 		bodyBuf = &bytes.Buffer{}
 	}
@@ -406,12 +406,12 @@ func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err e
 }
 
 // detectContentType method is used to figure out `Request.Body` content type for request header
-func detectContentType(body interface{}) string {
+func detectContentType(body any) string {
 	contentType := "text/plain; charset=utf-8"
 	kind := reflect.TypeOf(body).Kind()
 
 	switch kind {
-	case reflect.Struct, reflect.Map, reflect.Ptr:
+	case reflect.Struct, reflect.Map, reflect.Pointer:
 		contentType = "application/json; charset=utf-8"
 	case reflect.String:
 		contentType = "text/plain; charset=utf-8"
@@ -432,7 +432,7 @@ type cacheControl map[string]string
 func parseCacheControl(headers http.Header) cacheControl {
 	cc := cacheControl{}
 	ccHeader := headers.Get("Cache-Control")
-	for _, part := range strings.Split(ccHeader, ",") {
+	for part := range strings.SplitSeq(ccHeader, ",") {
 		part = strings.Trim(part, " ")
 		if part == "" {
 			continue
@@ -480,7 +480,7 @@ func CacheExpires(r *http.Response) time.Time {
 type GenericOpenAPIError struct {
 	body  []byte
 	error string
-	model interface{}
+	model any
 }
 
 // Error returns non-empty string if there was an error.
@@ -494,6 +494,6 @@ func (e GenericOpenAPIError) Body() []byte {
 }
 
 // Model returns the unpacked model of the error
-func (e GenericOpenAPIError) Model() interface{} {
+func (e GenericOpenAPIError) Model() any {
 	return e.model
 }

--- a/pinning/remote/client/openapi/model_failure.go
+++ b/pinning/remote/client/openapi/model_failure.go
@@ -61,7 +61,7 @@ func (o *Failure) SetError(v FailureError) {
 }
 
 func (o Failure) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
+	toSerialize := map[string]any{}
 	if true {
 		toSerialize["error"] = o.Error
 	}

--- a/pinning/remote/client/openapi/model_failure_error.go
+++ b/pinning/remote/client/openapi/model_failure_error.go
@@ -96,7 +96,7 @@ func (o *FailureError) SetDetails(v string) {
 }
 
 func (o FailureError) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
+	toSerialize := map[string]any{}
 	if true {
 		toSerialize["reason"] = o.Reason
 	}

--- a/pinning/remote/client/openapi/model_pin.go
+++ b/pinning/remote/client/openapi/model_pin.go
@@ -164,7 +164,7 @@ func (o *Pin) SetMeta(v map[string]string) {
 }
 
 func (o Pin) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
+	toSerialize := map[string]any{}
 	if true {
 		toSerialize["cid"] = o.Cid
 	}

--- a/pinning/remote/client/openapi/model_pin_results.go
+++ b/pinning/remote/client/openapi/model_pin_results.go
@@ -89,7 +89,7 @@ func (o *PinResults) SetResults(v []PinStatus) {
 }
 
 func (o PinResults) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
+	toSerialize := map[string]any{}
 	if true {
 		toSerialize["count"] = o.Count
 	}

--- a/pinning/remote/client/openapi/model_pin_status.go
+++ b/pinning/remote/client/openapi/model_pin_status.go
@@ -203,7 +203,7 @@ func (o *PinStatus) SetInfo(v map[string]string) {
 }
 
 func (o PinStatus) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
+	toSerialize := map[string]any{}
 	if true {
 		toSerialize["requestid"] = o.Requestid
 	}

--- a/pinning/remote/client/openapi/model_status.go
+++ b/pinning/remote/client/openapi/model_status.go
@@ -12,6 +12,7 @@ package openapi
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 )
 
 // Status Status a pin object can have at a pinning service
@@ -32,11 +33,9 @@ func (v *Status) UnmarshalJSON(src []byte) error {
 		return err
 	}
 	enumTypeValue := Status(value)
-	for _, existing := range []Status{"queued", "pinning", "pinned", "failed"} {
-		if existing == enumTypeValue {
-			*v = enumTypeValue
-			return nil
-		}
+	if slices.Contains([]Status{"queued", "pinning", "pinned", "failed"}, enumTypeValue) {
+		*v = enumTypeValue
+		return nil
 	}
 
 	return fmt.Errorf("%+v is not a valid Status", value)

--- a/provider/reprovider_test.go
+++ b/provider/reprovider_test.go
@@ -308,8 +308,7 @@ func TestNewPrioritizedProvider(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			stream := NewPrioritizedProvider(newMockKeyChanFunc(tc.priority), newMockKeyChanFunc(tc.all))
 			ch, err := stream(ctx)

--- a/retrieval/state_test.go
+++ b/retrieval/state_test.go
@@ -317,7 +317,7 @@ func TestState(t *testing.T) {
 
 		// Run multiple goroutines trying to set stages in various orders
 		var wg sync.WaitGroup
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()

--- a/routing/http/filters/filters.go
+++ b/routing/http/filters/filters.go
@@ -68,7 +68,7 @@ func ApplyFiltersToIter(recordsIter iter.ResultIter[types.Record], filterAddrs, 
 		case types.SchemaPeer:
 			record, ok := v.Val.(*types.PeerRecord)
 			if !ok {
-				logger.Errorw("problem casting find providers record", "Schema", v.Val.GetSchema(), "Type", reflect.TypeOf(v).String())
+				logger.Errorw("problem casting find providers record", "Schema", v.Val.GetSchema(), "Type", reflect.TypeFor[iter.Result[types.Record]]().String())
 				// drop failed type assertion
 				return iter.Result[types.Record]{}
 			}
@@ -85,7 +85,7 @@ func ApplyFiltersToIter(recordsIter iter.ResultIter[types.Record], filterAddrs, 
 			//lint:ignore SA1019 // ignore staticcheck
 			record, ok := v.Val.(*types.BitswapRecord)
 			if !ok {
-				logger.Errorw("problem casting find providers record", "Schema", v.Val.GetSchema(), "Type", reflect.TypeOf(v).String())
+				logger.Errorw("problem casting find providers record", "Schema", v.Val.GetSchema(), "Type", reflect.TypeFor[iter.Result[types.Record]]().String())
 				// drop failed type assertion
 				return iter.Result[types.Record]{}
 			}

--- a/routing/http/internal/goroutines.go
+++ b/routing/http/internal/goroutines.go
@@ -21,9 +21,7 @@ func DoBatch[A any](ctx context.Context, maxBatchSize, maxConcurrency int, items
 	errChan := make(chan error)
 	wg := sync.WaitGroup{}
 	for range min(maxConcurrency, len(batches)) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case batch, ok := <-batchChan:
@@ -42,7 +40,7 @@ func DoBatch[A any](ctx context.Context, maxBatchSize, maxConcurrency int, items
 					return
 				}
 			}
-		}()
+		})
 	}
 
 	// work sender

--- a/routing/http/internal/goroutines_test.go
+++ b/routing/http/internal/goroutines_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func sequence(n int) (items []int) {
-	for i := 0; i < n; i++ {
+	for i := range n {
 		items = append(items, i+1)
 	}
 	return

--- a/routing/http/server/server.go
+++ b/routing/http/server/server.go
@@ -227,7 +227,7 @@ func (s *server) detectResponseType(r *http.Request) (string, error) {
 	}
 
 	for _, acceptHeader := range acceptHeaders {
-		for _, accept := range strings.Split(acceptHeader, ",") {
+		for accept := range strings.SplitSeq(acceptHeader, ",") {
 			mediaType, _, err := mime.ParseMediaType(accept)
 			if err != nil {
 				return "", fmt.Errorf("unable to parse Accept header: %w", err)

--- a/routing/mock/centralized_test.go
+++ b/routing/mock/centralized_test.go
@@ -57,7 +57,7 @@ func TestClientOverMax(t *testing.T) {
 	rs := NewServer()
 	k := cid.NewCidV0(u.Hash([]byte("hello")))
 	numProvidersForHelloKey := 100
-	for i := 0; i < numProvidersForHelloKey; i++ {
+	for range numProvidersForHelloKey {
 		pi := tnet.RandIdentityOrFatal(t)
 		err := rs.Client(pi).Provide(context.Background(), k, true)
 		if err != nil {
@@ -144,8 +144,7 @@ func TestCanceledContext(t *testing.T) {
 }
 
 func TestValidAfter(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	pi := tnet.RandIdentityOrFatal(t)
 	key := cid.NewCidV0(u.Hash([]byte("mock key")))

--- a/routing/providerquerymanager/providerquerymanager_test.go
+++ b/routing/providerquerymanager/providerquerymanager_test.go
@@ -273,7 +273,7 @@ func TestRateLimitingRequests(t *testing.T) {
 	sessionCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	var requestChannels []<-chan peer.AddrInfo
-	for i := 0; i < maxInProcessRequests+1; i++ {
+	for i := range maxInProcessRequests + 1 {
 		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i], 0))
 	}
 	time.Sleep(20 * time.Millisecond)
@@ -283,7 +283,7 @@ func TestRateLimitingRequests(t *testing.T) {
 		t.Fatal("Did not limit parallel requests to rate limit")
 	}
 	fpn.queriesMadeMutex.Unlock()
-	for i := 0; i < maxInProcessRequests+1; i++ {
+	for i := range maxInProcessRequests + 1 {
 		for range requestChannels[i] {
 		}
 	}
@@ -314,7 +314,7 @@ func TestUnlimitedRequests(t *testing.T) {
 	sessionCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	var requestChannels []<-chan peer.AddrInfo
-	for i := 0; i < inProcessRequests; i++ {
+	for i := range inProcessRequests {
 		requestChannels = append(requestChannels, providerQueryManager.FindProvidersAsync(sessionCtx, keys[i], 0))
 	}
 	time.Sleep(20 * time.Millisecond)
@@ -324,7 +324,7 @@ func TestUnlimitedRequests(t *testing.T) {
 		t.Fatal("Parallel requests appear to be rate limited")
 	}
 	fpn.queriesMadeMutex.Unlock()
-	for i := 0; i < inProcessRequests; i++ {
+	for i := range inProcessRequests {
 		for range requestChannels[i] {
 		}
 	}

--- a/tracing/exporters.go
+++ b/tracing/exporters.go
@@ -23,7 +23,7 @@ import (
 // - https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md
 func NewSpanExporters(ctx context.Context) ([]trace.SpanExporter, error) {
 	var exporters []trace.SpanExporter
-	for _, exporterStr := range strings.Split(os.Getenv("OTEL_TRACES_EXPORTER"), ",") {
+	for exporterStr := range strings.SplitSeq(os.Getenv("OTEL_TRACES_EXPORTER"), ",") {
 		switch exporterStr {
 		case "otlp":
 			protocol := "http/protobuf"


### PR DESCRIPTION
- apply go fix modernizers from Go 1.26
- require go1.25 or later
- go1.26 is required to run sharness tests