### PR TITLE
test(dag/walker): fix flaky bloom FP assertion

### DIFF
--- a/dag/walker/visited_test.go
+++ b/dag/walker/visited_test.go
@@ -189,8 +189,10 @@ func TestBloomTracker(t *testing.T) {
 
 	t.Run("FP regression at default rate", func(t *testing.T) {
 		// DefaultBloomFPRate is ~1 in 4.75M. With 100K probes the
-		// expected FP count is 100K/4.75M = ~0.02, so we should see
-		// exactly 0. Any non-zero result indicates a regression.
+		// expected FP count is ~0.02. Bloom uses random SipHash keys,
+		// so rare FPs are possible. Asserting exactly 0 causes ~2%
+		// flake rate; allowing <=2 reduces that to roughly 1 in a
+		// million while still catching real regressions.
 		const n = 100_000
 		bt, err := NewBloomTracker(uint(n), DefaultBloomFPRate)
 		require.NoError(t, err)
@@ -205,10 +207,10 @@ func TestBloomTracker(t *testing.T) {
 				fpCount++
 			}
 		}
-		t.Logf("default rate FPs: %d / %d (expected: 0 at ~1 in %d)",
+		t.Logf("default rate FPs: %d / %d (expected: ~0 at 1 in %d)",
 			fpCount, n, DefaultBloomFPRate)
-		assert.Equal(t, 0, fpCount,
-			"at ~1 in 4.75M FP rate, 100K probes should produce 0 FPs")
+		assert.LessOrEqual(t, fpCount, 2,
+			"at ~1 in 4.75M FP rate, 100K probes should produce <=2 FPs")
 	})
 }
 


### PR DESCRIPTION
Allow up to 2 false positives instead of exactly 0 in the default-rate regression test. At 1 in 4.75M with 100K probes the expected count is ~0.02, giving a ~2% flake rate for an exact-zero assertion.


I think the purpose of the test should be to warn us if suddenly something gets totally out of whack, and it should not make our live miserable by being flaky, so dialing this a notch down should be a good compromise.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
