### PR TITLE
feat(routing/http/client): add WithProviderInfoFunc for lazy address resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `routing/http/client`: `WithProviderInfoFunc` option resolves provider addresses at provide-time instead of client construction time. This only impacts legacy HTTP-only custom routing setups that depend on [IPIP-526](https://github.com/ipfs/specs/pull/526) and were sending unresolved `0.0.0.0` addresses in provider records instead of actual interface addresses. [#1115](https://github.com/ipfs/boxo/pull/1115)
+
 ### Changed
 
 ### Removed

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -188,6 +188,10 @@ func WithProviderInfo(peerID peer.ID, addrs []multiaddr.Multiaddr) Option {
 	}
 }
 
+// WithProviderInfoFunc is like [WithProviderInfo] but accepts a callback that
+// is evaluated each time a provide request is made. Use this when addresses
+// may change over the lifetime of the client (e.g., resolved from a libp2p
+// host instead of static configuration).
 func WithProviderInfoFunc(peerID peer.ID, addrsFunc func() []multiaddr.Multiaddr) Option {
 	return func(c *Client) error {
 		c.peerID = peerID

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -178,6 +178,9 @@ func WithUserAgent(ua string) Option {
 	}
 }
 
+// WithProviderInfo sets the peer ID and static addresses used in provide requests.
+// Mutually exclusive with [WithProviderInfoFunc]; if both are provided,
+// [WithProviderInfoFunc] takes precedence.
 func WithProviderInfo(peerID peer.ID, addrs []multiaddr.Multiaddr) Option {
 	return func(c *Client) error {
 		c.peerID = peerID
@@ -192,6 +195,8 @@ func WithProviderInfo(peerID peer.ID, addrs []multiaddr.Multiaddr) Option {
 // is evaluated each time a provide request is made. Use this when addresses
 // may change over the lifetime of the client (e.g., resolved from a libp2p
 // host instead of static configuration).
+// Mutually exclusive with [WithProviderInfo]; if both are provided,
+// WithProviderInfoFunc takes precedence.
 func WithProviderInfoFunc(peerID peer.ID, addrsFunc func() []multiaddr.Multiaddr) Option {
 	return func(c *Client) error {
 		c.peerID = peerID

--- a/routing/http/client/client.go
+++ b/routing/http/client/client.go
@@ -69,9 +69,10 @@ type Client struct {
 	httpClient httpClient
 	accepts    string
 
-	peerID   peer.ID
-	addrs    []types.Multiaddr
-	identity crypto.PrivKey
+	peerID    peer.ID
+	addrs     []types.Multiaddr
+	addrsFunc func() []types.Multiaddr
+	identity  crypto.PrivKey
 
 	// Called immediately after signing a provide request. It is used
 	// for testing, e.g., testing the server with a mangled signature.
@@ -182,6 +183,21 @@ func WithProviderInfo(peerID peer.ID, addrs []multiaddr.Multiaddr) Option {
 		c.peerID = peerID
 		for _, a := range addrs {
 			c.addrs = append(c.addrs, types.Multiaddr{Multiaddr: a})
+		}
+		return nil
+	}
+}
+
+func WithProviderInfoFunc(peerID peer.ID, addrsFunc func() []multiaddr.Multiaddr) Option {
+	return func(c *Client) error {
+		c.peerID = peerID
+		c.addrsFunc = func() []types.Multiaddr {
+			addrs := addrsFunc()
+			out := make([]types.Multiaddr, len(addrs))
+			for i, a := range addrs {
+				out[i] = types.Multiaddr{Multiaddr: a}
+			}
+			return out
 		}
 		return nil
 	}
@@ -336,6 +352,13 @@ func (c *Client) FindProviders(ctx context.Context, key cid.Cid) (providers iter
 	return &measuringIter[iter.Result[types.Record]]{Iter: it, ctx: ctx, m: m}, nil
 }
 
+func (c *Client) providerAddrs() []types.Multiaddr {
+	if c.addrsFunc != nil {
+		return c.addrsFunc()
+	}
+	return c.addrs
+}
+
 // Deprecated: historic API from [IPIP-526], may be removed in a future version.
 //
 // [IPIP-526]: https://specs.ipfs.tech/ipips/ipip-0526/
@@ -362,7 +385,7 @@ func (c *Client) ProvideBitswap(ctx context.Context, keys []cid.Cid, ttl time.Du
 			AdvisoryTTL: &types.Duration{Duration: ttl},
 			Timestamp:   &types.Time{Time: now},
 			ID:          &c.peerID,
-			Addrs:       c.addrs,
+			Addrs:       c.providerAddrs(),
 		},
 	}
 	err := req.Sign(c.peerID, c.identity)

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -103,7 +103,9 @@ func (c *recordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func makeTestDeps(t *testing.T, clientsOpts []Option, serverOpts []server.Option) testDeps {
+type AddrResolver func() []multiaddr.Multiaddr
+
+func makeTestDeps(t *testing.T, clientsOpts []Option, serverOpts []server.Option, resolver AddrResolver) testDeps {
 	const testUserAgent = "testUserAgent"
 	peerID, addrs, identity := makeProviderAndIdentity()
 	router := &mockContentRouter{}
@@ -119,8 +121,16 @@ func makeTestDeps(t *testing.T, clientsOpts []Option, serverOpts []server.Option
 	t.Cleanup(server.Close)
 	serverAddr := "http://" + server.Listener.Addr().String()
 	recordingHTTPClient := &recordingHTTPClient{httpClient: newDefaultHTTPClient(testUserAgent)}
+
+	var providerOpt Option
+	if resolver == nil {
+		providerOpt = WithProviderInfo(peerID, addrs)
+	} else {
+		providerOpt = WithProviderInfoFunc(peerID, resolver)
+	}
+
 	defaultClientOpts := []Option{
-		WithProviderInfo(peerID, addrs),
+		providerOpt,
 		WithIdentity(identity),
 		WithHTTPClient(recordingHTTPClient),
 	}
@@ -372,7 +382,7 @@ func TestClient_FindProviders(t *testing.T) {
 				})
 			}
 
-			deps := makeTestDeps(t, clientOpts, serverOpts)
+			deps := makeTestDeps(t, clientOpts, serverOpts, nil)
 
 			deps.recordingHTTPClient.f = append(deps.recordingHTTPClient.f, onRespReceived...)
 			deps.recordingHandler.f = append(deps.recordingHandler.f, onReqReceived...)
@@ -469,7 +479,7 @@ func TestClient_Provide(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			synctest.Test(t, func(t *testing.T) {
-				deps := makeTestDeps(t, nil, nil)
+				deps := makeTestDeps(t, nil, nil, nil)
 				client := deps.client
 				router := deps.router
 
@@ -671,7 +681,7 @@ func TestClient_FindPeers(t *testing.T) {
 				})
 			}
 
-			deps := makeTestDeps(t, clientOpts, serverOpts)
+			deps := makeTestDeps(t, clientOpts, serverOpts, nil)
 
 			deps.recordingHTTPClient.f = append(deps.recordingHTTPClient.f, onRespReceived...)
 			deps.recordingHandler.f = append(deps.recordingHandler.f, onReqReceived...)
@@ -934,7 +944,7 @@ func TestClient_GetClosestPeers(t *testing.T) {
 				})
 			}
 
-			deps := makeTestDeps(t, clientOpts, serverOpts)
+			deps := makeTestDeps(t, clientOpts, serverOpts, nil)
 
 			deps.recordingHTTPClient.f = append(deps.recordingHTTPClient.f, onRespReceived...)
 			deps.recordingHandler.f = append(deps.recordingHandler.f, onReqReceived...)
@@ -1075,7 +1085,7 @@ func TestClient_IPNS(t *testing.T) {
 	t.Run("Find IPNS Record returns error if server errors", func(t *testing.T) {
 		_, name := makeName(t)
 
-		deps := makeTestDeps(t, nil, nil)
+		deps := makeTestDeps(t, nil, nil, nil)
 		client := deps.client
 		router := deps.router
 
@@ -1091,7 +1101,7 @@ func TestClient_IPNS(t *testing.T) {
 			sk, name := makeName(t)
 			record, _ := makeIPNSRecord(t, sk, opts...)
 
-			deps := makeTestDeps(t, nil, nil)
+			deps := makeTestDeps(t, nil, nil, nil)
 			client := deps.client
 			router := deps.router
 
@@ -1107,7 +1117,7 @@ func TestClient_IPNS(t *testing.T) {
 			record, _ := makeIPNSRecord(t, sk, opts...)
 			_, name2 := makeName(t)
 
-			deps := makeTestDeps(t, nil, nil)
+			deps := makeTestDeps(t, nil, nil, nil)
 			client := deps.client
 			router := deps.router
 
@@ -1122,7 +1132,7 @@ func TestClient_IPNS(t *testing.T) {
 			sk, name := makeName(t)
 			record, _ := makeIPNSRecord(t, sk, opts...)
 
-			deps := makeTestDeps(t, nil, nil)
+			deps := makeTestDeps(t, nil, nil, nil)
 			client := deps.client
 			router := deps.router
 
@@ -1139,5 +1149,40 @@ func TestClient_IPNS(t *testing.T) {
 
 	t.Run("V2 IPNS Records", func(t *testing.T) {
 		runWithRecordOptions(t, ipns.WithV1Compatibility(false))
+	})
+}
+
+func TestProviderAddrs(t *testing.T) {
+	t.Run("returns static addresses when addrsFunc is nil", func(t *testing.T) {
+		_, addrs, _ := makeProviderAndIdentity()
+
+		deps := makeTestDeps(t, nil, nil, nil)
+
+		client := deps.client
+		providerAddrs := client.providerAddrs()
+
+		require.Len(t, providerAddrs, len(addrs))
+		for i, addr := range addrs {
+			require.Equal(t, addr, providerAddrs[i].Multiaddr)
+		}
+	})
+
+	t.Run("returns dynamic addresses when addrsFunc is set", func(t *testing.T) {
+		makeProviderAndIdentity()
+		ma1, err := multiaddr.NewMultiaddr("/ip4/203.0.113.1/tcp/4001")
+		require.NoError(t, err)
+
+		addrsFunc := func() []multiaddr.Multiaddr {
+			return []multiaddr.Multiaddr{ma1}
+		}
+
+		deps := makeTestDeps(t, nil, nil, addrsFunc)
+
+		client := deps.client
+		providerAddrs := client.providerAddrs()
+
+		// Should use dynamic addresses, not static ones
+		require.Len(t, providerAddrs, 1)
+		require.Equal(t, ma1, providerAddrs[0].Multiaddr)
 	})
 }

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -1177,4 +1177,40 @@ func TestProviderAddrs(t *testing.T) {
 		require.Len(t, got, 1)
 		require.Equal(t, resolved, got[0].Multiaddr)
 	})
+
+	t.Run("ProvideBitswap sends dynamic addresses from WithProviderInfoFunc", func(t *testing.T) {
+		// Verify that addresses from WithProviderInfoFunc propagate all the
+		// way through to the HTTP request body, not just providerAddrs().
+		synctest.Test(t, func(t *testing.T) {
+			resolved, err := multiaddr.NewMultiaddr("/ip4/203.0.113.1/tcp/4001")
+			require.NoError(t, err)
+
+			deps := makeTestDeps(t, nil, nil, func() []multiaddr.Multiaddr {
+				return []multiaddr.Multiaddr{resolved}
+			})
+
+			cids := []cid.Cid{makeCID()}
+			ttl := 5 * time.Minute
+
+			//nolint:staticcheck
+			//lint:ignore SA1019 // ignore staticcheck
+			expectedReq := &server.BitswapWriteProvideRequest{
+				Keys:        cids,
+				Timestamp:   time.Now().Truncate(time.Millisecond),
+				AdvisoryTTL: ttl,
+				ID:          deps.peerID,
+				Addrs:       []multiaddr.Multiaddr{resolved},
+			}
+
+			expectedTTL := 10 * time.Minute
+			deps.router.On("ProvideBitswap", mock.Anything, expectedReq).
+				Return(expectedTTL, nil)
+
+			//nolint:staticcheck
+			//lint:ignore SA1019 // ignore staticcheck
+			advisoryTTL, err := deps.client.ProvideBitswap(context.Background(), cids, ttl)
+			require.NoError(t, err)
+			require.Equal(t, expectedTTL, advisoryTTL)
+		})
+	})
 }

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -103,9 +103,7 @@ func (c *recordingHTTPClient) Do(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-type AddrResolver func() []multiaddr.Multiaddr
-
-func makeTestDeps(t *testing.T, clientsOpts []Option, serverOpts []server.Option, resolver AddrResolver) testDeps {
+func makeTestDeps(t *testing.T, clientsOpts []Option, serverOpts []server.Option, resolver func() []multiaddr.Multiaddr) testDeps {
 	const testUserAgent = "testUserAgent"
 	peerID, addrs, identity := makeProviderAndIdentity()
 	router := &mockContentRouter{}

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -1151,36 +1151,30 @@ func TestClient_IPNS(t *testing.T) {
 }
 
 func TestProviderAddrs(t *testing.T) {
-	t.Run("returns static addresses when addrsFunc is nil", func(t *testing.T) {
-		_, addrs, _ := makeProviderAndIdentity()
-
+	t.Run("returns static addresses from WithProviderInfo", func(t *testing.T) {
+		// When constructed with WithProviderInfo, providerAddrs must return
+		// the same addresses the client was initialized with.
 		deps := makeTestDeps(t, nil, nil, nil)
+		got := deps.client.providerAddrs()
 
-		client := deps.client
-		providerAddrs := client.providerAddrs()
-
-		require.Len(t, providerAddrs, len(addrs))
-		for i, addr := range addrs {
-			require.Equal(t, addr, providerAddrs[i].Multiaddr)
+		require.Len(t, got, len(deps.addrs))
+		for i, addr := range deps.addrs {
+			require.Equal(t, addr, got[i].Multiaddr)
 		}
 	})
 
-	t.Run("returns dynamic addresses when addrsFunc is set", func(t *testing.T) {
-		makeProviderAndIdentity()
-		ma1, err := multiaddr.NewMultiaddr("/ip4/203.0.113.1/tcp/4001")
+	t.Run("returns dynamic addresses from WithProviderInfoFunc", func(t *testing.T) {
+		// When constructed with WithProviderInfoFunc, providerAddrs must call
+		// the callback and return its result instead of static addresses.
+		resolved, err := multiaddr.NewMultiaddr("/ip4/203.0.113.1/tcp/4001")
 		require.NoError(t, err)
 
-		addrsFunc := func() []multiaddr.Multiaddr {
-			return []multiaddr.Multiaddr{ma1}
-		}
+		deps := makeTestDeps(t, nil, nil, func() []multiaddr.Multiaddr {
+			return []multiaddr.Multiaddr{resolved}
+		})
+		got := deps.client.providerAddrs()
 
-		deps := makeTestDeps(t, nil, nil, addrsFunc)
-
-		client := deps.client
-		providerAddrs := client.providerAddrs()
-
-		// Should use dynamic addresses, not static ones
-		require.Len(t, providerAddrs, 1)
-		require.Equal(t, ma1, providerAddrs[0].Multiaddr)
+		require.Len(t, got, 1)
+		require.Equal(t, resolved, got[0].Multiaddr)
 	})
 }

--- a/routing/http/client/client_test.go
+++ b/routing/http/client/client_test.go
@@ -1206,8 +1206,6 @@ func TestProviderAddrs(t *testing.T) {
 			deps.router.On("ProvideBitswap", mock.Anything, expectedReq).
 				Return(expectedTTL, nil)
 
-			//nolint:staticcheck
-			//lint:ignore SA1019 // ignore staticcheck
 			advisoryTTL, err := deps.client.ProvideBitswap(context.Background(), cids, ttl)
 			require.NoError(t, err)
 			require.Equal(t, expectedTTL, advisoryTTL)


### PR DESCRIPTION
### Summary

This change was proposed by @lidel in issue ipfs/kubo#11213 to support dynamic provider address resolution for routing advertisement.

### Changes

* Add optional dynamic address resolution path for routing provider info.
* Prefer confirmed reachable addresses when host reachability metadata is available.
* Fall back to default address discovery when confirmation data is absent.

### Note

This PR references [kubo#11213](https://github.com/ipfs/kubo/issues/11213) for context but does not imply cross-repository automatic closure of the issue.
