### PR TITLE
fix(bitswap/httpnet): infer default port for portless HTTP multiaddrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `bitswap/server`: incoming identity CIDs in wantlist messages are now silently ignored instead of killing the connection to the remote peer. Some IPFS implementations naively send identity CIDs, and disconnecting them for it caused unnecessary churn. [#1117](https://github.com/ipfs/boxo/pull/1117)
+- `bitswap/network`: `ExtractHTTPAddress` now infers default ports for portless HTTP multiaddrs (e.g. `/dns/host/https` without `/tcp/443`). [#1123](https://github.com/ipfs/boxo/pull/1123)
 
 ### Security
 

--- a/bitswap/network/http_multiaddr.go
+++ b/bitswap/network/http_multiaddr.go
@@ -57,12 +57,35 @@ func ExtractHTTPAddress(ma multiaddr.Multiaddr) (ParsedURL, error) {
 		}
 	}
 
+	// Default well-known ports when schema is set but port is missing.
+	// This handles shorthand multiaddrs like /dns/example.com/https
+	// where the /tcp/443 component is omitted.
+	if port == "" {
+		switch schema {
+		case "https":
+			port = "443"
+		case "http":
+			port = "80"
+		}
+	}
+
 	if host == "" || port == "" || schema == "" {
 		return ParsedURL{}, fmt.Errorf("multiaddress is missing required components (host/port/schema)")
 	}
 
-	// Construct the URL object
-	address := fmt.Sprintf("%s://%s:%s", schema, host, port)
+	// Construct the URL object.
+	// Omit the port when it matches the schema default to produce
+	// canonical URLs. This ensures the HTTP client sends a clean Host
+	// header (e.g. "example.com" instead of "example.com:443") and
+	// avoids sharding HTTP caches on providers that key on Host,
+	// as well as issues with reverse proxies or redirects that fail
+	// to match when an explicit default port is present.
+	var address string
+	if (schema == "https" && port == "443") || (schema == "http" && port == "80") {
+		address = fmt.Sprintf("%s://%s", schema, host)
+	} else {
+		address = fmt.Sprintf("%s://%s:%s", schema, host, port)
+	}
 	pURL, err := url.Parse(address)
 	if err != nil {
 		return ParsedURL{}, fmt.Errorf("failed to parse URL: %w", err)

--- a/bitswap/network/http_multiaddr_test.go
+++ b/bitswap/network/http_multiaddr_test.go
@@ -30,7 +30,7 @@ func TestExtractHTTPAddress(t *testing.T) {
 			maStr: "/dns4/example.com/tcp/443/https",
 			want: &url.URL{
 				Scheme: "https",
-				Host:   "example.com:443",
+				Host:   "example.com",
 			},
 			expectErr: false,
 		},
@@ -39,7 +39,7 @@ func TestExtractHTTPAddress(t *testing.T) {
 			maStr: "/dns6/example.com/tcp/443/https",
 			want: &url.URL{
 				Scheme: "https",
-				Host:   "example.com:443",
+				Host:   "example.com",
 			},
 			expectErr: false,
 		},
@@ -48,16 +48,16 @@ func TestExtractHTTPAddress(t *testing.T) {
 			maStr: "/dns/example.com/tcp/443/https",
 			want: &url.URL{
 				Scheme: "https",
-				Host:   "example.com:443",
+				Host:   "example.com",
 			},
 			expectErr: false,
 		},
 		{
-			name:  "Valid HTTPS multiaddress with DNS",
+			name:  "Valid HTTPS multiaddress with DNS (dns4)",
 			maStr: "/dns4/example.com/tcp/443/https",
 			want: &url.URL{
 				Scheme: "https",
-				Host:   "example.com:443",
+				Host:   "example.com",
 			},
 			expectErr: false,
 		},
@@ -77,10 +77,59 @@ func TestExtractHTTPAddress(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "Missing port",
+			name:      "HTTP without port on non-local DNS rejects (no TLS)",
 			maStr:     "/dns4/example.com/http",
 			want:      nil,
-			expectErr: true,
+			expectErr: true, // default port 80 is inferred, but rejected: non-local without TLS
+		},
+		{
+			name:  "HTTPS non-default port preserved",
+			maStr: "/dns4/example.com/tcp/8443/https",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "example.com:8443",
+			},
+			expectErr: false,
+		},
+		// Regression tests: some HTTP providers advertise /dns/host/https
+		// without the /tcp/443 component. Port 443 must be inferred for
+		// https and port 80 for http to match the behavior of browsers
+		// and curl.
+		{
+			name:  "HTTPS without tcp component infers port 443 (dns)",
+			maStr: "/dns/example.com/https",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "example.com",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "HTTPS without tcp component infers port 443 (dns4)",
+			maStr: "/dns4/example.net/https",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "example.net",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "HTTPS without tcp component infers port 443 (dns6)",
+			maStr: "/dns6/example.net/https",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "example.net",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "HTTP without tcp component infers port 80 (loopback)",
+			maStr: "/ip4/127.0.0.1/http",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "127.0.0.1",
+			},
+			expectErr: false,
 		},
 		{
 			name:      "Invalid multiaddress",
@@ -117,7 +166,7 @@ func TestExtractHTTPAddress(t *testing.T) {
 			maStr: "/dns4/example.com/tcp/443/tls/sni/example2.com/http",
 			want: &url.URL{
 				Scheme: "https",
-				Host:   "example.com:443",
+				Host:   "example.com",
 			},
 			sni:       "example2.com",
 			expectErr: false,
@@ -188,6 +237,47 @@ func TestExtractHTTPAddressesFromPeer(t *testing.T) {
 				Addrs: []multiaddr.Multiaddr{},
 			},
 			want: nil,
+		},
+		{
+			name: "HTTPS without tcp component (portless multiaddr)",
+			peerInfo: &peer.AddrInfo{
+				ID: "12D3KooWQrKv5jtT5anTrKjwgb5dkt7DYHhTT9JzLs7dABZ1mkTf",
+				Addrs: []multiaddr.Multiaddr{
+					multiaddr.StringCast("/dns/example.com/https"),
+					multiaddr.StringCast("/dns/example.net/https"),
+				},
+			},
+			want: []*url.URL{
+				{
+					Scheme: "https",
+					Host:   "example.com",
+				},
+				{
+					Scheme: "https",
+					Host:   "example.net",
+				},
+			},
+		},
+		{
+			name: "Mix of explicit port and inferred port",
+			peerInfo: &peer.AddrInfo{
+				ID: "12D3KooWQrKv5jtT5anTrKjwgb5dkt7DYHhTT9JzLs7dABZ1mkTf",
+				Addrs: []multiaddr.Multiaddr{
+					multiaddr.StringCast("/dns/example.com/tcp/443/https"),
+					multiaddr.StringCast("/dns/example.net/https"),
+					multiaddr.StringCast("/ip4/127.0.0.1/tcp/9000"), // Non-HTTP
+				},
+			},
+			want: []*url.URL{
+				{
+					Scheme: "https",
+					Host:   "example.com",
+				},
+				{
+					Scheme: "https",
+					Host:   "example.net",
+				},
+			},
 		},
 	}
 

--- a/bitswap/network/http_multiaddr_test.go
+++ b/bitswap/network/http_multiaddr_test.go
@@ -91,6 +91,35 @@ func TestExtractHTTPAddress(t *testing.T) {
 			},
 			expectErr: false,
 		},
+		// Mismatched default ports: port must be preserved when it does
+		// not match the schema default (e.g. http+443, https+80).
+		{
+			name:  "HTTP with port 443 preserves port (non-local, errors)",
+			maStr: "/dns/example.com/tcp/443/http",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "example.com:443",
+			},
+			expectErr: true, // non-local without TLS
+		},
+		{
+			name:  "HTTPS with port 80 preserves port",
+			maStr: "/dns/example.com/tcp/80/https",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "example.com:80",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "HTTP with port 443 on loopback preserves port",
+			maStr: "/ip4/127.0.0.1/tcp/443/http",
+			want: &url.URL{
+				Scheme: "http",
+				Host:   "127.0.0.1:443",
+			},
+			expectErr: false,
+		},
 		// Regression tests: some HTTP providers advertise /dns/host/https
 		// without the /tcp/443 component. Port 443 must be inferred for
 		// https and port 80 for http to match the behavior of browsers

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -510,10 +510,7 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	// Filter addresses based on allow and denylists
 	var filteredURLs []network.ParsedURL
 	for _, u := range urls {
-		host, _, err := net.SplitHostPort(u.URL.Host)
-		if err != nil {
-			return err
-		}
+		host := u.URL.Hostname()
 
 		// Filter out if allowlist is enabled and it is not allowed,
 		// OR if host is in denylist.

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"slices"
 	"strconv"
@@ -292,7 +291,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 
 	sender.ht.metrics.ResponseSizes.Observe(float64(respLen))
 	sender.ht.metrics.RequestsInFlight.Dec()
-	host, _, _ := net.SplitHostPort(u.URL.Host)
+	host := u.URL.Hostname()
 	// updateStatusCounter
 	sender.ht.metrics.updateStatusCounter(req.Method, statusCode, host)
 


### PR DESCRIPTION
HTTP providers advertising `/dns/host/https` without a `/tcp/443` component were silently rejected because `ExtractHTTPAddress` required an explicit port. (cc @aschmahmann)

- infer port 443 for https and 80 for http when tcp/udp is absent
- produce canonical URLs without default port to avoid cache sharding, reverse-proxy mismatches, and redirect failures
- use `url.Hostname()` instead of `net.SplitHostPort` in `httpnet` `Connect` and `msg_sender` so portless `URL.Host` values don't error

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
