### PR TITLE
fix(bitswap): ignore identity CIDs instead of killing connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `bitswap/server`: incoming identity CIDs in wantlist messages are now silently ignored instead of killing the connection to the remote peer. Some IPFS implementations naively send identity CIDs, and disconnecting them for it caused unnecessary churn. [#1117](https://github.com/ipfs/boxo/pull/1117)
+
 ### Security
 
 

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -4,7 +4,6 @@ package decision
 import (
 	"cmp"
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"sync"
@@ -889,7 +888,12 @@ func (e *Engine) splitWantsCancelsDenials(p peer.ID, m bsmsg.BitSwapMessage) ([]
 			continue
 		}
 		if c.Prefix().MhType == mh.IDENTITY {
-			return nil, nil, nil, errors.New("peer canceled an identity CID")
+			// Ignore identity CIDs rather than killing the connection.
+			// Some implementations naively send these without malicious
+			// intent, and peers don't update fast enough to justify
+			// disconnecting them.
+			log.Debugw("ignoring identity CID in wantlist", "local", e.self, "from", p, "cid", c)
+			continue
 		}
 
 		if et.Cancel {

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1644,36 +1644,125 @@ func TestWantlistGrowsToLimit(t *testing.T) {
 	}
 }
 
+// TestIgnoresCidsAboveLimit verifies that CIDs exceeding MaxCidSize are
+// silently dropped from wantlist messages without killing the connection.
 func TestIgnoresCidsAboveLimit(t *testing.T) {
 	const cidLimit = 64
-	warsaw := newTestEngine("warsaw", WithMaxCidSize(cidLimit))
-	defer warsaw.Engine.Close()
-	riga := newTestEngine("riga")
-	defer riga.Engine.Close()
 
-	// Send in two messages to test reslicing.
-	m := message.New(true)
-
-	m.AddEntry(blocks.NewBlock([]byte("Hæ")).Cid(), 0, pb.Message_Wantlist_Block, true)
-
-	var hash mh.Multihash
-	hash = binary.AppendUvarint(hash, mh.BLAKE3)
-	hash = binary.AppendUvarint(hash, cidLimit)
-	startOfDigest := len(hash)
-	hash = append(hash, make(mh.Multihash, cidLimit)...)
-	rand.Read(hash[startOfDigest:])
-	m.AddEntry(cid.NewCidV1(cid.Raw, hash), 0, pb.Message_Wantlist_Block, true)
-
-	warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m)
-
-	if warsaw.Peer == riga.Peer {
-		t.Fatal("Sanity Check: Peers have same Key!")
+	// mkOversizedCid builds a CIDv1 whose total byte length exceeds cidLimit.
+	mkOversizedCid := func() cid.Cid {
+		var hash mh.Multihash
+		hash = binary.AppendUvarint(hash, mh.BLAKE3)
+		hash = binary.AppendUvarint(hash, cidLimit)
+		startOfDigest := len(hash)
+		hash = append(hash, make(mh.Multihash, cidLimit)...)
+		rand.Read(hash[startOfDigest:])
+		return cid.NewCidV1(cid.Raw, hash)
 	}
 
-	wl := warsaw.Engine.WantlistForPeer(riga.Peer)
-	if len(wl) != 1 {
-		t.Fatalf("expected 1 entry in wantlist, got %d", len(wl))
-	}
+	t.Run("want-block filters oversized and keeps legitimate CID", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw", WithMaxCidSize(cidLimit))
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
+
+		legitimateCid := blocks.NewBlock([]byte("legitimate")).Cid()
+		m := message.New(true)
+		m.AddEntry(legitimateCid, 0, pb.Message_Wantlist_Block, true)
+		m.AddEntry(mkOversizedCid(), 0, pb.Message_Wantlist_Block, true)
+
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for oversized CIDs")
+		}
+
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 1 {
+			t.Fatalf("expected 1 entry in wantlist, got %d", len(wl))
+		}
+		if wl[0].Cid != legitimateCid {
+			t.Fatalf("expected legitimate CID %s in wantlist, got %s", legitimateCid, wl[0].Cid)
+		}
+	})
+
+	// want-have entries take a separate code path (haveKs) in MessageReceived.
+	t.Run("want-have filters oversized and keeps legitimate CID", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw", WithMaxCidSize(cidLimit))
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
+
+		legitimateCid := blocks.NewBlock([]byte("legitimate-have")).Cid()
+		m := message.New(true)
+		m.AddEntry(legitimateCid, 0, pb.Message_Wantlist_Have, true)
+		m.AddEntry(mkOversizedCid(), 0, pb.Message_Wantlist_Have, true)
+
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for oversized CIDs")
+		}
+
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 1 {
+			t.Fatalf("expected 1 entry in wantlist, got %d", len(wl))
+		}
+		if wl[0].Cid != legitimateCid {
+			t.Fatalf("expected legitimate CID %s in wantlist, got %s", legitimateCid, wl[0].Cid)
+		}
+	})
+
+	t.Run("oversized cancel does not affect existing wantlist", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw", WithMaxCidSize(cidLimit))
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
+
+		firstCid := blocks.NewBlock([]byte("first")).Cid()
+		m := message.New(true)
+		m.AddEntry(firstCid, 0, pb.Message_Wantlist_Block, true)
+		warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m)
+
+		// Send a second message: a new legitimate want + cancel of an oversized CID.
+		secondCid := blocks.NewBlock([]byte("second")).Cid()
+		m.Reset(false)
+		m.AddEntry(secondCid, 0, pb.Message_Wantlist_Block, true)
+		m.Cancel(mkOversizedCid())
+
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for oversized CID in cancel")
+		}
+
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 2 {
+			t.Fatalf("expected 2 entries in wantlist, got %d", len(wl))
+		}
+		if !findCid(firstCid, wl) {
+			t.Fatal("first legitimate want was removed by oversized cancel")
+		}
+		if !findCid(secondCid, wl) {
+			t.Fatal("second legitimate want was not added")
+		}
+	})
+
+	// When every entry is oversized, splitWantsCancelsDenials returns
+	// all-empty slices. Verify the engine handles this without crashing.
+	t.Run("message with only oversized CIDs", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw", WithMaxCidSize(cidLimit))
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
+
+		m := message.New(true)
+		m.AddEntry(mkOversizedCid(), 0, pb.Message_Wantlist_Block, true)
+		m.AddEntry(mkOversizedCid(), 0, pb.Message_Wantlist_Have, true)
+
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for oversized-only message")
+		}
+
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 0 {
+			t.Fatalf("expected empty wantlist, got %d entries", len(wl))
+		}
+	})
 }
 
 // TestIgnoresIdentityCid verifies that identity CIDs (multihash type IDENTITY)

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1676,7 +1676,7 @@ func TestIgnoresCidsAboveLimit(t *testing.T) {
 	}
 }
 
-func TestKillConnectionForInlineCid(t *testing.T) {
+func TestIgnoresIdentityCid(t *testing.T) {
 	warsaw := newTestEngine("warsaw")
 	defer warsaw.Engine.Close()
 	riga := newTestEngine("riga")
@@ -1686,7 +1686,6 @@ func TestKillConnectionForInlineCid(t *testing.T) {
 		t.Fatal("Sanity Check: Peers have same Key!")
 	}
 
-	// Send in two messages to test reslicing.
 	m := message.New(true)
 
 	m.AddEntry(blocks.NewBlock([]byte("Hæ")).Cid(), 0, pb.Message_Wantlist_Block, true)
@@ -1700,8 +1699,13 @@ func TestKillConnectionForInlineCid(t *testing.T) {
 	rand.Read(hash[startOfDigest:])
 	m.AddEntry(cid.NewCidV1(cid.Raw, hash), 0, pb.Message_Wantlist_Block, true)
 
-	if !warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m) {
-		t.Fatal("connection was not killed when receiving inline in cancel")
+	if warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m) {
+		t.Fatal("connection should not be killed for identity CIDs")
+	}
+
+	wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+	if len(wl) != 1 {
+		t.Fatalf("expected 1 entry in wantlist (identity CID silently ignored), got %d", len(wl))
 	}
 
 	m.Reset(true)
@@ -1709,8 +1713,8 @@ func TestKillConnectionForInlineCid(t *testing.T) {
 	m.AddEntry(blocks.NewBlock([]byte("Hæ")).Cid(), 0, pb.Message_Wantlist_Block, true)
 	m.Cancel(cid.NewCidV1(cid.Raw, hash))
 
-	if !warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m) {
-		t.Fatal("connection was not killed when receiving inline in cancel")
+	if warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m) {
+		t.Fatal("connection should not be killed for identity CID in cancel")
 	}
 }
 

--- a/bitswap/server/internal/decision/engine_test.go
+++ b/bitswap/server/internal/decision/engine_test.go
@@ -1676,46 +1676,125 @@ func TestIgnoresCidsAboveLimit(t *testing.T) {
 	}
 }
 
+// TestIgnoresIdentityCid verifies that identity CIDs (multihash type IDENTITY)
+// are silently dropped from wantlist messages instead of killing the peer
+// connection. Some IPFS implementations naively send these.
 func TestIgnoresIdentityCid(t *testing.T) {
-	warsaw := newTestEngine("warsaw")
-	defer warsaw.Engine.Close()
-	riga := newTestEngine("riga")
-	defer riga.Engine.Close()
-
-	if warsaw.Peer == riga.Peer {
-		t.Fatal("Sanity Check: Peers have same Key!")
+	// mkIdentityCid builds a CIDv1 with a random IDENTITY multihash.
+	mkIdentityCid := func() cid.Cid {
+		var hash mh.Multihash
+		hash = binary.AppendUvarint(hash, mh.IDENTITY)
+		const digestSize = 32
+		hash = binary.AppendUvarint(hash, digestSize)
+		startOfDigest := len(hash)
+		hash = append(hash, make(mh.Multihash, digestSize)...)
+		rand.Read(hash[startOfDigest:])
+		return cid.NewCidV1(cid.Raw, hash)
 	}
 
-	m := message.New(true)
+	t.Run("want-block filters identity and keeps legitimate CID", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw")
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
 
-	m.AddEntry(blocks.NewBlock([]byte("Hæ")).Cid(), 0, pb.Message_Wantlist_Block, true)
+		legitimateCid := blocks.NewBlock([]byte("legitimate")).Cid()
+		m := message.New(true)
+		m.AddEntry(legitimateCid, 0, pb.Message_Wantlist_Block, true)
+		m.AddEntry(mkIdentityCid(), 0, pb.Message_Wantlist_Block, true)
 
-	var hash mh.Multihash
-	hash = binary.AppendUvarint(hash, mh.IDENTITY)
-	const digestSize = 32
-	hash = binary.AppendUvarint(hash, digestSize)
-	startOfDigest := len(hash)
-	hash = append(hash, make(mh.Multihash, digestSize)...)
-	rand.Read(hash[startOfDigest:])
-	m.AddEntry(cid.NewCidV1(cid.Raw, hash), 0, pb.Message_Wantlist_Block, true)
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for identity CIDs")
+		}
 
-	if warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m) {
-		t.Fatal("connection should not be killed for identity CIDs")
-	}
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 1 {
+			t.Fatalf("expected 1 entry in wantlist, got %d", len(wl))
+		}
+		if wl[0].Cid != legitimateCid {
+			t.Fatalf("expected legitimate CID %s in wantlist, got %s", legitimateCid, wl[0].Cid)
+		}
+	})
 
-	wl := warsaw.Engine.WantlistForPeer(riga.Peer)
-	if len(wl) != 1 {
-		t.Fatalf("expected 1 entry in wantlist (identity CID silently ignored), got %d", len(wl))
-	}
+	// want-have entries take a separate code path (haveKs) in MessageReceived.
+	t.Run("want-have filters identity and keeps legitimate CID", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw")
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
 
-	m.Reset(true)
+		legitimateCid := blocks.NewBlock([]byte("legitimate-have")).Cid()
+		m := message.New(true)
+		m.AddEntry(legitimateCid, 0, pb.Message_Wantlist_Have, true)
+		m.AddEntry(mkIdentityCid(), 0, pb.Message_Wantlist_Have, true)
 
-	m.AddEntry(blocks.NewBlock([]byte("Hæ")).Cid(), 0, pb.Message_Wantlist_Block, true)
-	m.Cancel(cid.NewCidV1(cid.Raw, hash))
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for identity CIDs")
+		}
 
-	if warsaw.Engine.MessageReceived(context.Background(), riga.Peer, m) {
-		t.Fatal("connection should not be killed for identity CID in cancel")
-	}
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 1 {
+			t.Fatalf("expected 1 entry in wantlist, got %d", len(wl))
+		}
+		if wl[0].Cid != legitimateCid {
+			t.Fatalf("expected legitimate CID %s in wantlist, got %s", legitimateCid, wl[0].Cid)
+		}
+	})
+
+	t.Run("identity cancel does not affect existing wantlist", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw")
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
+
+		firstCid := blocks.NewBlock([]byte("first")).Cid()
+		m := message.New(true)
+		m.AddEntry(firstCid, 0, pb.Message_Wantlist_Block, true)
+		warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m)
+
+		// Send a second message: a new legitimate want + cancel of an identity CID.
+		secondCid := blocks.NewBlock([]byte("second")).Cid()
+		m.Reset(false)
+		m.AddEntry(secondCid, 0, pb.Message_Wantlist_Block, true)
+		m.Cancel(mkIdentityCid())
+
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for identity CID in cancel")
+		}
+
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 2 {
+			t.Fatalf("expected 2 entries in wantlist, got %d", len(wl))
+		}
+		if !findCid(firstCid, wl) {
+			t.Fatal("first legitimate want was removed by identity cancel")
+		}
+		if !findCid(secondCid, wl) {
+			t.Fatal("second legitimate want was not added")
+		}
+	})
+
+	// When every entry is an identity CID, splitWantsCancelsDenials returns
+	// all-empty slices. Verify the engine handles this without crashing.
+	t.Run("message with only identity CIDs", func(t *testing.T) {
+		warsaw := newTestEngine("warsaw")
+		defer warsaw.Engine.Close()
+		riga := newTestEngine("riga")
+		defer riga.Engine.Close()
+
+		m := message.New(true)
+		m.AddEntry(mkIdentityCid(), 0, pb.Message_Wantlist_Block, true)
+		m.AddEntry(mkIdentityCid(), 0, pb.Message_Wantlist_Have, true)
+
+		if warsaw.Engine.MessageReceived(t.Context(), riga.Peer, m) {
+			t.Fatal("connection should not be killed for identity-only message")
+		}
+
+		wl := warsaw.Engine.WantlistForPeer(riga.Peer)
+		if len(wl) != 0 {
+			t.Fatalf("expected empty wantlist, got %d entries", len(wl))
+		}
+	})
 }
 
 func TestWantlistBlocked(t *testing.T) {


### PR DESCRIPTION
third-party implementations may not be aware that identity CIDs should not appear in Bitswap wantlists, and their users should not be punished with dropped connections for naive CID handling.

unify behavior with oversized CIDs to reduce connection churn: silently ignore and continue processing the rest of the message.

- engine.go: replace error return with debug log + continue
- engine_test.go: flip assertions to verify no disconnect, check identity CID is silently dropped from wantlist
- (we also improved test coverage for oversized cids to follow the similar pattern)
<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
