### PR TITLE
fix(bitswap): prevent low-pending peer starvation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- `bitswap/server`: the default peer comparator now schedules peers fairly. A peer that has never been served, or has waited longer than 10s, outranks non-starved peers. Pending counts cap at 16 for ordering purposes, so peers with small wantlists no longer wait behind peers with large ones. The final tiebreak uses a per-process salted hash of peer.ID, so no peer can craft an ID that permanently outranks everyone. Engines built with `WithTaskComparator` keep their existing behavior. [#1141](https://github.com/ipfs/boxo/issues/1141)
+
 ### Removed
 
 ### Fixed
+
+- `bitswap/server`: a peer with a single pending want no longer waits behind peers with large wantlists. [#1141](https://github.com/ipfs/boxo/issues/1141)
 
 ### Security
 

--- a/bitswap/server/internal/decision/chokepoint_bench_test.go
+++ b/bitswap/server/internal/decision/chokepoint_bench_test.go
@@ -1,0 +1,148 @@
+package decision
+
+import (
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-peertaskqueue/peertracker"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// benchSink prevents the compiler from hoisting or eliminating comparator
+// calls whose result would otherwise go unused.
+var benchSink atomic.Bool
+
+// realisticPeerID returns a 38-byte peer.ID whose bytes look like an
+// identity-multihash of an ed25519 pubkey. The short test IDs used elsewhere
+// understate hash cost at layer 5; these do not.
+func realisticPeerID(tb testing.TB) peer.ID {
+	b := make([]byte, 38)
+	if _, err := rand.Read(b); err != nil {
+		tb.Fatal(err)
+	}
+	b[0], b[1] = 0x00, 0x24
+	return peer.ID(b)
+}
+
+// BenchmarkComparatorVsUpstream measures per-call cost of the fair
+// comparator against peertracker.DefaultPeerComparator on realistic peer
+// IDs. Any added chokepoint would show up here as a large gap.
+func BenchmarkComparatorVsUpstream(b *testing.B) {
+	idA := realisticPeerID(b)
+	idB := realisticPeerID(b)
+	a := newTestTracker(string(idA), 50)
+	c := newTestTracker(string(idB), 50)
+
+	b.Run("upstream_default", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			benchSink.Store(peertracker.DefaultPeerComparator(a, c))
+		}
+	})
+
+	b.Run("fair_layer2_shortcut", func(b *testing.B) {
+		s := newPeerScheduler()
+		s.markServed(idB) // idA is never-served, layer 2 fires
+		cmp := fairPeerComparator(s)
+		for i := 0; i < b.N; i++ {
+			benchSink.Store(cmp(a, c))
+		}
+	})
+
+	b.Run("fair_layer5_fallthrough", func(b *testing.B) {
+		s := newPeerScheduler()
+		s.markServed(idA)
+		s.markServed(idB)
+		cmp := fairPeerComparator(s)
+		for i := 0; i < b.N; i++ {
+			benchSink.Store(cmp(a, c))
+		}
+	})
+}
+
+// BenchmarkMarkServed measures the cost of the write-lock path. The engine
+// calls this once per emitted envelope, so at 400k envelopes/sec it must
+// stay well under 1us.
+func BenchmarkMarkServed(b *testing.B) {
+	s := newPeerScheduler()
+	id := realisticPeerID(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		s.markServed(id)
+	}
+}
+
+// BenchmarkContended exercises the realistic shape of load: many readers
+// (the heap is fixing itself up on every push/pop) and one writer (the
+// single task-worker goroutine calling markServed on each envelope). A
+// chokepoint in the RWMutex would show up as reader throughput collapsing
+// when the writer is active.
+func BenchmarkContended(b *testing.B) {
+	const readers = 16
+
+	for _, writeHz := range []int{0, 10_000, 100_000, 400_000} {
+		name := fmt.Sprintf("readers=%d_writes/s=%d", readers, writeHz)
+		b.Run(name, func(b *testing.B) {
+			s := newPeerScheduler()
+
+			// Pre-populate so isStarved reads actually find entries.
+			ids := make([]peer.ID, 64)
+			for i := range ids {
+				ids[i] = realisticPeerID(b)
+				s.markServed(ids[i])
+			}
+
+			trackers := make([]*peertracker.PeerTracker, len(ids))
+			for i, id := range ids {
+				trackers[i] = newTestTracker(string(id), 50)
+			}
+			cmp := fairPeerComparator(s)
+
+			stop := make(chan struct{})
+			var wg sync.WaitGroup
+
+			// Writer goroutine: calls markServed at the target rate.
+			if writeHz > 0 {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					interval := time.Second / time.Duration(writeHz)
+					t := time.NewTicker(interval)
+					defer t.Stop()
+					i := 0
+					for {
+						select {
+						case <-stop:
+							return
+						case <-t.C:
+							s.markServed(ids[i%len(ids)])
+							i++
+						}
+					}
+				}()
+			}
+
+			var ops atomic.Uint64
+			b.ResetTimer()
+			b.SetParallelism(readers)
+			b.RunParallel(func(pb *testing.PB) {
+				i := 0
+				for pb.Next() {
+					pa := trackers[i%len(trackers)]
+					pc := trackers[(i+1)%len(trackers)]
+					benchSink.Store(cmp(pa, pc))
+					i++
+					ops.Add(1)
+				}
+			})
+			b.StopTimer()
+
+			close(stop)
+			wg.Wait()
+			b.ReportMetric(float64(ops.Load())/b.Elapsed().Seconds(), "cmp/s")
+		})
+	}
+}

--- a/bitswap/server/internal/decision/engine.go
+++ b/bitswap/server/internal/decision/engine.go
@@ -119,7 +119,69 @@ type ScoreLedger interface {
 	Stop()
 }
 
-// Engine manages sending requested blocks to peers.
+// Engine schedules outbound bitswap traffic. It turns wantlists received
+// from peers into a stream of message envelopes on [Engine.Outbox],
+// deciding which peer to serve next, which blocks to pack into each
+// message, and how to answer when a wanted block is missing.
+//
+// # Request flow
+//
+// [Engine.MessageReceived] parses an incoming wantlist, records it in the
+// per-peer ledger, and pushes one task per wanted CID onto the internal
+// peer-task queue. Task workers loop through nextEnvelope: pop a batch of
+// tasks for a single peer, fetch the blocks from the blockstore, build a
+// BitSwapMessage, and emit it on Outbox. The envelope's Sent callback
+// marks those tasks done once the network layer has taken the message.
+//
+// # Peer selection
+//
+// The peer-task queue picks whose turn is next through a peer comparator.
+// The default is [fairPeerComparator]; see its godoc for the five
+// ordering layers (empty queue loses, starvation override, active-work
+// locality, capped pending, salted-hash tiebreak). An engine built with
+// [WithTaskComparator] supplies a custom comparator instead, and the fair
+// scheduler stays uninstalled.
+//
+// # Task selection within a peer
+//
+// Once the comparator picks a peer, PopTasks pulls tasks from that peer's
+// subqueue until it has packed approximately targetMessageSize bytes. A
+// [TaskComparator] set with [WithTaskComparator] reorders tasks within
+// the subqueue; the default ordering comes from go-peertaskqueue.
+//
+// # Want-have vs want-block
+//
+// For each wanted CID the engine inspects the block. If the block is
+// present and fits under wantHaveReplaceSize bytes (see
+// [WithWantHaveReplaceSize]), the engine answers a want-have with the
+// block itself, saving one round-trip on small blocks. For larger blocks
+// the engine returns HAVE and lets the peer decide whether to upgrade to
+// want-block. A missing block produces DONT_HAVE when the task asked for
+// it ([WithSetSendDontHave]).
+//
+// # Anti-abuse limits
+//
+// [WithMaxQueuedWantlistEntriesPerPeer] caps how many wants one peer can
+// keep queued; newer high-priority wants evict lower-priority ones, so a
+// peer cannot grow the queue without bound. [WithMaxCidSize] rejects CIDs
+// whose encoded length exceeds the limit, defending against pathological
+// varint encodings. [WithMaxOutstandingBytesPerPeer] applies soft
+// per-peer backpressure: once outstanding bytes for a peer cross the
+// limit, the queue stops handing it new tasks until earlier ones drain.
+//
+// # Peer scoring
+//
+// [ScoreLedger] tracks bytes sent and received per peer. The default
+// ledger feeds a reputation score to the libp2p connection manager, which
+// uses it to keep useful peers connected under churn. The score does not
+// influence ordering in the default comparator; only a custom
+// TaskComparator can read it.
+//
+// # Freeze and thaw
+//
+// When a peer cancels a batch of wants, the peer-task queue may freeze
+// that peer's slot briefly. An internal ticker calls ThawRound every
+// 100ms so a frozen slot cannot stall a task worker.
 type Engine struct {
 	// peerRequestQueue is a priority queue of requests received from peers.
 	// Requests are popped from the queue, packaged up, and placed in the
@@ -187,6 +249,10 @@ type Engine struct {
 
 	maxQueuedWantlistEntriesPerPeer uint
 	maxCidSize                      uint
+
+	// scheduler holds per-peer state the fair comparator reads. The engine
+	// installs the fair comparator only when no custom task comparator is set.
+	scheduler *peerScheduler
 }
 
 // TaskInfo represents the details of a request from a peer.
@@ -370,6 +436,7 @@ func NewEngine(
 	}
 
 	e.peerLedger = newPeerLedger(e.maxQueuedWantlistEntriesPerPeer)
+	e.scheduler = newPeerScheduler()
 
 	e.bsm = newBlockstoreManager(bs, e.bstoreWorkerCount, bmetrics.PendingBlocksGauge(ctx), bmetrics.ActiveBlocksGauge(ctx))
 
@@ -386,6 +453,8 @@ func NewEngine(
 		queueTaskComparator := wrapTaskComparator(e.taskComparator)
 		peerTaskQueueOpts = append(peerTaskQueueOpts, peertaskqueue.PeerComparator(peertracker.TaskPriorityPeerComparator(queueTaskComparator)))
 		peerTaskQueueOpts = append(peerTaskQueueOpts, peertaskqueue.TaskComparator(queueTaskComparator))
+	} else {
+		peerTaskQueueOpts = append(peerTaskQueueOpts, peertaskqueue.PeerComparator(fairPeerComparator(e.scheduler)))
 	}
 
 	e.peerRequestQueue = peertaskqueue.New(peerTaskQueueOpts...)
@@ -465,6 +534,7 @@ func (e *Engine) onPeerAdded(p peer.ID) {
 
 func (e *Engine) onPeerRemoved(p peer.ID) {
 	e.peerTagger.UntagPeer(p, e.tagQueued)
+	e.scheduler.forget(p)
 }
 
 // WantlistForPeer returns the list of keys that the given peer has asked for
@@ -597,6 +667,7 @@ func (e *Engine) nextEnvelope(ctx context.Context) (*Envelope, error) {
 		}
 
 		log.Debugw("Bitswap engine -> msg", "local", e.self, "to", p, "blockCount", len(msg.Blocks()), "presenceCount", len(msg.BlockPresences()), "size", msg.Size())
+		e.scheduler.markServed(p)
 		return &Envelope{
 			Peer:    p,
 			Message: msg,

--- a/bitswap/server/internal/decision/scheduler.go
+++ b/bitswap/server/internal/decision/scheduler.go
@@ -3,6 +3,7 @@ package decision
 import (
 	"hash/maphash"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ipfs/go-peertaskqueue/peertracker"
@@ -23,9 +24,15 @@ const peerStarvationTimeout = 10 * time.Second
 // peerScheduler records the last time each peer received an envelope. The
 // fair comparator reads this state to promote peers that have waited too
 // long, or never received an envelope at all.
+//
+// lastServedAt keys peer.ID to *atomic.Int64 holding the last-served
+// nanosecond timestamp. The access pattern is read-heavy (every comparator
+// call hits isStarved, once per peer), write-rare (markServed runs once
+// per emitted envelope), and the key set churns slowly. sync.Map carries
+// the concurrent key lookup; *atomic.Int64 carries the concurrent value
+// update without further allocation after the first write per peer.
 type peerScheduler struct {
-	mu           sync.RWMutex
-	lastServedAt map[peer.ID]time.Time
+	lastServedAt sync.Map
 	// tiebreakSeed randomizes the layer-5 peer.ID tiebreak once per process.
 	// Ordering stays transitive within a run (heap invariants hold), but the
 	// winner on otherwise-identical state flips across runs, so no peer can
@@ -35,7 +42,6 @@ type peerScheduler struct {
 
 func newPeerScheduler() *peerScheduler {
 	return &peerScheduler{
-		lastServedAt: make(map[peer.ID]time.Time),
 		tiebreakSeed: maphash.MakeSeed(),
 	}
 }
@@ -46,9 +52,23 @@ func (s *peerScheduler) markServed(p peer.ID) {
 	if s == nil {
 		return
 	}
-	s.mu.Lock()
-	s.lastServedAt[p] = time.Now()
-	s.mu.Unlock()
+	s.recordServedAt(p, time.Now())
+}
+
+// recordServedAt is the test-accessible form of markServed. Splitting lets
+// tests install deterministic timestamps without bypassing the storage
+// layout.
+func (s *peerScheduler) recordServedAt(p peer.ID, t time.Time) {
+	ns := t.UnixNano()
+	if v, ok := s.lastServedAt.Load(p); ok {
+		v.(*atomic.Int64).Store(ns)
+		return
+	}
+	fresh := new(atomic.Int64)
+	fresh.Store(ns)
+	if actual, loaded := s.lastServedAt.LoadOrStore(p, fresh); loaded {
+		actual.(*atomic.Int64).Store(ns)
+	}
 }
 
 // forget drops per-peer state when a peer disconnects.
@@ -56,9 +76,7 @@ func (s *peerScheduler) forget(p peer.ID) {
 	if s == nil {
 		return
 	}
-	s.mu.Lock()
-	delete(s.lastServedAt, p)
-	s.mu.Unlock()
+	s.lastServedAt.Delete(p)
 }
 
 // isStarved reports whether the peer's wait exceeds peerStarvationTimeout.
@@ -67,13 +85,11 @@ func (s *peerScheduler) isStarved(p peer.ID, now time.Time) bool {
 	if s == nil {
 		return false
 	}
-	s.mu.RLock()
-	last, seen := s.lastServedAt[p]
-	s.mu.RUnlock()
-	if !seen {
+	v, ok := s.lastServedAt.Load(p)
+	if !ok {
 		return true
 	}
-	return now.Sub(last) > peerStarvationTimeout
+	return now.UnixNano()-v.(*atomic.Int64).Load() > int64(peerStarvationTimeout)
 }
 
 // fairPeerComparator returns a peer comparator that keeps low-pending peers

--- a/bitswap/server/internal/decision/scheduler.go
+++ b/bitswap/server/internal/decision/scheduler.go
@@ -1,0 +1,132 @@
+package decision
+
+import (
+	"hash/maphash"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-peertaskqueue/peertracker"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// peerPendingCap caps how much a peer's pending count drives its ordering.
+// Without a cap, a peer with a large wantlist permanently outranks peers
+// with smaller ones and starves them. See
+// https://github.com/ipfs/boxo/issues/1141.
+const peerPendingCap = 16
+
+// peerStarvationTimeout caps how long a peer with queued tasks waits before
+// the comparator promotes it above non-starved peers. The bound is soft:
+// the heap re-evaluates ordering on push/pop, not on wall-clock time.
+const peerStarvationTimeout = 10 * time.Second
+
+// peerScheduler records the last time each peer received an envelope. The
+// fair comparator reads this state to promote peers that have waited too
+// long, or never received an envelope at all.
+type peerScheduler struct {
+	mu           sync.RWMutex
+	lastServedAt map[peer.ID]time.Time
+	// tiebreakSeed randomizes the layer-5 peer.ID tiebreak once per process.
+	// Ordering stays transitive within a run (heap invariants hold), but the
+	// winner on otherwise-identical state flips across runs, so no peer can
+	// craft an ID that permanently outranks everyone.
+	tiebreakSeed maphash.Seed
+}
+
+func newPeerScheduler() *peerScheduler {
+	return &peerScheduler{
+		lastServedAt: make(map[peer.ID]time.Time),
+		tiebreakSeed: maphash.MakeSeed(),
+	}
+}
+
+// markServed records the time the engine selected this peer for an
+// outbound envelope. The engine calls it on every emitted envelope.
+func (s *peerScheduler) markServed(p peer.ID) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.lastServedAt[p] = time.Now()
+	s.mu.Unlock()
+}
+
+// forget drops per-peer state when a peer disconnects.
+func (s *peerScheduler) forget(p peer.ID) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	delete(s.lastServedAt, p)
+	s.mu.Unlock()
+}
+
+// isStarved reports whether the peer's wait exceeds peerStarvationTimeout.
+// A never-served peer (no lastServedAt entry) counts as starved.
+func (s *peerScheduler) isStarved(p peer.ID, now time.Time) bool {
+	if s == nil {
+		return false
+	}
+	s.mu.RLock()
+	last, seen := s.lastServedAt[p]
+	s.mu.RUnlock()
+	if !seen {
+		return true
+	}
+	return now.Sub(last) > peerStarvationTimeout
+}
+
+// fairPeerComparator returns a peer comparator that keeps low-pending peers
+// from starving behind a few heavy peers (issue #1141). Ordering layers,
+// first difference wins:
+//
+//  1. Empty queue loses (matches upstream rule).
+//  2. Starvation override: a never-served peer, or one waiting longer than
+//     peerStarvationTimeout, outranks any non-starved peer. A new peer with
+//     a single pending want gets its first envelope even while heavy peers
+//     have queued work.
+//  3. Lower activeWork wins, which keeps active peers busy.
+//  4. On active ties, higher min(pending, peerPendingCap) wins. Pending
+//     counts past the cap stop contributing, so 1000 pending does not
+//     permanently outrank 17.
+//  5. Per-process salted hash of peer.ID. Transitive within a run (heap
+//     invariants hold), but unpredictable across runs, so no peer can mine
+//     an ID that permanently outranks everyone.
+func fairPeerComparator(sched *peerScheduler) peertracker.PeerComparator {
+	return func(pa, pb *peertracker.PeerTracker) bool {
+		paStats := pa.Stats()
+		pbStats := pb.Stats()
+
+		// Layer 1: empty queue.
+		if paStats.NumPending == 0 {
+			return false
+		}
+		if pbStats.NumPending == 0 {
+			return true
+		}
+
+		// Layer 2: starvation override.
+		now := time.Now()
+		aStarved := sched.isStarved(pa.Target(), now)
+		bStarved := sched.isStarved(pb.Target(), now)
+		if aStarved != bStarved {
+			return aStarved
+		}
+
+		// Layer 3: lower activeWork wins.
+		if paStats.NumActive != pbStats.NumActive {
+			return paStats.NumActive < pbStats.NumActive
+		}
+
+		// Layer 4: capped pending.
+		aCapped := min(paStats.NumPending, peerPendingCap)
+		bCapped := min(pbStats.NumPending, peerPendingCap)
+		if aCapped != bCapped {
+			return aCapped > bCapped
+		}
+
+		// Layer 5: salted-hash tiebreak.
+		return maphash.String(sched.tiebreakSeed, string(pa.Target())) <
+			maphash.String(sched.tiebreakSeed, string(pb.Target()))
+	}
+}

--- a/bitswap/server/internal/decision/scheduler_test.go
+++ b/bitswap/server/internal/decision/scheduler_test.go
@@ -1,0 +1,277 @@
+package decision
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	blockstore "github.com/ipfs/boxo/blockstore"
+	blocks "github.com/ipfs/go-block-format"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipfs/go-peertaskqueue/peertask"
+	"github.com/ipfs/go-peertaskqueue/peertracker"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// newTestTracker builds a PeerTracker with the given pending-task count, so
+// tests can drive fairPeerComparator without starting an engine.
+func newTestTracker(id string, pending int) *peertracker.PeerTracker {
+	pt := peertracker.New(peer.ID(id), &peertracker.DefaultTaskMerger{}, 0)
+	if pending == 0 {
+		return pt
+	}
+	tasks := make([]peertask.Task, pending)
+	for i := range tasks {
+		tasks[i] = peertask.Task{
+			Topic:    fmt.Sprintf("%s-%d", id, i),
+			Priority: 1,
+			Work:     1,
+		}
+	}
+	pt.PushTasks(tasks...)
+	return pt
+}
+
+// TestFairSchedulerLowPendingPeerIsServed reproduces the starvation
+// scenario from https://github.com/ipfs/boxo/issues/1141. Before the fair
+// comparator, the engine served heavy peers in a loop and a peer with a
+// single pending want waited indefinitely.
+func TestFairSchedulerLowPendingPeerIsServed(t *testing.T) {
+	const (
+		heavyPeerCount     = 10
+		heavyWantCount     = 50
+		maxEnvelopesToWait = heavyPeerCount + 2
+	)
+
+	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
+	heavyCids := make([]string, heavyWantCount)
+	for i := range heavyCids {
+		heavyCids[i] = fmt.Sprintf("heavy-%03d", i)
+		if err := bs.Put(context.Background(), blocks.NewBlock([]byte(heavyCids[i]))); err != nil {
+			t.Fatal(err)
+		}
+	}
+	newPeerCid := "new-peer-block"
+	if err := bs.Put(context.Background(), blocks.NewBlock([]byte(newPeerCid))); err != nil {
+		t.Fatal(err)
+	}
+
+	e := newEngineForTesting(bs, &fakePeerTagger{}, "localhost", 0,
+		WithScoreLedger(NewTestScoreLedger(shortTerm, nil)),
+		WithBlockstoreWorkerCount(4))
+	defer e.Close()
+
+	heavyPeers := make([]peer.ID, heavyPeerCount)
+	for i := range heavyPeers {
+		heavyPeers[i] = peer.ID(fmt.Sprintf("heavy-peer-%02d", i))
+		partnerWantBlocks(e, heavyCids, heavyPeers[i])
+	}
+
+	newPeer := peer.ID("new-peer")
+	partnerWantBlocks(e, []string{newPeerCid}, newPeer)
+
+	newPeerBlockCid := blocks.NewBlock([]byte(newPeerCid)).Cid()
+
+	for i := 0; i < maxEnvelopesToWait; i++ {
+		select {
+		case next := <-e.Outbox():
+			env := <-next
+			if env == nil {
+				continue
+			}
+			for _, blk := range env.Message.Blocks() {
+				if blk.Cid() == newPeerBlockCid {
+					env.Sent()
+					return
+				}
+			}
+			env.Sent()
+		case <-time.After(5 * time.Second):
+			t.Fatalf("timed out waiting for envelope %d", i)
+		}
+	}
+	t.Fatalf("new peer was not served within %d envelopes (starvation regression)", maxEnvelopesToWait)
+}
+
+// TestFairSchedulerForgetsDisconnectedPeer verifies forget drops the
+// per-peer entry, so the scheduler does not grow without bound.
+func TestFairSchedulerForgetsDisconnectedPeer(t *testing.T) {
+	s := newPeerScheduler()
+	p := peer.ID("p")
+
+	s.markServed(p)
+	if !s.isStarved(p, time.Now().Add(peerStarvationTimeout+time.Second)) {
+		t.Fatal("peer should be starved past timeout")
+	}
+	s.forget(p)
+	s.mu.RLock()
+	_, present := s.lastServedAt[p]
+	s.mu.RUnlock()
+	if present {
+		t.Fatal("scheduler still holds state for forgotten peer")
+	}
+}
+
+// TestFairComparatorEmptyQueueLoses covers layer 1: a peer with nothing
+// pending cannot outrank a peer with queued work.
+func TestFairComparatorEmptyQueueLoses(t *testing.T) {
+	cmp := fairPeerComparator(newPeerScheduler())
+	busy := newTestTracker("busy", 5)
+	empty := newTestTracker("empty", 0)
+
+	if cmp(empty, busy) {
+		t.Fatal("empty-pending peer must not outrank pending peer")
+	}
+	if !cmp(busy, empty) {
+		t.Fatal("pending peer must outrank empty-pending peer")
+	}
+}
+
+// TestFairComparatorNeverServedBeatsSteady covers layer 2 (never-served
+// branch): a fresh peer with one pending want outranks a just-served peer,
+// even when the steady peer holds vastly more pending work. This is #1141
+// at the comparator level.
+func TestFairComparatorNeverServedBeatsSteady(t *testing.T) {
+	s := newPeerScheduler()
+	s.markServed(peer.ID("steady"))
+	cmp := fairPeerComparator(s)
+
+	fresh := newTestTracker("fresh", 1)
+	steady := newTestTracker("steady", 100)
+
+	if !cmp(fresh, steady) {
+		t.Fatal("never-served peer must outrank steady peer")
+	}
+	if cmp(steady, fresh) {
+		t.Fatal("steady peer must not outrank never-served peer")
+	}
+}
+
+// TestFairComparatorTimeoutOverridesSteady covers layer 2 (timeout
+// branch): a peer last served longer than peerStarvationTimeout ago
+// outranks a just-served peer.
+func TestFairComparatorTimeoutOverridesSteady(t *testing.T) {
+	s := newPeerScheduler()
+	s.mu.Lock()
+	s.lastServedAt[peer.ID("late")] = time.Now().Add(-peerStarvationTimeout - time.Second)
+	s.lastServedAt[peer.ID("steady")] = time.Now()
+	s.mu.Unlock()
+	cmp := fairPeerComparator(s)
+
+	late := newTestTracker("late", 1)
+	steady := newTestTracker("steady", 100)
+
+	if !cmp(late, steady) {
+		t.Fatal("peer waiting past timeout must outrank steady peer")
+	}
+}
+
+// TestFairComparatorCappedPendingAndTiebreak covers layers 4 and 5: higher
+// capped pending wins, and ties on capped pending fall through to the
+// salted-hash tiebreak.
+func TestFairComparatorCappedPendingAndTiebreak(t *testing.T) {
+	s := newPeerScheduler()
+	now := time.Now()
+	s.mu.Lock()
+	s.lastServedAt[peer.ID("a")] = now
+	s.lastServedAt[peer.ID("b")] = now
+	s.mu.Unlock()
+	cmp := fairPeerComparator(s)
+
+	// 17 caps to 16, 3 stays at 3: higher capped pending wins.
+	a := newTestTracker("a", 17)
+	b := newTestTracker("b", 3)
+	if !cmp(a, b) {
+		t.Fatal("peer with higher capped pending must win (17 > 3 after cap)")
+	}
+
+	// 1000 and 17 both cap to 16, so layer 4 ties. Layer 5 must break
+	// antisymmetrically (exactly one side wins) and stably (same winner on
+	// every call) or the heap breaks. The direction depends on the
+	// per-process seed.
+	aBig := newTestTracker("a", 1000)
+	bMed := newTestTracker("b", 17)
+	first := cmp(aBig, bMed)
+	if first == cmp(bMed, aBig) {
+		t.Fatal("salted tiebreak must be antisymmetric")
+	}
+	for i := 0; i < 100; i++ {
+		if cmp(aBig, bMed) != first {
+			t.Fatal("salted tiebreak must be stable within a scheduler instance")
+		}
+	}
+}
+
+// TestFairComparatorTiebreakSaltVariesAcrossSchedulers checks that the
+// layer-5 tiebreak resists forgery. Two independent schedulers disagree on
+// the winner for roughly half of all peer.ID pairs; a deterministic
+// byte-compare tiebreak would agree on every pair.
+func TestFairComparatorTiebreakSaltVariesAcrossSchedulers(t *testing.T) {
+	const pairs = 256
+	now := time.Now()
+
+	flips := 0
+	for i := 0; i < pairs; i++ {
+		s1 := newPeerScheduler()
+		s2 := newPeerScheduler()
+		idA := peer.ID(fmt.Sprintf("peer-a-%03d", i))
+		idB := peer.ID(fmt.Sprintf("peer-b-%03d", i))
+
+		s1.mu.Lock()
+		s1.lastServedAt[idA] = now
+		s1.lastServedAt[idB] = now
+		s1.mu.Unlock()
+		s2.mu.Lock()
+		s2.lastServedAt[idA] = now
+		s2.lastServedAt[idB] = now
+		s2.mu.Unlock()
+
+		a := newTestTracker(string(idA), 100)
+		b := newTestTracker(string(idB), 100)
+		if fairPeerComparator(s1)(a, b) != fairPeerComparator(s2)(a, b) {
+			flips++
+		}
+	}
+	// Expected around 50%. The band stays wide so the test does not flake; a
+	// deterministic tiebreak produces 0 flips and fails loudly.
+	if flips < pairs/4 || flips > pairs*3/4 {
+		t.Fatalf("tiebreak looks non-random across schedulers: %d/%d flips", flips, pairs)
+	}
+}
+
+// BenchmarkFairPeerComparator measures per-call comparator cost. The
+// engine runs this on every heap fix-up, so the layer-2 shortcut and the
+// full layer-5 fall-through both matter under load.
+func BenchmarkFairPeerComparator(b *testing.B) {
+	s := newPeerScheduler()
+	s.markServed(peer.ID("steady"))
+	cmp := fairPeerComparator(s)
+
+	steady := newTestTracker("steady", 50)
+	fresh := newTestTracker("fresh", 1)
+
+	b.Run("layer2_starved_shortcut", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = cmp(fresh, steady)
+		}
+	})
+
+	// Two steady peers, neither starved, so the comparator walks every
+	// layer down to the peer.ID tiebreak.
+	s2 := newPeerScheduler()
+	s2.markServed(peer.ID("a"))
+	s2.markServed(peer.ID("b"))
+	cmp2 := fairPeerComparator(s2)
+	aT := newTestTracker("a", 100)
+	bT := newTestTracker("b", 100)
+
+	b.Run("layer5_fall_through", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = cmp2(aT, bT)
+		}
+	})
+}

--- a/bitswap/server/internal/decision/scheduler_test.go
+++ b/bitswap/server/internal/decision/scheduler_test.go
@@ -106,10 +106,7 @@ func TestFairSchedulerForgetsDisconnectedPeer(t *testing.T) {
 		t.Fatal("peer should be starved past timeout")
 	}
 	s.forget(p)
-	s.mu.RLock()
-	_, present := s.lastServedAt[p]
-	s.mu.RUnlock()
-	if present {
+	if _, present := s.lastServedAt.Load(p); present {
 		t.Fatal("scheduler still holds state for forgotten peer")
 	}
 }
@@ -154,10 +151,8 @@ func TestFairComparatorNeverServedBeatsSteady(t *testing.T) {
 // outranks a just-served peer.
 func TestFairComparatorTimeoutOverridesSteady(t *testing.T) {
 	s := newPeerScheduler()
-	s.mu.Lock()
-	s.lastServedAt[peer.ID("late")] = time.Now().Add(-peerStarvationTimeout - time.Second)
-	s.lastServedAt[peer.ID("steady")] = time.Now()
-	s.mu.Unlock()
+	s.recordServedAt(peer.ID("late"), time.Now().Add(-peerStarvationTimeout-time.Second))
+	s.recordServedAt(peer.ID("steady"), time.Now())
 	cmp := fairPeerComparator(s)
 
 	late := newTestTracker("late", 1)
@@ -174,10 +169,8 @@ func TestFairComparatorTimeoutOverridesSteady(t *testing.T) {
 func TestFairComparatorCappedPendingAndTiebreak(t *testing.T) {
 	s := newPeerScheduler()
 	now := time.Now()
-	s.mu.Lock()
-	s.lastServedAt[peer.ID("a")] = now
-	s.lastServedAt[peer.ID("b")] = now
-	s.mu.Unlock()
+	s.recordServedAt(peer.ID("a"), now)
+	s.recordServedAt(peer.ID("b"), now)
 	cmp := fairPeerComparator(s)
 
 	// 17 caps to 16, 3 stays at 3: higher capped pending wins.
@@ -219,14 +212,10 @@ func TestFairComparatorTiebreakSaltVariesAcrossSchedulers(t *testing.T) {
 		idA := peer.ID(fmt.Sprintf("peer-a-%03d", i))
 		idB := peer.ID(fmt.Sprintf("peer-b-%03d", i))
 
-		s1.mu.Lock()
-		s1.lastServedAt[idA] = now
-		s1.lastServedAt[idB] = now
-		s1.mu.Unlock()
-		s2.mu.Lock()
-		s2.lastServedAt[idA] = now
-		s2.lastServedAt[idB] = now
-		s2.mu.Unlock()
+		s1.recordServedAt(idA, now)
+		s1.recordServedAt(idB, now)
+		s2.recordServedAt(idA, now)
+		s2.recordServedAt(idB, now)
 
 		a := newTestTracker(string(idA), 100)
 		b := newTestTracker(string(idB), 100)


### PR DESCRIPTION
## Problem

The default decision-engine peer comparator ordered by pending-count descending, so a peer with a single want waited indefinitely behind peers with large wantlists.

This is one of contributing reasons collab cluster stopped responding after bitswap knobs got reduced earlier this month (#1141).

## This PR 

Aims to fix starvation: replace peer comparator with a fair comparator backed by a per-peer scheduler:

* promote never-served peers and peers waiting past a 10s starvation timeout above non-starved peers
* cap pending's ordering weight at 16 so large wantlists no longer dominate the tiebreak
* final tiebreak uses a per-process salted hash of peer.id, so no peer can craft an id to permanently outrank others

This only tweaks the implicit default behavior. Custom engines built with `WithTaskComparator` keep their existing behavior.

- Closes #1141
