### PR TITLE
fix(dspinner): snapshot index before emitting pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `pinner/dspinner`: `RecursiveKeys` and `DirectKeys` now snapshot the pin index under the read lock and release it before emitting pins, so a slow consumer (e.g. the reprovider draining the channel at DHT speed under `Provide.Strategy=pinned*`) can no longer starve `Pin`/`Unpin`/`Flush` writers. [#1140](https://github.com/ipfs/boxo/pull/1140)
+
 ### Security
 
 

--- a/pinning/pinner/dspinner/pin.go
+++ b/pinning/pinner/dspinner/pin.go
@@ -174,7 +174,7 @@ func New(ctx context.Context, dstore ds.Datastore, dserv ipld.DAGService, opts .
 
 	data, err := dstore.Get(ctx, dirtyKey)
 	if err != nil {
-		if err == ds.ErrNotFound {
+		if errors.Is(err, ds.ErrNotFound) {
 			return p, nil
 		}
 		return nil, fmt.Errorf("cannot load dirty flag: %v", err)
@@ -849,7 +849,7 @@ func (p *pinner) removePinsForCid(ctx context.Context, c cid.Cid, mode ipfspinne
 		var pp *pin
 		pp, err = p.loadPin(ctx, pid)
 		if err != nil {
-			if err == ds.ErrNotFound {
+			if errors.Is(err, ds.ErrNotFound) {
 				p.setDirty(ctx)
 				// Fix index; remove index for pin that does not exist
 				switch mode {

--- a/pinning/pinner/dspinner/pin.go
+++ b/pinning/pinner/dspinner/pin.go
@@ -914,16 +914,37 @@ func (p *pinner) RecursiveKeys(ctx context.Context, detailed bool) <-chan ipfspi
 	return p.streamIndex(ctx, p.cidRIndex, detailed)
 }
 
+type indexEntry struct {
+	key, value string
+}
+
+// snapshotIndex reads all (key, value) pairs from an index under the read
+// lock. Callers iterate the returned slice without holding any pinner lock,
+// so a slow consumer cannot starve writers.
+//
+// The whole keyset lives in memory, which is cheap because the pin index
+// holds one entry per pin, not per block: a recursive pin covering millions
+// of blocks costs one entry (~130 B, so ~130 MB per 1M pins). Deployments
+// with >100M pins can swap the slice for a `go-dsqueue` (already vendored;
+// see `boxo/provider/reprovider.go`) to spool entries through the datastore.
+func (p *pinner) snapshotIndex(ctx context.Context, index dsindex.Indexer) ([]indexEntry, error) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	var entries []indexEntry
+	err := index.ForEach(ctx, "", func(key, value string) bool {
+		entries = append(entries, indexEntry{key, value})
+		return true
+	})
+	return entries, err
+}
+
 func (p *pinner) streamIndex(ctx context.Context, index dsindex.Indexer, detailed bool) <-chan ipfspinner.StreamedPin {
 	out := make(chan ipfspinner.StreamedPin)
 
 	go func() {
 		defer close(out)
 
-		p.lock.RLock()
-		defer p.lock.RUnlock()
-
-		cidSet := cid.NewSet()
 		send := func(sp ipfspinner.StreamedPin) (ok bool) {
 			select {
 			case <-ctx.Done():
@@ -933,21 +954,35 @@ func (p *pinner) streamIndex(ctx context.Context, index dsindex.Indexer, detaile
 			}
 		}
 
-		err := index.ForEach(ctx, "", func(key, value string) bool {
-			c, err := cid.Cast([]byte(key))
+		entries, err := p.snapshotIndex(ctx, index)
+		if err != nil {
+			send(ipfspinner.StreamedPin{Err: err})
+			return
+		}
+
+		cidSet := cid.NewSet()
+		for _, e := range entries {
+			c, err := cid.Cast([]byte(e.key))
 			if err != nil {
 				send(ipfspinner.StreamedPin{Err: err})
-				return false
+				return
+			}
+
+			if cidSet.Has(c) {
+				continue
 			}
 
 			var pin ipfspinner.Pinned
 			if detailed {
-				pp, err := p.loadPin(ctx, value)
+				pp, err := p.loadPin(ctx, e.value)
 				if err != nil {
+					if errors.Is(err, ds.ErrNotFound) {
+						// Pin removed between snapshot and load.
+						continue
+					}
 					send(ipfspinner.StreamedPin{Err: err})
-					return false
+					return
 				}
-
 				pin.Key = pp.Cid
 				pin.Mode = pp.Mode
 				pin.Name = pp.Name
@@ -955,17 +990,10 @@ func (p *pinner) streamIndex(ctx context.Context, index dsindex.Indexer, detaile
 				pin.Key = c
 			}
 
-			if !cidSet.Has(c) {
-				if !send(ipfspinner.StreamedPin{Pin: pin}) {
-					return false
-				}
-				cidSet.Add(c)
+			if !send(ipfspinner.StreamedPin{Pin: pin}) {
+				return
 			}
-			return true
-		})
-		if err != nil {
-			send(ipfspinner.StreamedPin{Err: err})
-			return
+			cidSet.Add(c)
 		}
 	}()
 

--- a/pinning/pinner/dspinner/pin_test.go
+++ b/pinning/pinner/dspinner/pin_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"path"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	bs "github.com/ipfs/boxo/blockservice"
@@ -1425,49 +1426,49 @@ func benchmarkDetails(b *testing.B, count int, details bool) {
 // held, which would stall Pin/Unpin/Update writers. This regressed the
 // kubo collab cluster when Provide.Strategy was set to pinned*, causing
 // convoys of stuck pin ls and ipfs add requests.
+//
+// Runs inside a synctest bubble so we can assert "Pin completes while a
+// RecursiveKeys consumer is parked" deterministically. Under the broken
+// code path the streamIndex goroutine would be durably blocked on send
+// while holding p.lock.RLock(), Pin would be durably blocked on Lock(),
+// and synctest would report a deadlock.
 func TestStreamIndexDoesNotBlockWriters(t *testing.T) {
-	ctx := t.Context()
-
-	dstore, dserv := makeStore()
-	p, err := New(ctx, dstore, dserv)
-	require.NoError(t, err)
-
-	initial := makeNodes(8, dserv)
-	pinNodes(initial, p, true)
-
 	for _, detailed := range []bool{false, true} {
 		t.Run(fmt.Sprintf("detailed=%v", detailed), func(t *testing.T) {
-			// Open a RecursiveKeys stream without consuming anything.
-			// Under the old implementation this held p.lock.RLock()
-			// for the channel's entire lifetime.
-			streamCtx, cancelStream := context.WithCancel(ctx)
-			defer cancelStream()
-			kch := p.RecursiveKeys(streamCtx, detailed)
+			synctest.Test(t, func(t *testing.T) {
+				ctx := t.Context()
 
-			// Give the producer goroutine time to reach the point where
-			// it would have held the lock in the old code path.
-			time.Sleep(50 * time.Millisecond)
-
-			// A fresh node: Pin needs p.lock.Lock().
-			newNode, _ := randNode()
-			require.NoError(t, dserv.Add(ctx, newNode))
-
-			done := make(chan error, 1)
-			go func() {
-				done <- p.Pin(ctx, newNode, true, "")
-			}()
-
-			select {
-			case err := <-done:
+				dstore, dserv := makeStore()
+				p, err := New(ctx, dstore, dserv)
 				require.NoError(t, err)
-			case <-time.After(3 * time.Second):
-				t.Fatal("Pin blocked behind a RecursiveKeys stream with no consumer: streamIndex is holding p.lock.RLock for the duration of the channel")
-			}
 
-			// Drain the stream so the goroutine exits cleanly.
-			cancelStream()
-			for range kch {
-			}
+				initial := makeNodes(8, dserv)
+				pinNodes(initial, p, true)
+
+				// Open a RecursiveKeys stream without consuming
+				// anything. Under the old implementation this held
+				// p.lock.RLock() for the channel's entire lifetime.
+				streamCtx, cancelStream := context.WithCancel(ctx)
+				defer cancelStream()
+				kch := p.RecursiveKeys(streamCtx, detailed)
+
+				// Wait for the streamIndex goroutine to park on its
+				// first send. With the fix it has already released
+				// p.lock.RLock() before parking.
+				synctest.Wait()
+
+				// A fresh node: Pin needs p.lock.Lock(). With the
+				// fix this returns without waiting on the parked
+				// streamIndex goroutine.
+				newNode, _ := randNode()
+				require.NoError(t, dserv.Add(ctx, newNode))
+				require.NoError(t, p.Pin(ctx, newNode, true, ""))
+
+				// Drain the stream so the goroutine exits cleanly.
+				cancelStream()
+				for range kch {
+				}
+			})
 		})
 	}
 }

--- a/pinning/pinner/dspinner/pin_test.go
+++ b/pinning/pinner/dspinner/pin_test.go
@@ -1419,3 +1419,55 @@ func benchmarkDetails(b *testing.B, count int, details bool) {
 		}
 	}
 }
+
+// TestStreamIndexDoesNotBlockWriters verifies that a slow (or blocked)
+// RecursiveKeys/DirectKeys consumer does not keep the pinner's read lock
+// held, which would stall Pin/Unpin/Update writers. This regressed the
+// kubo collab cluster when Provide.Strategy was set to pinned*, causing
+// convoys of stuck pin ls and ipfs add requests.
+func TestStreamIndexDoesNotBlockWriters(t *testing.T) {
+	ctx := t.Context()
+
+	dstore, dserv := makeStore()
+	p, err := New(ctx, dstore, dserv)
+	require.NoError(t, err)
+
+	initial := makeNodes(8, dserv)
+	pinNodes(initial, p, true)
+
+	for _, detailed := range []bool{false, true} {
+		t.Run(fmt.Sprintf("detailed=%v", detailed), func(t *testing.T) {
+			// Open a RecursiveKeys stream without consuming anything.
+			// Under the old implementation this held p.lock.RLock()
+			// for the channel's entire lifetime.
+			streamCtx, cancelStream := context.WithCancel(ctx)
+			defer cancelStream()
+			kch := p.RecursiveKeys(streamCtx, detailed)
+
+			// Give the producer goroutine time to reach the point where
+			// it would have held the lock in the old code path.
+			time.Sleep(50 * time.Millisecond)
+
+			// A fresh node: Pin needs p.lock.Lock().
+			newNode, _ := randNode()
+			require.NoError(t, dserv.Add(ctx, newNode))
+
+			done := make(chan error, 1)
+			go func() {
+				done <- p.Pin(ctx, newNode, true, "")
+			}()
+
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(3 * time.Second):
+				t.Fatal("Pin blocked behind a RecursiveKeys stream with no consumer: streamIndex is holding p.lock.RLock for the duration of the channel")
+			}
+
+			// Drain the stream so the goroutine exits cleanly.
+			cancelStream()
+			for range kch {
+			}
+		})
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> _Found this on collab cluster while testing v0.41.0-rc2_, not a release blocker but would be good to fix in 0.42
> Kubo PR with changelog: https://github.com/ipfs/kubo/pull/11290

## Problem

`streamIndex` held `pins.lock.RLock` for the channel's full lifetime, so when the **reprovider drained the channel at DHT speed the lock stayed held for hours** and starved Pin/Unpin/Flush writers behind `RWMutex` writer preference. 

Not impacting defaults (`Provide.Strategy=all`), but surfaces with `Provide.Strategy=pinned*`, concurrent `pin ls` and `ipfs add` (common RPCs done by ipfs-cluster) requests then piled up behind the queued writer. We had `ipfs add` waiting many hours for the lock on one of the boxes.

## Proposed Solution  (this PR)

`streamIndex` now materializes (key, value) pairs into a slice under the read lock and returns, letting the goroutine emit without holding any pinner lock. 

when pin details are requested, `loadPin` runs lock-free in the detailed path; if a pin from the snapshot was removed and emits `ErrNotFound` it is skipped. this way we dont have any races, but also dont need to hold lock all the time.

Number of pins is small enough to keep them in memory, but we can add `go-dsqueue` is we ever have users with 100M of pins complaining.  

`TestStreamIndexDoesNotBlockWriters` guards the regression.

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->


## TODO

- [x] add regression rest to not re-introduce lock
- [x] green ci here
- [x] kubo PR https://github.com/ipfs/kubo/pull/11290  has green ci