### PR TITLE
fix(bitswap/bsnet): close streams in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `bitswap/network/bsnet`: `SendMessage` and `handleNewStream` now close streams in a background goroutine. Previously, `stream.Close` could hold the caller for up to `DefaultNegotiationTimeout` (10s) while `lazyClientConn.Close` waited for the remote peer to complete the multistream handshake. This saturated the bitswap `TaskWorkerCount` pool when peers were unresponsive and stopped bitswap from serving blocks to other peers. As a side effect, `SendMessage` no longer returns errors from `stream.Close`; close failures are logged at Debug. [#1142](https://github.com/ipfs/boxo/issues/1142)
+
 ### Security
 
 

--- a/bitswap/network/bsnet/bench_close_test.go
+++ b/bitswap/network/bsnet/bench_close_test.go
@@ -1,0 +1,66 @@
+package bsnet_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	tnet "github.com/libp2p/go-libp2p-testing/net"
+)
+
+// BenchmarkSendMessageHappyPath measures the per-call cost of SendMessage
+// against a live peer. With the async-close change, the caller returns as
+// soon as the bytes are written; the goroutine cost of spawning Close is the
+// main extra work on the happy path.
+func BenchmarkSendMessageHappyPath(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	p1, err := tnet.RandIdentity()
+	if err != nil {
+		b.Fatal(err)
+	}
+	p2, err := tnet.RandIdentity()
+	if err != nil {
+		b.Fatal(err)
+	}
+	r1 := newReceiver()
+	r2 := newReceiver()
+	_, bsnet1, _, _, msg := prepareNetwork(b, ctx, p1, r1, p2, r2)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if err := bsnet1.SendMessage(ctx, p2.ID(), msg); err != nil {
+			b.Fatalf("SendMessage failed: %v", err)
+		}
+	}
+}
+
+// BenchmarkSendMessageHappyPathParallel measures concurrent SendMessage
+// throughput. With the old synchronous close, goroutines would serialize on
+// each Close; with async close, they pipeline freely.
+func BenchmarkSendMessageHappyPathParallel(b *testing.B) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	p1, err := tnet.RandIdentity()
+	if err != nil {
+		b.Fatal(err)
+	}
+	p2, err := tnet.RandIdentity()
+	if err != nil {
+		b.Fatal(err)
+	}
+	r1 := newReceiver()
+	r2 := newReceiver()
+	_, bsnet1, _, _, msg := prepareNetwork(b, ctx, p1, r1, p2, r2)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			if err := bsnet1.SendMessage(ctx, p2.ID(), msg); err != nil {
+				b.Fatalf("SendMessage failed: %v", err)
+			}
+		}
+	})
+}

--- a/bitswap/network/bsnet/ipfs_impl.go
+++ b/bitswap/network/bsnet/ipfs_impl.go
@@ -390,15 +390,40 @@ func (bsnet *impl) SendMessage(
 		return err
 	}
 
-	// Set a read deadline to prevent Close() from blocking indefinitely
-	// when the remote peer is slow or unresponsive during multistream
-	// handshake completion.
+	// Close the stream in a background goroutine so this caller does not
+	// wait while lazyClientConn.Close completes the multistream handshake
+	// with the remote peer. Holding bitswap taskWorker goroutines on that
+	// wait can saturate the worker pool when peers are unresponsive and
+	// block service to other peers.
+	// See: https://github.com/ipfs/boxo/issues/1142
 	// See: https://github.com/multiformats/go-multistream/issues/47
-	// See: https://github.com/ipshipyard/waterworks-infra/issues/860
-	if err := s.SetReadDeadline(time.Now().Add(timeout)); err != nil {
-		log.Debugf("error setting read deadline: %s", err)
-	}
-	return s.Close()
+	closeStreamAsync(s, timeout)
+	return nil
+}
+
+// closeStreamAsync sets a read deadline on s and closes s in a new goroutine,
+// so lazyClientConn.Close, which completes the multistream handshake by
+// reading from the remote, cannot block the caller. The caller must not use
+// s after calling this function.
+//
+// Close errors are logged at Debug, matching the pre-async behavior when
+// bitswap/server.sendBlocks logged the error returned from SendMessage. A
+// recover() guard catches panics so that a bug in go-libp2p or
+// go-multistream cannot bring down the process from a detached goroutine.
+func closeStreamAsync(s network.Stream, timeout time.Duration) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				log.Errorf("panic during async stream close to %s: %v", s.Conn().RemotePeer(), r)
+			}
+		}()
+		if err := s.SetReadDeadline(time.Now().Add(timeout)); err != nil {
+			log.Debugf("error setting read deadline on async close to %s: %s", s.Conn().RemotePeer(), err)
+		}
+		if err := s.Close(); err != nil {
+			log.Debugf("failed to close stream to %s: %s", s.Conn().RemotePeer(), err)
+		}
+	}()
 }
 
 func (bsnet *impl) newStreamToPeer(ctx context.Context, p peer.ID) (network.Stream, error) {
@@ -447,7 +472,10 @@ func (bsnet *impl) IsConnectedToPeer(ctx context.Context, p peer.ID) bool {
 
 // handleNewStream receives a new stream from the network.
 func (bsnet *impl) handleNewStream(s network.Stream) {
-	defer s.Close()
+	// Close in a background goroutine so this handler does not wait on
+	// lazyClientConn.Close's multistream handshake read when the remote
+	// peer has gone silent. See https://github.com/ipfs/boxo/issues/1142.
+	defer closeStreamAsync(s, minSendTimeout)
 
 	// In HTTPnet this metric measures sending the request and reading the
 	// response.

--- a/bitswap/network/bsnet/ipfs_impl_test.go
+++ b/bitswap/network/bsnet/ipfs_impl_test.go
@@ -22,11 +22,13 @@ import (
 	"github.com/libp2p/go-libp2p/core/protocol"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	"github.com/multiformats/go-multistream"
+	"github.com/stretchr/testify/require"
 )
 
 // receiver implements the Receiver interface for receiving messages from the
 // Bitswap network.
 type receiver struct {
+	mu              sync.Mutex
 	peers           map[peer.ID]struct{}
 	messageReceived chan struct{}
 	connectionEvent chan bool
@@ -49,8 +51,10 @@ func (r *receiver) ReceiveMessage(
 	sender peer.ID,
 	incoming bsmsg.BitSwapMessage,
 ) {
+	r.mu.Lock()
 	r.lastSender = sender
 	r.lastMessage = incoming
+	r.mu.Unlock()
 	select {
 	case <-ctx.Done():
 	case r.messageReceived <- struct{}{}:
@@ -61,12 +65,16 @@ func (r *receiver) ReceiveError(err error) {
 }
 
 func (r *receiver) PeerConnected(p peer.ID) {
+	r.mu.Lock()
 	r.peers[p] = struct{}{}
+	r.mu.Unlock()
 	r.connectionEvent <- true
 }
 
 func (r *receiver) PeerDisconnected(p peer.ID) {
+	r.mu.Lock()
 	delete(r.peers, p)
+	r.mu.Unlock()
 	r.connectionEvent <- false
 }
 
@@ -79,6 +87,7 @@ type ErrStream struct {
 	timingOut       bool
 	closed          bool
 	blockOnClose    bool      // if true, Close() will block until deadline
+	panicOnClose    bool      // if true, Close() will panic to exercise recover()
 	readDeadlineSet bool      // tracks if SetReadDeadline was called
 	readDeadline    time.Time // the deadline that was set
 }
@@ -89,6 +98,7 @@ type ErrHost struct {
 	err          error
 	timingOut    bool
 	blockOnClose bool
+	panicOnClose bool
 	streams      []*ErrStream
 }
 
@@ -116,10 +126,15 @@ func (es *ErrStream) SetReadDeadline(t time.Time) error {
 func (es *ErrStream) Close() error {
 	es.lk.Lock()
 	blockOnClose := es.blockOnClose
+	panicOnClose := es.panicOnClose
 	readDeadlineSet := es.readDeadlineSet
 	readDeadline := es.readDeadline
 	es.closed = true
 	es.lk.Unlock()
+
+	if panicOnClose {
+		panic("simulated panic during Close")
+	}
 
 	if blockOnClose {
 		if readDeadlineSet && !readDeadline.IsZero() {
@@ -170,7 +185,7 @@ func (eh *ErrHost) NewStream(ctx context.Context, p peer.ID, pids ...protocol.ID
 		return nil, context.DeadlineExceeded
 	}
 	stream, err := eh.Host.NewStream(ctx, p, pids...)
-	estrm := &ErrStream{Stream: stream, err: eh.err, timingOut: eh.timingOut, blockOnClose: eh.blockOnClose}
+	estrm := &ErrStream{Stream: stream, err: eh.err, timingOut: eh.timingOut, blockOnClose: eh.blockOnClose, panicOnClose: eh.panicOnClose}
 
 	eh.streams = append(eh.streams, estrm)
 	return estrm, err
@@ -208,6 +223,18 @@ func (eh *ErrHost) setBlockOnClose(block bool) {
 	for _, s := range eh.streams {
 		s.lk.Lock()
 		s.blockOnClose = block
+		s.lk.Unlock()
+	}
+}
+
+func (eh *ErrHost) setPanicOnClose(p bool) {
+	eh.lk.Lock()
+	defer eh.lk.Unlock()
+
+	eh.panicOnClose = p
+	for _, s := range eh.streams {
+		s.lk.Lock()
+		s.panicOnClose = p
 		s.lk.Unlock()
 	}
 }
@@ -319,7 +346,7 @@ func TestMessageSendAndReceive(t *testing.T) {
 	}
 }
 
-func prepareNetwork(t *testing.T, ctx context.Context, p1 tnet.Identity, r1 *receiver, p2 tnet.Identity, r2 *receiver) (*ErrHost, network.BitSwapNetwork, *ErrHost, network.BitSwapNetwork, bsmsg.BitSwapMessage) {
+func prepareNetwork(t testing.TB, ctx context.Context, p1 tnet.Identity, r1 *receiver, p2 tnet.Identity, r2 *receiver) (*ErrHost, network.BitSwapNetwork, *ErrHost, network.BitSwapNetwork, bsmsg.BitSwapMessage) {
 	// create network
 	mn := mocknet.New()
 	defer mn.Close()
@@ -714,13 +741,17 @@ func TestNetworkCounters(t *testing.T) {
 	}
 }
 
-// TestSendMessageCloseDoesNotHang verifies that SendMessage calls SetReadDeadline
-// before Close(), preventing indefinite blocking when the remote peer is
-// unresponsive during multistream handshake completion.
+// TestSendMessageCloseDoesNotHang verifies that SendMessage returns promptly
+// even when Close on the underlying stream would block on the multistream
+// handshake read, and that the stream is closed in the background.
 //
-// This test uses ErrStream to simulate a blocking Close() that only unblocks
-// when SetReadDeadline has been called. This proves the fix works without
-// relying on real network timeouts.
+// Regression test for https://github.com/ipfs/boxo/issues/1142. The previous
+// fix (setting a read deadline before Close) bounded the hang but still held
+// the caller for the length of the deadline. SendMessage now runs Close in a
+// background goroutine, so the caller returns as soon as the message bytes
+// are written, preserving the task-worker pool under unresponsive peers.
+//
+// ErrStream simulates a Close that blocks until the read deadline fires.
 func TestSendMessageCloseDoesNotHang(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -730,32 +761,128 @@ func TestSendMessageCloseDoesNotHang(t *testing.T) {
 	p2 := tnet.RandIdentityOrFatal(t)
 	r2 := newReceiver()
 
-	// Use prepareNetwork but we'll configure blocking after
 	eh1, bsnet1, _, _, msg := prepareNetwork(t, ctx, p1, r1, p2, r2)
 
-	// Configure h1's streams to block on Close() - this simulates the scenario
-	// where multistream handshake read would block indefinitely.
-	// With the fix, SetReadDeadline is called before Close(), so the simulated
-	// blocking will respect the deadline and unblock.
+	// Configure h1's streams to block on Close until the read deadline fires.
 	eh1.setBlockOnClose(true)
 
-	// SendMessage should complete because the fix sets a read deadline before
-	// calling Close(). The ErrStream.Close() will block until the deadline,
-	// simulating the real-world scenario where Close() would hang without
-	// a deadline.
 	start := time.Now()
 	err := bsnet1.SendMessage(ctx, p2.ID(), msg)
 	elapsed := time.Since(start)
-
-	// The sendTimeout for a small message is minSendTimeout (10s).
-	// With the fix, Close() should return after waiting until the deadline.
-	// Without the fix, it would hang forever (ErrStream.Close blocks indefinitely
-	// when blockOnClose=true and no deadline is set).
-	maxExpected := 15 * time.Second // minSendTimeout + margin
-	if elapsed > maxExpected {
-		t.Fatalf("SendMessage took %v, expected < %v (should timeout via SetReadDeadline)", elapsed, maxExpected)
+	if err != nil {
+		t.Fatalf("SendMessage returned error: %v", err)
 	}
 
-	// Error is expected because the simulated blocking causes the deadline to be reached
-	t.Logf("SendMessage returned in %v with error: %v", elapsed, err)
+	// Before the async-close change, SendMessage waited for Close to finish,
+	// which meant sitting at least one sendTimeout (10s) with blockOnClose.
+	// After the change, SendMessage returns as soon as the bytes are written.
+	const callerMax = 500 * time.Millisecond
+	if elapsed > callerMax {
+		t.Fatalf("SendMessage took %v, expected < %v (caller must not wait for Close)", elapsed, callerMax)
+	}
+	t.Logf("SendMessage returned in %v", elapsed)
+
+	// Verify the stream does get closed asynchronously. The send message
+	// deadline is sendTimeout(msg.Size()) which for a small msg is 10s; the
+	// close goroutine should finish shortly after that.
+	require.Eventually(t, func() bool {
+		for _, s := range eh1.streams {
+			s.lk.Lock()
+			closed := s.closed
+			s.lk.Unlock()
+			if closed {
+				return true
+			}
+		}
+		return false
+	}, 20*time.Second, 100*time.Millisecond, "stream was not closed by background goroutine")
+}
+
+// TestSendMessageManyCallersDoNotSerialize verifies that many concurrent
+// SendMessage calls against a peer whose Close blocks all finish promptly,
+// rather than each caller paying the full Close deadline. Before async
+// close, the task-worker pool saturated under this pattern.
+//
+// Regression test for https://github.com/ipfs/boxo/issues/1142.
+func TestSendMessageManyCallersDoNotSerialize(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	p1 := tnet.RandIdentityOrFatal(t)
+	r1 := newReceiver()
+	p2 := tnet.RandIdentityOrFatal(t)
+	r2 := newReceiver()
+
+	eh1, bsnet1, _, _, msg := prepareNetwork(t, ctx, p1, r1, p2, r2)
+	eh1.setBlockOnClose(true)
+
+	const callers = 50
+	start := time.Now()
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := bsnet1.SendMessage(ctx, p2.ID(), msg); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	elapsed := time.Since(start)
+
+	for err := range errs {
+		t.Errorf("SendMessage returned error: %v", err)
+	}
+
+	// If callers paid the sendTimeout each (10s), 50 serialized calls would
+	// take many minutes; concurrent in a 12-worker pool it would still take
+	// around (50 * 10s) / 12 = 41s. With async close they should all finish
+	// within a couple of seconds.
+	const maxExpected = 5 * time.Second
+	if elapsed > maxExpected {
+		t.Fatalf("%d concurrent SendMessage calls took %v, expected < %v", callers, elapsed, maxExpected)
+	}
+	t.Logf("%d concurrent SendMessage calls finished in %v", callers, elapsed)
+}
+
+// TestSendMessagePanicInCloseIsRecovered verifies that a panic inside the
+// async close goroutine does not crash the process. The caller must still
+// return cleanly, because the panic happens in a goroutine the caller does
+// not wait on.
+//
+// Guards the defensive recover() in closeStreamAsync for
+// https://github.com/ipfs/boxo/issues/1142.
+func TestSendMessagePanicInCloseIsRecovered(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	p1 := tnet.RandIdentityOrFatal(t)
+	r1 := newReceiver()
+	p2 := tnet.RandIdentityOrFatal(t)
+	r2 := newReceiver()
+
+	eh1, bsnet1, _, _, msg := prepareNetwork(t, ctx, p1, r1, p2, r2)
+	eh1.setPanicOnClose(true)
+
+	// SendMessage must not surface the panic; the recover() in the close
+	// goroutine swallows it and logs at Error level.
+	err := bsnet1.SendMessage(ctx, p2.ID(), msg)
+	require.NoError(t, err)
+
+	// Give the close goroutine a moment to run and recover. If recover() were
+	// missing, the process would have crashed before we got here.
+	require.Eventually(t, func() bool {
+		for _, s := range eh1.streams {
+			s.lk.Lock()
+			closed := s.closed
+			s.lk.Unlock()
+			if closed {
+				return true
+			}
+		}
+		return false
+	}, 2*time.Second, 50*time.Millisecond, "close goroutine did not mark stream closed")
 }


### PR DESCRIPTION
`SendMessage` and `handleNewStream` now close streams from a background goroutine, so `lazyClientConn.Close`'s multistream handshake read cannot hold (block/waste) bitswap task workers. 

`Close` errors are logged at Debug; a `recover()` guard keeps a panic in libp2p or multistream internals from crashing the process.

- Fixes #1142

<!--
Please update the CHANGELOG.md if you're modifying Go files. If your change does not require a changelog entry, please do one of the following:
- add `[skip changelog]` to the PR title
- label the PR with `skip/changelog`
-->
