### PR TITLE
docs: add missing godoc 

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ The exhaustive list is https://github.com/ipfs/boxo/network/dependents. Some not
 3. [rainbow](https://github.com/ipfs/rainbow), a specialized IPFS gateway
 4. [ipfs-check](https://github.com/ipfs/ipfs-check), checks IPFS data availability
 5. [someguy](https://github.com/ipfs/someguy), a dedicated Delegated Routing V1 server and client
+6. [IPFS Desktop](https://github.com/ipfs/ipfs-desktop), a desktop application for running an IPFS node
 
 ### Governance and Access
 

--- a/bitswap/bitswap_test.go
+++ b/bitswap/bitswap_test.go
@@ -853,7 +853,7 @@ func TestWithScoreLedger(t *testing.T) {
 	}
 }
 
-// TestWithServerDisabled tests that BitSwap can function properly with the server disabled.
+// TestWithServerDisabled tests that Bitswap can function properly with the server disabled.
 // In this mode, it should still be able to request and receive blocks from other peers,
 // but should not respond to requests from others.
 func TestWithServerDisabled(t *testing.T) {

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -1,5 +1,7 @@
-// Package client implements the IPFS exchange interface with the BitSwap
+// Package client implements the IPFS exchange interface with the [Bitswap]
 // bilateral exchange protocol.
+//
+// [Bitswap]: https://specs.ipfs.tech/bitswap-protocol/
 package client
 
 import (

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -1,7 +1,8 @@
 // Package client implements the IPFS exchange interface with the [Bitswap]
-// bilateral exchange protocol.
+// bilateral exchange protocol (see [interaction pattern]).
 //
 // [Bitswap]: https://specs.ipfs.tech/bitswap-protocol/
+// [interaction pattern]: https://specs.ipfs.tech/bitswap-protocol/#bitswap-1-2-0-interaction-pattern
 package client
 
 import (

--- a/bitswap/client/client.go
+++ b/bitswap/client/client.go
@@ -430,7 +430,7 @@ func (bs *Client) GetBlock(ctx context.Context, k cid.Cid) (blocks.Block, error)
 }
 
 // GetBlocks returns a channel where the caller may receive blocks that
-// correspond to the provided |keys|. Returns an error if BitSwap is unable to
+// correspond to the provided |keys|. Returns an error if Bitswap is unable to
 // begin this request within the deadline enforced by the context.
 //
 // If [WithTraceBlock] option is set true, then returns a channel of

--- a/bitswap/doc.go
+++ b/bitswap/doc.go
@@ -1,0 +1,14 @@
+// Package bitswap implements the [Bitswap protocol] for exchanging blocks
+// between IPFS peers.
+//
+// [Bitswap] combines a [client.Client] for requesting blocks and a
+// [server.Server] for serving them. Create instances with [New], which
+// accepts both client and server options.
+//
+//	bs := bitswap.New(ctx, network, providerFinder, blockstore)
+//	defer bs.Close()
+//
+//	block, err := bs.GetBlock(ctx, c)
+//
+// [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+package bitswap

--- a/bitswap/doc.go
+++ b/bitswap/doc.go
@@ -1,5 +1,6 @@
 // Package bitswap implements the [Bitswap protocol] for exchanging blocks
-// between IPFS peers.
+// between IPFS peers. It supports [protocol versions] 1.0.0, 1.1.0, and
+// 1.2.0.
 //
 // [Bitswap] combines a [client.Client] for requesting blocks and a
 // [server.Server] for serving them. Create instances with [New], which
@@ -11,4 +12,5 @@
 //	block, err := bs.GetBlock(ctx, c)
 //
 // [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+// [protocol versions]: https://specs.ipfs.tech/bitswap-protocol/#bitswap-protocol-versions
 package bitswap

--- a/bitswap/message/doc.go
+++ b/bitswap/message/doc.go
@@ -1,0 +1,9 @@
+// Package message implements [Bitswap protocol] messages.
+//
+// A [BitSwapMessage] carries wantlist entries, blocks, and block presence
+// indicators (HAVE/DONT_HAVE) between peers. Messages are serialized using
+// Protocol Buffers for network transmission. Use [New] to create a message and
+// [FromNet] to decode one from a network stream.
+//
+// [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+package message

--- a/bitswap/message/doc.go
+++ b/bitswap/message/doc.go
@@ -2,8 +2,9 @@
 //
 // A [BitSwapMessage] carries wantlist entries, blocks, and block presence
 // indicators (HAVE/DONT_HAVE) between peers. Messages are serialized using
-// Protocol Buffers for network transmission. Use [New] to create a message and
-// [FromNet] to decode one from a network stream.
+// Protocol Buffers for network transmission (see [wire format]). Use [New] to
+// create a message and [FromNet] to decode one from a network stream.
 //
 // [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+// [wire format]: https://specs.ipfs.tech/bitswap-protocol/#bitswap-1-2-0-wire-format
 package message

--- a/bitswap/message/message.go
+++ b/bitswap/message/message.go
@@ -17,7 +17,7 @@ import (
 )
 
 // BitSwapMessage is the basic interface for interacting building, encoding,
-// and decoding messages sent on the BitSwap protocol.
+// and decoding messages sent on the Bitswap protocol.
 type BitSwapMessage interface {
 	FillWantlist([]Entry) []Entry
 	// Wantlist returns a slice of unique keys that represent data wanted by

--- a/bitswap/metrics/doc.go
+++ b/bitswap/metrics/doc.go
@@ -1,0 +1,4 @@
+// Package metrics provides metric constructors for Bitswap operations,
+// including histograms for received, sent, and duplicate block sizes and
+// for message send times.
+package metrics

--- a/bitswap/network/bsnet/ipfs_impl_test.go
+++ b/bitswap/network/bsnet/ipfs_impl_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/multiformats/go-multistream"
 )
 
-// Receiver is an interface for receiving messages from the GraphSyncNetwork.
+// Receiver is an interface for receiving messages from the BitSwap network.
 type receiver struct {
 	peers           map[peer.ID]struct{}
 	messageReceived chan struct{}

--- a/bitswap/network/bsnet/ipfs_impl_test.go
+++ b/bitswap/network/bsnet/ipfs_impl_test.go
@@ -24,7 +24,8 @@ import (
 	"github.com/multiformats/go-multistream"
 )
 
-// Receiver is an interface for receiving messages from the BitSwap network.
+// receiver implements the Receiver interface for receiving messages from the
+// Bitswap network.
 type receiver struct {
 	peers           map[peer.ID]struct{}
 	messageReceived chan struct{}

--- a/bitswap/network/doc.go
+++ b/bitswap/network/doc.go
@@ -4,7 +4,9 @@
 // [BitSwapNetwork] is the primary interface, providing message sending, peer
 // connectivity management, and connection events. [Receiver] handles incoming
 // messages and peer notifications. [MessageSender] supports sending a series
-// of messages to a single peer.
+// of messages to a single peer. See [protocol versions] for the supported
+// protocol identifiers.
 //
 // [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+// [protocol versions]: https://specs.ipfs.tech/bitswap-protocol/#bitswap-protocol-versions
 package network

--- a/bitswap/network/doc.go
+++ b/bitswap/network/doc.go
@@ -1,0 +1,10 @@
+// Package network defines interfaces for [Bitswap protocol] network
+// operations.
+//
+// [BitSwapNetwork] is the primary interface, providing message sending, peer
+// connectivity management, and connection events. [Receiver] handles incoming
+// messages and peer notifications. [MessageSender] supports sending a series
+// of messages to a single peer.
+//
+// [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+package network

--- a/bitswap/network/interface.go
+++ b/bitswap/network/interface.go
@@ -12,9 +12,9 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
-// BitSwapNetwork provides network connectivity for BitSwap sessions.
+// BitSwapNetwork provides network connectivity for Bitswap sessions.
 type BitSwapNetwork interface {
-	// SendMessage sends a BitSwap message to a peer.
+	// SendMessage sends a Bitswap message to a peer.
 	SendMessage(
 		context.Context,
 		peer.ID,

--- a/bitswap/server/doc.go
+++ b/bitswap/server/doc.go
@@ -1,0 +1,10 @@
+// Package server implements the [Bitswap protocol] server that handles
+// incoming block requests from peers.
+//
+// [Server] uses a decision engine to determine which blocks to send and in
+// what order. Create instances with [New] and customize behavior with [Option]
+// functions such as task worker count, peer block request filters, and score
+// ledger configuration.
+//
+// [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+package server

--- a/bitswap/server/doc.go
+++ b/bitswap/server/doc.go
@@ -1,5 +1,5 @@
 // Package server implements the [Bitswap protocol] server that handles
-// incoming block requests from peers.
+// incoming block requests from peers (see [interaction pattern]).
 //
 // [Server] uses a decision engine to determine which blocks to send and in
 // what order. Create instances with [New] and customize behavior with [Option]
@@ -7,4 +7,5 @@
 // ledger configuration.
 //
 // [Bitswap protocol]: https://specs.ipfs.tech/bitswap-protocol/
+// [interaction pattern]: https://specs.ipfs.tech/bitswap-protocol/#bitswap-1-2-0-interaction-pattern
 package server

--- a/bootstrap/doc.go
+++ b/bootstrap/doc.go
@@ -1,0 +1,7 @@
+// Package bootstrap manages network bootstrapping for IPFS nodes.
+//
+// [Bootstrap] periodically checks the number of open connections and, if below
+// [BootstrapConfig.MinPeerThreshold], connects to well-known bootstrap peers.
+// It also supports saving and restoring backup peers via [WithBackupPeers] for
+// resilience when primary bootstrap nodes are unreachable.
+package bootstrap

--- a/exchange/offline/offline.go
+++ b/exchange/offline/offline.go
@@ -1,4 +1,4 @@
-// package offline implements an object that implements the exchange
+// Package offline implements an object that implements the exchange
 // interface but returns nil values to every request.
 package offline
 

--- a/fetcher/doc.go
+++ b/fetcher/doc.go
@@ -1,0 +1,6 @@
+// Package fetcher defines interfaces for reading data from a DAG.
+//
+// A [Fetcher] traverses node graphs using IPLD selectors, optionally crossing
+// block boundaries. Reads may be local or remote, using data exchange protocols
+// like Bitswap. Use [Factory] to create session-scoped fetchers.
+package fetcher

--- a/fetcher/fetcher.go
+++ b/fetcher/fetcher.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Fetcher is an interface for reading from a dag. Reads may be local or remote, and may employ data exchange
-// protocols like graphsync and bitswap
+// protocols like bitswap
 type Fetcher interface {
 	// NodeMatching traverses a node graph starting with the provided root node using the given selector node and
 	// possibly crossing block boundaries. Each matched node is passed as FetchResult to the callback. Errors returned

--- a/files/doc.go
+++ b/files/doc.go
@@ -1,0 +1,20 @@
+// Package files provides abstractions for working with files, directories,
+// and other file-like objects.
+//
+// # Core Interfaces
+//
+// The package defines a hierarchy of interfaces:
+//
+//   - [Node]: Base interface for all file-like objects (mode, modification time, size)
+//   - [File]: A regular file with [io.Reader] and [io.Seeker]
+//   - [Directory]: Contains entries traversable via [DirIterator]
+//   - [FileInfo]: Extends [Node] with local filesystem information
+//
+// # Implementations
+//
+//   - [ReaderFile]: Wraps an [io.Reader] as a [File]
+//   - [NewSerialFile]: Reads from a local filesystem path
+//   - [WebFile]: Reads from an HTTP URL
+//   - [NewSliceDirectory]: In-memory directory from a slice of entries
+//   - [MultiFileReader]: Multipart HTTP encoding for file trees
+package files

--- a/ipld/unixfs/unixfs.go
+++ b/ipld/unixfs/unixfs.go
@@ -1,6 +1,7 @@
-// Package unixfs implements a data format for files in the IPFS filesystem It
-// is not the only format in ipfs, but it is the one that the filesystem
-// assumes
+// Package unixfs implements the [UnixFS] data format for describing files,
+// directories, and symlinks in IPFS.
+//
+// [UnixFS]: https://specs.ipfs.tech/unixfs/
 package unixfs
 
 import (

--- a/ipns/doc.go
+++ b/ipns/doc.go
@@ -1,0 +1,31 @@
+// Package ipns implements IPNS record creation, marshaling, and validation as
+// specified in the [IPNS Record] specification.
+//
+// # Records
+//
+// An IPNS [Record] maps a [Name] to a content path, with a sequence number,
+// expiration time, and TTL. Records are signed with the private key
+// corresponding to the name.
+//
+//	record, err := ipns.NewRecord(privateKey, path, seq, eol, ttl)
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	data, err := ipns.MarshalRecord(record)
+//
+// Records can be deserialized and validated:
+//
+//	record, err := ipns.UnmarshalRecord(data)
+//	err = ipns.ValidateWithName(record, name)
+//
+// # Names
+//
+// A [Name] is a multihash of a serialized public key. Names can be created
+// from peer IDs or strings:
+//
+//	name := ipns.NameFromPeer(peerID)
+//	name, err := ipns.NameFromString("k51...")
+//
+// [IPNS Record]: https://specs.ipfs.tech/ipns/ipns-record/
+package ipns

--- a/keystore/doc.go
+++ b/keystore/doc.go
@@ -1,0 +1,7 @@
+// Package keystore provides a key management interface and a filesystem-backed
+// implementation for storing cryptographic private keys.
+//
+// [FSKeystore] stores keys as individual files in a directory, with names
+// encoded using base32. Keys are written with mode 0400 and the keystore
+// directory is created with mode 0700.
+package keystore

--- a/mfs/doc.go
+++ b/mfs/doc.go
@@ -1,0 +1,19 @@
+// Package mfs implements an in-memory model of a mutable IPFS filesystem.
+//
+// The filesystem is rooted at a [Root] which contains a tree of [Directory]
+// and [File] nodes. Changes to files and directories are accumulated in
+// memory and flushed to the underlying DAG service.
+//
+// # Structure
+//
+//   - [Root]: Top-level entry point, created via [NewRoot], with optional
+//     republishing of the root CID on changes
+//   - [Directory]: A mutable directory that maps names to child nodes
+//   - [File]: A mutable file backed by a UnixFS DAG
+//
+// # Filesystem Operations
+//
+// Top-level functions [Mv], [Lookup], and [FlushPath] operate on paths within
+// the MFS tree. Directories support adding, removing, and listing entries.
+// Files support reading and writing through [FileDescriptor].
+package mfs

--- a/mfs/root.go
+++ b/mfs/root.go
@@ -1,6 +1,3 @@
-// package mfs implements an in memory model of a mutable IPFS filesystem.
-// TODO: Develop on this line (and move it to `doc.go`).
-
 package mfs
 
 import (

--- a/namesys/namesys.go
+++ b/namesys/namesys.go
@@ -3,13 +3,16 @@
 // IPNS path becomes an /ipfs/<cid> path.
 //
 // Traditionally, these paths would be in the form of /ipns/peer_id, which
-// references an IPNS record in a distributed ValueStore (usually the IPFS
+// references an [IPNS record] in a distributed ValueStore (usually the IPFS
 // DHT).
 //
 // Additionally, the /ipns/ namespace can also be used with domain names that
-// use DNSLink (/ipns/<dnslink_name>, https://docs.ipfs.io/concepts/dnslink/)
+// use [DNSLink].
 //
 // The package provides implementations for all three resolvers.
+//
+// [IPNS record]: https://specs.ipfs.tech/ipns/ipns-record/
+// [DNSLink]: https://docs.ipfs.tech/concepts/dnslink/
 package namesys
 
 import (

--- a/peering/doc.go
+++ b/peering/doc.go
@@ -1,0 +1,7 @@
+// Package peering maintains persistent connections to specified peers.
+//
+// [PeeringService] automatically reconnects to registered peers when
+// disconnected, using exponential backoff up to 10 minutes between attempts.
+// Peers can be added and removed at any time, including before the service is
+// started.
+package peering

--- a/routing/http/client/doc.go
+++ b/routing/http/client/doc.go
@@ -1,0 +1,30 @@
+// Package client implements an HTTP client for the [Delegated Routing V1] API
+// (IPIP-337).
+//
+// The client supports finding content providers, peers, IPNS records, and
+// closest DHT peers. Responses can be streamed as NDJSON or returned as plain
+// JSON.
+//
+// # Basic Usage
+//
+//	c, err := client.New("https://delegated-ipfs.dev")
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	providers, err := c.FindProviders(ctx, cid)
+//
+// # Options
+//
+// The client can be customized with functional options:
+//
+//   - [WithHTTPClient]: Use a custom [http.Client]
+//   - [WithUserAgent]: Set the User-Agent header
+//   - [WithIdentity]: Set a private key for authenticated requests
+//   - [WithProtocolFilter]: Filter results by transport protocol
+//   - [WithAddrFilter]: Filter results by multiaddr pattern
+//   - [WithProviderInfo]: Set peer ID and addresses for provide requests
+//   - [WithDisabledLocalFiltering]: Skip client-side filtering of results
+//
+// [Delegated Routing V1]: https://specs.ipfs.tech/routing/http-routing-v1/
+package client

--- a/routing/http/server/doc.go
+++ b/routing/http/server/doc.go
@@ -1,0 +1,29 @@
+// Package server implements an HTTP server for the [Delegated Routing V1] API
+// (IPIP-337).
+//
+// The server handles requests for content providers, peer records, IPNS
+// records, and DHT closest peers. It supports both JSON and streaming NDJSON
+// response formats.
+//
+// # Basic Usage
+//
+//	router := ... // your DelegatedRouter implementation
+//	handler := server.Handler(router)
+//	http.ListenAndServe(":8080", handler)
+//
+// # Options
+//
+//   - [WithStreamingResultsDisabled]: Return only JSON, no NDJSON streaming
+//   - [WithRecordsLimit]: Maximum records per non-streaming response (default: 20)
+//   - [WithStreamingRecordsLimit]: Maximum records per streaming response (default: unlimited)
+//   - [WithRoutingTimeout]: Timeout for routing operations (default: 30s)
+//   - [WithPrometheusRegistry]: Enable Prometheus metrics
+//
+// # DelegatedRouter Interface
+//
+// Implement [DelegatedRouter] to provide the routing backend. The interface
+// covers finding providers, finding peers, IPNS get/put, and DHT closest
+// peers.
+//
+// [Delegated Routing V1]: https://specs.ipfs.tech/routing/http-routing-v1/
+package server

--- a/tar/doc.go
+++ b/tar/doc.go
@@ -1,0 +1,7 @@
+// Package tar extracts tar archives to the local filesystem.
+//
+// [Extractor] handles tar files containing regular files, directories, and
+// symlinks. Archives must have either a single root file or symlink, or all
+// entries nested under a single root directory. File modes and modification
+// times from the archive are preserved.
+package tar

--- a/tracing/doc.go
+++ b/tracing/doc.go
@@ -1,0 +1,14 @@
+// Package tracing creates OpenTelemetry span exporters from environment
+// variables.
+//
+// [NewSpanExporters] reads OTEL_TRACES_EXPORTER and returns the corresponding
+// exporters. Supported values:
+//
+//   - "otlp": OTLP exporter (protocol selected by OTEL_EXPORTER_OTLP_PROTOCOL,
+//     defaults to "http/protobuf"; also supports "grpc")
+//   - "stdout": Pretty-printed traces on standard output
+//   - "file": JSON traces written to OTEL_EXPORTER_FILE_PATH (defaults to traces.json)
+//   - "none": Disables trace export
+//
+// Multiple exporters can be enabled by separating values with commas.
+package tracing

--- a/verifcid/doc.go
+++ b/verifcid/doc.go
@@ -1,0 +1,13 @@
+// Package verifcid validates CIDs against configurable hash function
+// allowlists.
+//
+// [ValidateCid] checks that a CID's multihash uses an allowed hash function
+// and that the digest size falls within the permitted range. The
+// [DefaultAllowlist] permits common secure hash functions (SHA2, SHA3, BLAKE2,
+// BLAKE3) and identity CIDs with constrained digest sizes.
+//
+// # Custom Allowlists
+//
+// Use [NewAllowlist] to build a custom set of allowed hash functions, or
+// [NewOverridingAllowlist] to extend an existing allowlist with overrides.
+package verifcid


### PR DESCRIPTION
Docs-only, this PR 
- adds missing top level package descriptions for packages without descriptions on pkg.go.dev  (https://pkg.go.dev/github.com/ipfs/boxo)
- adds links to relevant docs and specs so LLMs hallucinate less

