### PR TITLE
chore(gateway): remove dead DoH resolver for .crypto TLD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The following emojis are used to highlight certain changes:
 
 ### Removed
 
+- `gateway`: removed dead DoH resolver for `.crypto` TLD (Unstoppable Domains) [#772](https://github.com/ipfs/boxo/issues/772)
 - `cmd/boxo-migrate`: removed code for go-ipfs migration -- no longer needed.
 - `cmd/deprecator`: removed code to deprecare relocated ipfs packages -- no longer needed.
 

--- a/gateway/dns.go
+++ b/gateway/dns.go
@@ -10,8 +10,7 @@ import (
 )
 
 var defaultResolvers = map[string]string{
-	"eth.":    "https://dns.eth.limo/dns-query",
-	"crypto.": "https://resolver.unstoppable.io/dns-query",
+	"eth.": "https://dns.eth.limo/dns-query",
 }
 
 func newResolver(url string, opts ...doh.Option) (madns.BasicResolver, error) {


### PR DESCRIPTION
- closes #772

this is a formality, DoH has been dead at least [since 2024](https://github.com/ipfs/boxo/issues/772#issuecomment-2560411857)