### PR TITLE
feat(gateway): add content size limits for responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
-- `gateway`: `Config.MaxDeserializedResponseSize` allows setting a maximum file/directory size for deserialized gateway responses. Content exceeding this limit returns `501 Not Implemented`, directing users to run their own IPFS node. Trustless response formats (`application/vnd.ipld.raw`, `application/vnd.ipld.car`) are not affected. The size is read from the UnixFS root block, so no extra block fetches are needed for the check. [#1138](https://github.com/ipfs/boxo/pull/1138)
-- `gateway`: `Config.MaxUnixFSDAGResponseSize` allows setting a maximum content size applied to all response formats (deserialized, raw blocks, CAR, TAR). Content exceeding this limit returns `501 Not Implemented`. For most handlers the check reuses size information already available in the request path; for CAR responses a lightweight `Head` call is made only when the limit is configured. [#1138](https://github.com/ipfs/boxo/pull/1138)
+- `gateway`: `Config.MaxDeserializedResponseSize` allows setting a maximum file/directory size for deserialized gateway responses. Content exceeding this limit returns `410 Gone`, directing users to run their own IPFS node. Trustless response formats (`application/vnd.ipld.raw`, `application/vnd.ipld.car`) are not affected. The size is read from the UnixFS root block, so no extra block fetches are needed for the check. [#1138](https://github.com/ipfs/boxo/pull/1138)
+- `gateway`: `Config.MaxUnixFSDAGResponseSize` allows setting a maximum content size applied to all response formats (deserialized, raw blocks, CAR, TAR). Content exceeding this limit returns `410 Gone`. For most handlers the check reuses size information already available in the request path; for CAR responses a lightweight `Head` call is made only when the limit is configured. [#1138](https://github.com/ipfs/boxo/pull/1138)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `gateway`: `Config.MaxDeserializedResponseSize` allows setting a maximum file/directory size for deserialized gateway responses. Content exceeding this limit returns `501 Not Implemented`, directing users to run their own IPFS node. Trustless response formats (`application/vnd.ipld.raw`, `application/vnd.ipld.car`) are not affected. The size is read from the UnixFS root block, so no extra block fetches are needed for the check. [#1138](https://github.com/ipfs/boxo/pull/1138)
+- `gateway`: `Config.MaxUnixFSDAGResponseSize` allows setting a maximum content size applied to all response formats (deserialized, raw blocks, CAR, TAR). Content exceeding this limit returns `501 Not Implemented`. For most handlers the check reuses size information already available in the request path; for CAR responses a lightweight `Head` call is made only when the limit is configured. [#1138](https://github.com/ipfs/boxo/pull/1138)
+
 ### Changed
 
 ### Removed

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -153,9 +153,9 @@ type Config struct {
 	// MaxDeserializedResponseSize is the maximum file or directory DAG size
 	// in bytes for deserialized responses. When set to a value greater than 0,
 	// requests for UnixFS content larger than this limit will return
-	// 501 Not Implemented, directing users to run their own IPFS node for
-	// large content. This applies to both regular and range requests: if the
-	// underlying file exceeds the limit, even a small range is rejected.
+	// 410 Gone, directing users to run their own IPFS node for large content.
+	// This applies to both regular and range requests: if the underlying file
+	// exceeds the limit, even a small range is rejected.
 	// No additional block fetches are needed; size is already available from
 	// the request's normal processing of the UnixFS root block.
 	// A value of 0 disables this limit. Only affects deserialized responses;
@@ -166,9 +166,9 @@ type Config struct {
 	// MaxUnixFSDAGResponseSize is the maximum UnixFS file or directory DAG
 	// size in bytes, applied to all response formats: deserialized, raw
 	// blocks, CAR, and TAR. When set to a value greater than 0, any request
-	// whose resolved content exceeds this limit will return
-	// 501 Not Implemented, regardless of response format. This allows
-	// gateway operators to cap bandwidth across all response types.
+	// whose resolved content exceeds this limit will return 410 Gone,
+	// regardless of response format. This allows gateway operators to cap
+	// bandwidth across all response types.
 	// Most handlers reuse the size already available from normal request
 	// processing; the CAR handler performs a lightweight Head call (root
 	// block is then cached for the subsequent CAR traversal).

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -150,6 +150,31 @@ type Config struct {
 	// (e.g., Cloudflare's 5GB limit). A value of 0 disables this limit.
 	MaxRangeRequestFileSize int64
 
+	// MaxDeserializedResponseSize is the maximum file or directory DAG size
+	// in bytes for deserialized responses. When set to a value greater than 0,
+	// requests for UnixFS content larger than this limit will return
+	// 501 Not Implemented, directing users to run their own IPFS node for
+	// large content. This applies to both regular and range requests: if the
+	// underlying file exceeds the limit, even a small range is rejected.
+	// No additional block fetches are needed; size is already available from
+	// the request's normal processing of the UnixFS root block.
+	// A value of 0 disables this limit. Only affects deserialized responses;
+	// trustless formats (application/vnd.ipld.raw, application/vnd.ipld.car)
+	// are not affected.
+	MaxDeserializedResponseSize int64
+
+	// MaxUnixFSDAGResponseSize is the maximum UnixFS file or directory DAG
+	// size in bytes, applied to all response formats: deserialized, raw
+	// blocks, CAR, and TAR. When set to a value greater than 0, any request
+	// whose resolved content exceeds this limit will return
+	// 501 Not Implemented, regardless of response format. This allows
+	// gateway operators to cap bandwidth across all response types.
+	// Most handlers reuse the size already available from normal request
+	// processing; the CAR handler performs a lightweight Head call (root
+	// block is then cached for the subsequent CAR traversal).
+	// A value of 0 disables this limit.
+	MaxUnixFSDAGResponseSize int64
+
 	// MaxRequestDuration is the maximum total time a request can take.
 	// Unlike RetrievalTimeout (which resets on each data write and catches
 	// stalled transfers), this is an absolute deadline for the entire request.

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1640,6 +1640,290 @@ func TestMaxRangeRequestFileSize(t *testing.T) {
 	})
 }
 
+func TestMaxDeserializedResponseSize(t *testing.T) {
+	backend, root := newMockBackend(t, "fixtures.car")
+
+	// "fnord" file is 5 bytes, lives at subdir/fnord
+	p, err := path.Join(path.FromCid(root), "subdir", "fnord")
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	k, err := backend.resolvePathNoRootsReturned(ctx, p)
+	require.NoError(t, err)
+
+	t.Run("GET exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 4, // smaller than "fnord" (5 bytes)
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "not supported for content larger than 4 bytes")
+		require.Contains(t, string(body), "https://docs.ipfs.tech/install/")
+	})
+
+	t.Run("range request for file exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 4, // smaller than "fnord" (5 bytes)
+		})
+
+		// Even though range is only 2 bytes, the file itself is 5 bytes
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+		req.Header.Set("Range", "bytes=0-1")
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "not supported for content larger than 4 bytes")
+	})
+
+	t.Run("HEAD exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodHead, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+	})
+
+	t.Run("GET within limit works", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 1000,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "fnord", string(body))
+	})
+
+	t.Run("disabled when set to 0", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 0,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "fnord", string(body))
+	})
+
+	t.Run("raw format query param bypasses limit", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 1, // 1 byte, way below any content
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String()+"?format=raw", nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("raw Accept header bypasses limit", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 1,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/vnd.ipld.raw")
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("car format query param bypasses limit", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 1,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String()+"?format=car", nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+	})
+
+	t.Run("car Accept header bypasses limit", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:       true,
+			MaxDeserializedResponseSize: 1,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/vnd.ipld.car")
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+	})
+}
+
+func TestMaxUnixFSDAGResponseSize(t *testing.T) {
+	backend, root := newMockBackend(t, "fixtures.car")
+
+	// "fnord" file is 5 bytes, lives at subdir/fnord
+	p, err := path.Join(path.FromCid(root), "subdir", "fnord")
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	k, err := backend.resolvePathNoRootsReturned(ctx, p)
+	require.NoError(t, err)
+
+	t.Run("deserialized GET exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Contains(t, string(body), "not supported for content larger than 4 bytes")
+		require.Contains(t, string(body), "https://docs.ipfs.tech/install/")
+	})
+
+	t.Run("deserialized range request for file exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+		req.Header.Set("Range", "bytes=0-1")
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+	})
+
+	t.Run("raw format exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String()+"?format=raw", nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+	})
+
+	t.Run("raw Accept header exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/vnd.ipld.raw")
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+	})
+
+	t.Run("car format exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String()+"?format=car", nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+	})
+
+	t.Run("car Accept header exceeding limit returns 501", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 4,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/vnd.ipld.car")
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+	})
+
+	t.Run("GET within limit works", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 1000,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "fnord", string(body))
+	})
+
+	t.Run("disabled when set to 0", func(t *testing.T) {
+		ts := newTestServerWithConfig(t, backend, Config{
+			DeserializedResponses:    true,
+			MaxUnixFSDAGResponseSize: 0,
+		})
+
+		req, err := http.NewRequest(http.MethodGet, ts.URL+k.String(), nil)
+		require.NoError(t, err)
+
+		res := mustDoWithoutRedirect(t, req)
+		require.Equal(t, http.StatusOK, res.StatusCode)
+
+		body, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		require.Equal(t, "fnord", string(body))
+	})
+}
+
 func TestValidateConfig_MaxRequestDuration(t *testing.T) {
 	t.Parallel()
 

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1652,7 +1652,7 @@ func TestMaxDeserializedResponseSize(t *testing.T) {
 	k, err := backend.resolvePathNoRootsReturned(ctx, p)
 	require.NoError(t, err)
 
-	t.Run("GET exceeding limit returns 501", func(t *testing.T) {
+	t.Run("GET exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:       true,
 			MaxDeserializedResponseSize: 4, // smaller than "fnord" (5 bytes)
@@ -1662,7 +1662,8 @@ func TestMaxDeserializedResponseSize(t *testing.T) {
 		require.NoError(t, err)
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
+		require.Equal(t, cacheControlSizeLimit, res.Header.Get("Cache-Control"))
 
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
@@ -1670,7 +1671,7 @@ func TestMaxDeserializedResponseSize(t *testing.T) {
 		require.Contains(t, string(body), "https://docs.ipfs.tech/install/")
 	})
 
-	t.Run("range request for file exceeding limit returns 501", func(t *testing.T) {
+	t.Run("range request for file exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:       true,
 			MaxDeserializedResponseSize: 4, // smaller than "fnord" (5 bytes)
@@ -1682,14 +1683,14 @@ func TestMaxDeserializedResponseSize(t *testing.T) {
 		req.Header.Set("Range", "bytes=0-1")
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
 		require.Contains(t, string(body), "not supported for content larger than 4 bytes")
 	})
 
-	t.Run("HEAD exceeding limit returns 501", func(t *testing.T) {
+	t.Run("HEAD exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:       true,
 			MaxDeserializedResponseSize: 4,
@@ -1699,7 +1700,7 @@ func TestMaxDeserializedResponseSize(t *testing.T) {
 		require.NoError(t, err)
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 	})
 
 	t.Run("GET within limit works", func(t *testing.T) {
@@ -1803,7 +1804,7 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 	k, err := backend.resolvePathNoRootsReturned(ctx, p)
 	require.NoError(t, err)
 
-	t.Run("deserialized GET exceeding limit returns 501", func(t *testing.T) {
+	t.Run("deserialized GET exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:    true,
 			MaxUnixFSDAGResponseSize: 4,
@@ -1813,7 +1814,8 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		require.NoError(t, err)
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
+		require.Equal(t, cacheControlSizeLimit, res.Header.Get("Cache-Control"))
 
 		body, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
@@ -1821,7 +1823,7 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		require.Contains(t, string(body), "https://docs.ipfs.tech/install/")
 	})
 
-	t.Run("deserialized range request for file exceeding limit returns 501", func(t *testing.T) {
+	t.Run("deserialized range request for file exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:    true,
 			MaxUnixFSDAGResponseSize: 4,
@@ -1832,10 +1834,10 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		req.Header.Set("Range", "bytes=0-1")
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 	})
 
-	t.Run("raw format exceeding limit returns 501", func(t *testing.T) {
+	t.Run("raw format exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:    true,
 			MaxUnixFSDAGResponseSize: 4,
@@ -1845,10 +1847,10 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		require.NoError(t, err)
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 	})
 
-	t.Run("raw Accept header exceeding limit returns 501", func(t *testing.T) {
+	t.Run("raw Accept header exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:    true,
 			MaxUnixFSDAGResponseSize: 4,
@@ -1859,10 +1861,10 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		req.Header.Set("Accept", "application/vnd.ipld.raw")
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 	})
 
-	t.Run("car format exceeding limit returns 501", func(t *testing.T) {
+	t.Run("car format exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:    true,
 			MaxUnixFSDAGResponseSize: 4,
@@ -1872,10 +1874,10 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		require.NoError(t, err)
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 	})
 
-	t.Run("car Accept header exceeding limit returns 501", func(t *testing.T) {
+	t.Run("car Accept header exceeding limit returns 410", func(t *testing.T) {
 		ts := newTestServerWithConfig(t, backend, Config{
 			DeserializedResponses:    true,
 			MaxUnixFSDAGResponseSize: 4,
@@ -1886,7 +1888,7 @@ func TestMaxUnixFSDAGResponseSize(t *testing.T) {
 		req.Header.Set("Accept", "application/vnd.ipld.car")
 
 		res := mustDoWithoutRedirect(t, req)
-		require.Equal(t, http.StatusNotImplemented, res.StatusCode)
+		require.Equal(t, http.StatusGone, res.StatusCode)
 	})
 
 	t.Run("GET within limit works", func(t *testing.T) {

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -1126,25 +1126,36 @@ func (i *handler) webError(w http.ResponseWriter, r *http.Request, err error, de
 	webError(w, r, i.config, err, defaultCode)
 }
 
+// cacheControlSizeLimit is the Cache-Control header for responses rejected by
+// content size limits (MaxDeserializedResponseSize, MaxUnixFSDAGResponseSize).
+// Fresh for 1 week, serve stale for up to 31 days while revalidating in the
+// background. Uses 410 Gone which is heuristically cacheable per RFC 9110 and
+// cached by CDNs (Cloudflare, Fastly) by default.
+const cacheControlSizeLimit = "public, max-age=604800, stale-while-revalidate=2678400"
+
 // exceedsMaxUnixFSDAGResponseSize checks whether sz exceeds the configured
-// MaxUnixFSDAGResponseSize. If it does, it writes a 501 error and returns true.
-// Returns false (no-op) when the limit is disabled or not exceeded.
+// MaxUnixFSDAGResponseSize. If it does, it writes a cacheable 410 Gone
+// response and returns true. Returns false (no-op) when the limit is disabled
+// or not exceeded.
 func (i *handler) exceedsMaxUnixFSDAGResponseSize(w http.ResponseWriter, r *http.Request, sz int64) bool {
 	if i.config.MaxUnixFSDAGResponseSize > 0 && sz > i.config.MaxUnixFSDAGResponseSize {
 		err := fmt.Errorf("responses are not supported for content larger than %d bytes: for large content, run your own IPFS node (https://docs.ipfs.tech/install/)", i.config.MaxUnixFSDAGResponseSize)
-		i.webError(w, r, err, http.StatusNotImplemented)
+		w.Header().Set("Cache-Control", cacheControlSizeLimit)
+		i.webError(w, r, err, http.StatusGone)
 		return true
 	}
 	return false
 }
 
 // exceedsMaxDeserializedResponseSize checks whether sz exceeds the configured
-// MaxDeserializedResponseSize. If it does, it writes a 501 error and returns true.
-// Returns false (no-op) when the limit is disabled or not exceeded.
+// MaxDeserializedResponseSize. If it does, it writes a cacheable 410 Gone
+// response and returns true. Returns false (no-op) when the limit is disabled
+// or not exceeded.
 func (i *handler) exceedsMaxDeserializedResponseSize(w http.ResponseWriter, r *http.Request, sz int64) bool {
 	if i.config.MaxDeserializedResponseSize > 0 && sz > i.config.MaxDeserializedResponseSize {
 		err := fmt.Errorf("deserialized responses are not supported for content larger than %d bytes: for large content, run your own IPFS node (https://docs.ipfs.tech/install/)", i.config.MaxDeserializedResponseSize)
-		i.webError(w, r, err, http.StatusNotImplemented)
+		w.Header().Set("Cache-Control", cacheControlSizeLimit)
+		i.webError(w, r, err, http.StatusGone)
 		return true
 	}
 	return false

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -1125,3 +1125,27 @@ func (i *handler) getTemplateGlobalData(r *http.Request, contentPath path.Path) 
 func (i *handler) webError(w http.ResponseWriter, r *http.Request, err error, defaultCode int) {
 	webError(w, r, i.config, err, defaultCode)
 }
+
+// exceedsMaxUnixFSDAGResponseSize checks whether sz exceeds the configured
+// MaxUnixFSDAGResponseSize. If it does, it writes a 501 error and returns true.
+// Returns false (no-op) when the limit is disabled or not exceeded.
+func (i *handler) exceedsMaxUnixFSDAGResponseSize(w http.ResponseWriter, r *http.Request, sz int64) bool {
+	if i.config.MaxUnixFSDAGResponseSize > 0 && sz > i.config.MaxUnixFSDAGResponseSize {
+		err := fmt.Errorf("responses are not supported for content larger than %d bytes: for large content, run your own IPFS node (https://docs.ipfs.tech/install/)", i.config.MaxUnixFSDAGResponseSize)
+		i.webError(w, r, err, http.StatusNotImplemented)
+		return true
+	}
+	return false
+}
+
+// exceedsMaxDeserializedResponseSize checks whether sz exceeds the configured
+// MaxDeserializedResponseSize. If it does, it writes a 501 error and returns true.
+// Returns false (no-op) when the limit is disabled or not exceeded.
+func (i *handler) exceedsMaxDeserializedResponseSize(w http.ResponseWriter, r *http.Request, sz int64) bool {
+	if i.config.MaxDeserializedResponseSize > 0 && sz > i.config.MaxDeserializedResponseSize {
+		err := fmt.Errorf("deserialized responses are not supported for content larger than %d bytes: for large content, run your own IPFS node (https://docs.ipfs.tech/install/)", i.config.MaxDeserializedResponseSize)
+		i.webError(w, r, err, http.StatusNotImplemented)
+		return true
+	}
+	return false
+}

--- a/gateway/handler_block.go
+++ b/gateway/handler_block.go
@@ -44,6 +44,10 @@ func (i *handler) serveRawBlock(ctx context.Context, w http.ResponseWriter, r *h
 		return false
 	}
 
+	if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
+		return false
+	}
+
 	if !i.seekToStartOfFirstRange(w, r, data, sz) {
 		return false
 	}

--- a/gateway/handler_block.go
+++ b/gateway/handler_block.go
@@ -20,6 +20,18 @@ func (i *handler) serveRawBlock(ctx context.Context, w http.ResponseWriter, r *h
 	}
 	defer data.Close()
 
+	sz, err := data.Size()
+	if err != nil {
+		i.handleRequestErrors(w, r, rq.contentPath, err)
+		return false
+	}
+
+	// Check size limit before setting response headers so 410 responses
+	// stay clean.
+	if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
+		return false
+	}
+
 	setIpfsRootsHeader(w, rq, &pathMetadata)
 
 	blockCid := pathMetadata.LastSegment.RootCid()
@@ -37,16 +49,6 @@ func (i *handler) serveRawBlock(ctx context.Context, w http.ResponseWriter, r *h
 	modtime := addCacheControlHeaders(w, r, rq.contentPath, rq.ttl, rq.lastMod, blockCid, rawResponseFormat)
 	w.Header().Set("Content-Type", rawResponseFormat)
 	w.Header().Set("X-Content-Type-Options", "nosniff") // no funny business in the browsers :^)
-
-	sz, err := data.Size()
-	if err != nil {
-		i.handleRequestErrors(w, r, rq.contentPath, err)
-		return false
-	}
-
-	if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
-		return false
-	}
 
 	if !i.seekToStartOfFirstRange(w, r, data, sz) {
 		return false

--- a/gateway/handler_car.go
+++ b/gateway/handler_car.go
@@ -76,16 +76,19 @@ func (i *handler) serveCAR(ctx context.Context, w http.ResponseWriter, r *http.R
 	// Check DAG size limit before streaming the CAR. This requires a
 	// lightweight Head call; the root block is cached in the blockstore
 	// so GetCAR will not re-fetch it from the network.
+	// If Head fails we fail closed rather than bypassing the cap: an
+	// operator-configured size limit must never be silently skipped due
+	// to a transient backend error.
 	if i.config.MaxUnixFSDAGResponseSize > 0 {
 		_, headResp, headErr := i.backend.Head(ctx, rq.immutablePath)
-		if headErr == nil {
-			sz := headResp.bytesSize
-			headResp.Close()
-			if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
-				return false
-			}
+		if !i.handleRequestErrors(w, r, rq.contentPath, headErr) {
+			return false
 		}
-		// If Head fails, let GetCAR surface the error with proper handling.
+		sz := headResp.bytesSize
+		headResp.Close()
+		if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
+			return false
+		}
 	}
 
 	md, carFile, err := i.backend.GetCAR(ctx, rq.immutablePath, params)

--- a/gateway/handler_car.go
+++ b/gateway/handler_car.go
@@ -73,6 +73,21 @@ func (i *handler) serveCAR(ctx context.Context, w http.ResponseWriter, r *http.R
 		return false
 	}
 
+	// Check DAG size limit before streaming the CAR. This requires a
+	// lightweight Head call; the root block is cached in the blockstore
+	// so GetCAR will not re-fetch it from the network.
+	if i.config.MaxUnixFSDAGResponseSize > 0 {
+		_, headResp, headErr := i.backend.Head(ctx, rq.immutablePath)
+		if headErr == nil {
+			sz := headResp.bytesSize
+			headResp.Close()
+			if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
+				return false
+			}
+		}
+		// If Head fails, let GetCAR surface the error with proper handling.
+	}
+
 	md, carFile, err := i.backend.GetCAR(ctx, rq.immutablePath, params)
 	if !i.handleRequestErrors(w, r, rq.contentPath, err) {
 		return false

--- a/gateway/handler_codec.go
+++ b/gateway/handler_codec.go
@@ -78,6 +78,10 @@ func (i *handler) serveCodec(ctx context.Context, w http.ResponseWriter, r *http
 		return false
 	}
 
+	if i.exceedsMaxUnixFSDAGResponseSize(w, r, blockSize) {
+		return false
+	}
+
 	return i.renderCodec(ctx, w, r, rq, blockSize, data)
 }
 

--- a/gateway/handler_codec.go
+++ b/gateway/handler_codec.go
@@ -71,16 +71,18 @@ func (i *handler) serveCodec(ctx context.Context, w http.ResponseWriter, r *http
 	}
 	defer data.Close()
 
-	setIpfsRootsHeader(w, rq, &pathMetadata)
-
 	blockSize, err := data.Size()
 	if !i.handleRequestErrors(w, r, rq.contentPath, err) {
 		return false
 	}
 
+	// Check size limit before setting response headers so 410 responses
+	// stay clean.
 	if i.exceedsMaxUnixFSDAGResponseSize(w, r, blockSize) {
 		return false
 	}
+
+	setIpfsRootsHeader(w, rq, &pathMetadata)
 
 	return i.renderCodec(ctx, w, r, rq, blockSize, data)
 }

--- a/gateway/handler_defaults.go
+++ b/gateway/handler_defaults.go
@@ -91,9 +91,8 @@ func (i *handler) serveDefaults(ctx context.Context, w http.ResponseWriter, r *h
 		return false
 	}
 
-	setIpfsRootsHeader(w, rq, &pathMetadata)
-
-	// Check content size limits before streaming any data.
+	// Check content size limits before streaming any data, and before
+	// setting response headers so 410 responses stay clean.
 	// Size comes from the UnixFS root block (no child blocks fetched).
 	// Applies to both regular and range requests: if the underlying file
 	// exceeds the limit, even a small byte range is rejected.
@@ -111,6 +110,8 @@ func (i *handler) serveDefaults(ctx context.Context, w http.ResponseWriter, r *h
 			return false
 		}
 	}
+
+	setIpfsRootsHeader(w, rq, &pathMetadata)
 
 	// On deserialized responses, we prefer Last-Modified from pathMetadata
 	// (mtime in UnixFS 1.5 DAG). This also applies to /ipns/, because value

--- a/gateway/handler_defaults.go
+++ b/gateway/handler_defaults.go
@@ -93,6 +93,25 @@ func (i *handler) serveDefaults(ctx context.Context, w http.ResponseWriter, r *h
 
 	setIpfsRootsHeader(w, rq, &pathMetadata)
 
+	// Check content size limits before streaming any data.
+	// Size comes from the UnixFS root block (no child blocks fetched).
+	// Applies to both regular and range requests: if the underlying file
+	// exceeds the limit, even a small byte range is rejected.
+	{
+		var sz int64
+		if headResp != nil {
+			sz = headResp.bytesSize
+		} else {
+			sz = getResp.bytesSize
+		}
+		if i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
+			return false
+		}
+		if i.exceedsMaxDeserializedResponseSize(w, r, sz) {
+			return false
+		}
+	}
+
 	// On deserialized responses, we prefer Last-Modified from pathMetadata
 	// (mtime in UnixFS 1.5 DAG). This also applies to /ipns/, because value
 	// from dag-pb, if present, is more meaningful than lastMod inferred from

--- a/gateway/handler_tar.go
+++ b/gateway/handler_tar.go
@@ -27,13 +27,15 @@ func (i *handler) serveTAR(ctx context.Context, w http.ResponseWriter, r *http.R
 	}
 	defer file.Close()
 
-	setIpfsRootsHeader(w, rq, &pathMetadata)
-
+	// Check size limit before setting response headers so 410 responses
+	// stay clean.
 	if i.config.MaxUnixFSDAGResponseSize > 0 {
 		if sz, err := file.Size(); err == nil && i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
 			return false
 		}
 	}
+
+	setIpfsRootsHeader(w, rq, &pathMetadata)
 
 	rootCid := pathMetadata.LastSegment.RootCid()
 

--- a/gateway/handler_tar.go
+++ b/gateway/handler_tar.go
@@ -28,6 +28,13 @@ func (i *handler) serveTAR(ctx context.Context, w http.ResponseWriter, r *http.R
 	defer file.Close()
 
 	setIpfsRootsHeader(w, rq, &pathMetadata)
+
+	if i.config.MaxUnixFSDAGResponseSize > 0 {
+		if sz, err := file.Size(); err == nil && i.exceedsMaxUnixFSDAGResponseSize(w, r, sz) {
+			return false
+		}
+	}
+
 	rootCid := pathMetadata.LastSegment.RootCid()
 
 	// Set Cache-Control and read optional Last-Modified time


### PR DESCRIPTION
Add two new Config options for gateway operators to limit responses based on content size read from the UnixFS root block:

- `MaxDeserializedResponseSize`: caps **deserialized responses onl**y, trustless formats (raw, CAR) are not affected
- `MaxUnixFSDAGResponseSize`: caps all response formats including raw blocks, CAR, and TAR

Both return 410 Gone with a message directing users to run their own IPFS node for large content.

### Integration points

- gateway.go: add config fields with documentation
- handler.go: add exceedsMax* helper methods
- handler_defaults.go: check both limits using bytesSize
- handler_block.go: check DAG limit using existing block size
- handler_codec.go: check DAG limit using existing block size
- handler_car.go: conditional Head call only when limit is set
- handler_tar.go: check DAG limit using existing file.Size()
- gateway_test.go: tests for both limits across all formats
- CHANGELOG.md: document new config options

## Test

- [x] https://github.com/ipfs/rainbow/pull/364
- [x] staging: https://www.notion.so/boxo-1138-34a1def34287809a9b29d11ba22db05d
