### PR TITLE
fix(bitswap): duplicated "the" in error_tracker and messagequeue comments

### DIFF
--- a/bitswap/client/internal/messagequeue/messagequeue.go
+++ b/bitswap/client/internal/messagequeue/messagequeue.go
@@ -594,7 +594,7 @@ func (mq *MessageQueue) sendMessage() {
 		mq.simulateDontHaveWithTimeout(wantlist)
 
 		// If the message was too big and only a subset of wants could be sent,
-		// send more if the the workcount is above the cutoff. Otherwise,
+		// send more if the workcount is above the cutoff. Otherwise,
 		// schedule sending the rest of the wants in the next iteration of the
 		// event loop.
 		pendingWork := mq.pendingWorkCount()

--- a/bitswap/network/httpnet/error_tracker.go
+++ b/bitswap/network/httpnet/error_tracker.go
@@ -29,7 +29,7 @@ func (et *errorTracker) stopTracking(p peer.ID) {
 	et.mux.Unlock()
 }
 
-// logErrors adds n to the current error count for p. If the total count is above the threshold, then an error is returned. If n is 0, the the total count is reset to 0.
+// logErrors adds n to the current error count for p. If the total count is above the threshold, then an error is returned. If n is 0, the total count is reset to 0.
 func (et *errorTracker) logErrors(p peer.ID, n int, threshold int) error {
 	et.mux.Lock()
 	defer et.mux.Unlock()


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in bitswap source comments:
- `bitswap/network/httpnet/error_tracker.go` — "If n is 0, the the total count is reset to 0." → "If n is 0, the total count is reset to 0."
- `bitswap/client/internal/messagequeue/messagequeue.go` — "// send more if the the workcount is above the cutoff." → "// send more if the workcount is above the cutoff."

No code/behavior change.