### PR TITLE
chore: improve reprovider with batch queue reads

### DIFF
--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -36,6 +36,13 @@ const (
 	// MAGIC: Maximum duration during which no workers are available to provide a
 	// cid before a warning is triggered.
 	provideDelayWarnDuration = 15 * time.Second
+
+	// batchReadSize is number of CIDs to read from provide queue in one visit.
+	batchReadSize = 2048
+
+	// dedupCacheSize is the number of CIDs which deduplication is done across.
+	// Set to 0 is disable deduplication.
+	dedupCacheSize = 2048
 )
 
 var log = logging.Logger("provider")
@@ -146,7 +153,7 @@ func New(ds datastore.Batching, opts ...Option) (System, error) {
 	}
 
 	s.ds = namespace.Wrap(ds, s.keyPrefix)
-	s.q = dsqueue.New(s.ds, "provide", dsqueue.WithDedupCacheSize(2048))
+	s.q = dsqueue.New(s.ds, "provide", dsqueue.WithDedupCacheSize(dedupCacheSize))
 
 	// This is after the options processing so we do not have to worry about leaking a context if there is an
 	// initialization error processing the options
@@ -345,8 +352,6 @@ func (s *reprovider) provideWorker() {
 		}
 		provideOperation(s.ctx, c)
 	}
-
-	const batchReadSize = 2048
 
 	for data := range s.q.Out() {
 		provideCid(data)

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -347,9 +347,8 @@ func (s *reprovider) provideWorker() {
 	}
 
 	const batchReadSize = 2048
-	provCh := s.q.Out()
 
-	for data := range provCh {
+	for data := range s.q.Out() {
 		provideCid(data)
 		buf, err := s.q.GetN(batchReadSize)
 		if err != nil {

--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -278,7 +278,6 @@ func (s *reprovider) run() {
 
 func (s *reprovider) provideWorker() {
 	defer s.closewg.Done()
-	provCh := s.q.Out()
 
 	provideFunc := func(ctx context.Context, c cid.Cid) {
 		log.Debugf("provider worker: providing %s", c)
@@ -334,17 +333,32 @@ func (s *reprovider) provideWorker() {
 		}
 	}
 
-	for data := range provCh {
+	provideCid := func(data []byte) {
 		c, err := cid.Parse(data)
 		if err != nil {
 			log.Errorf("invalid cid read from queue: %s", err)
-			continue
+			return
 		}
 		if err = verifcid.ValidateCid(s.allowlist, c); err != nil {
 			log.Errorf("insecure hash in reprovider, %s (%s)", c, err)
-			continue
+			return
 		}
 		provideOperation(s.ctx, c)
+	}
+
+	const batchReadSize = 2048
+	provCh := s.q.Out()
+
+	for data := range provCh {
+		provideCid(data)
+		buf, err := s.q.GetN(batchReadSize)
+		if err != nil {
+			log.Errorf("error fetching data from queue: %s", err)
+			continue
+		}
+		for _, data = range buf {
+			provideCid(data)
+		}
 	}
 }
 


### PR DESCRIPTION
Improve reprovider queue efficiency by attempting a batch read whenever more data is available.
