### PR TITLE
feat(gateway): always answer empty identity probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `gateway`: `GET`/`HEAD /ipfs/bafkqaaa?format=raw` now always returns `200` with an empty body, so probing clients keep marking the gateway as functional even when its backend cannot serve identity CIDs. `bitswap/network/httpnet` sends this [trustless gateway probe](https://specs.ipfs.tech/http-gateways/trustless-gateway/#dedicated-probe-paths) to check providers, and a failed probe drops the provider. Exported as `gateway.EmptyIdentityCID`. [#1179](https://github.com/ipfs/boxo/pull/1179)
+
 ### Changed
 
 ### Removed

--- a/gateway/backend_blocks.go
+++ b/gateway/backend_blocks.go
@@ -391,7 +391,7 @@ func (bb *BlocksBackend) Head(ctx context.Context, path path.ImmutablePath) (Con
 // emptyRoot is a CAR root with the empty identity CID. CAR files are recommended
 // to always include a CID in their root, even if it's just the empty CID.
 // https://ipld.io/specs/transport/car/carv1/#number-of-roots
-var emptyRoot = []cid.Cid{cid.MustParse("bafkqaaa")}
+var emptyRoot = []cid.Cid{EmptyIdentityCID}
 
 func (bb *BlocksBackend) GetCAR(ctx context.Context, p path.ImmutablePath, params CarParams) (ContentPathMetadata, io.ReadCloser, error) {
 	pathMetadata, resolveErr := bb.ResolvePath(ctx, p)

--- a/gateway/handler_block.go
+++ b/gateway/handler_block.go
@@ -7,16 +7,49 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/ipfs/boxo/files"
+	"github.com/ipfs/go-cid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// EmptyIdentityCIDString is the canonical string form of [EmptyIdentityCID].
+const EmptyIdentityCIDString = "bafkqaaa"
+
+// EmptyIdentityCID is the empty block addressed with an identity multihash:
+// CIDv1, raw codec, zero-length digest (bytes 0x01 0x55 0x00 0x00). Because the
+// multihash is an identity hash, the block's content (zero bytes) is encoded in
+// the CID itself, so it can be served without any blockstore or network lookup.
+//
+// The trustless gateway specification designates this CID as the probe for
+// checking whether an endpoint is a working trustless gateway, and requires a
+// 200 OK with an empty body for a raw-block request:
+// https://specs.ipfs.tech/http-gateways/trustless-gateway/#dedicated-probe-paths
+//
+// boxo's bitswap HTTP client (bitswap/network/httpnet) sends HEAD and GET
+// requests for this CID with ?format=raw to probe providers before fetching
+// real blocks and to ping connected ones. [handler.serveRawBlock] answers those
+// requests directly so the gateway returns 200 with an empty body even when the
+// configured [IPFSBackend] cannot reconstruct identity CIDs from the CID alone.
+var EmptyIdentityCID = cid.MustParse(EmptyIdentityCIDString)
 
 // serveRawBlock returns bytes behind a raw block
 func (i *handler) serveRawBlock(ctx context.Context, w http.ResponseWriter, r *http.Request, rq *requestData) bool {
 	ctx, span := spanTrace(ctx, "Handler.ServeRawBlock", trace.WithAttributes(attribute.String("path", rq.immutablePath.String())))
 	defer span.End()
 
-	pathMetadata, data, err := i.backend.GetBlock(ctx, rq.mostlyResolvedPath())
+	var pathMetadata ContentPathMetadata
+	var data files.File
+	var err error
+	if isEmptyIdentityProbe(rq) {
+		// Serve the well-known empty identity block ([EmptyIdentityCID]) without
+		// touching the backend. This keeps the trustless-gateway probe and
+		// bitswap httpnet pings working even when the backend cannot serve
+		// identity CIDs. See [EmptyIdentityCID] for details.
+		pathMetadata, data = emptyIdentityBlock(rq)
+	} else {
+		pathMetadata, data, err = i.backend.GetBlock(ctx, rq.mostlyResolvedPath())
+	}
 	if !i.handleRequestErrors(w, r, rq.contentPath, err) {
 		return false
 	}
@@ -71,4 +104,26 @@ func (i *handler) serveRawBlock(ctx context.Context, w http.ResponseWriter, r *h
 	}
 
 	return dataSent
+}
+
+// isEmptyIdentityProbe reports whether rq is a raw-block request for exactly
+// [EmptyIdentityCID] with no trailing path. Such requests are the probe and ping
+// defined by the trustless-gateway spec and used by bitswap httpnet.
+func isEmptyIdentityProbe(rq *requestData) bool {
+	imPath := rq.mostlyResolvedPath()
+	// The CID comparison is an allocation-free string compare and gates the
+	// segment check (which allocates) so non-probe raw requests pay nothing.
+	// Two segments means the bare CID with no remainder, e.g. /ipfs/bafkqaaa.
+	return imPath.RootCid().Equals(EmptyIdentityCID) && len(imPath.Segments()) == 2
+}
+
+// emptyIdentityBlock returns the canonical raw-block response for
+// [EmptyIdentityCID]: a zero-byte block. It is synthesized locally so the rest
+// of serveRawBlock writes the same 200 response it would for any other raw
+// block.
+func emptyIdentityBlock(rq *requestData) (ContentPathMetadata, files.File) {
+	md := ContentPathMetadata{
+		LastSegment: rq.mostlyResolvedPath(),
+	}
+	return md, files.NewBytesFile(nil)
 }

--- a/gateway/handler_block_test.go
+++ b/gateway/handler_block_test.go
@@ -1,0 +1,84 @@
+package gateway
+
+import (
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/ipfs/boxo/blockservice"
+	"github.com/ipfs/boxo/blockstore"
+	offline "github.com/ipfs/boxo/exchange/offline"
+	"github.com/ipfs/boxo/path"
+	"github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	ipld "github.com/ipfs/go-ipld-format"
+	mh "github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEmptyIdentityCIDProbeShortCircuit verifies that the trustless-gateway
+// probe (GET/HEAD /ipfs/bafkqaaa?format=raw) returns 200 with an empty body even
+// when the backend cannot reconstruct identity CIDs. The backend here is a plain
+// blockstore (no [blockstore.NewIdStore]) with an offline exchange, so a 200
+// proves the handler short-circuit answers the probe, not the backend.
+func TestEmptyIdentityCIDProbeShortCircuit(t *testing.T) {
+	bs := blockstore.NewBlockstore(dssync.MutexWrap(ds.NewMapDatastore()))
+	blockService := blockservice.New(bs, offline.Exchange(bs))
+	backend, err := NewBlocksBackend(blockService, WithNameSystem(mockNamesys{}))
+	require.NoError(t, err)
+
+	// Sanity check: the backend really cannot serve the probe block by itself.
+	_, _, err = backend.GetBlock(t.Context(), path.FromCid(EmptyIdentityCID))
+	require.True(t, ipld.IsNotFound(err), "plain backend unexpectedly served the identity block: %v", err)
+
+	ts := newTestServer(t, backend)
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			req := mustNewRequest(t, method, ts.URL+"/ipfs/"+EmptyIdentityCIDString+"?format=raw", nil)
+			req.Header.Set("Accept", rawResponseFormat)
+			res := mustDo(t, req)
+			defer res.Body.Close()
+
+			require.Equal(t, http.StatusOK, res.StatusCode)
+			require.Equal(t, rawResponseFormat, res.Header.Get("Content-Type"))
+
+			body, err := io.ReadAll(res.Body)
+			require.NoError(t, err)
+			require.Empty(t, body)
+		})
+	}
+
+	// The short-circuit is scoped to the empty identity CID only. A different
+	// identity CID is left to the backend, which here cannot reconstruct it, so
+	// the gateway must return 404 rather than an empty 200.
+	t.Run("other identity CID is not short-circuited", func(t *testing.T) {
+		otherHash, err := mh.Sum([]byte("not empty"), mh.IDENTITY, -1)
+		require.NoError(t, err)
+		otherCID := cid.NewCidV1(cid.Raw, otherHash)
+
+		req := mustNewRequest(t, http.MethodGet, ts.URL+"/ipfs/"+otherCID.String()+"?format=raw", nil)
+		req.Header.Set("Accept", rawResponseFormat)
+		res := mustDo(t, req)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusNotFound, res.StatusCode)
+	})
+}
+
+// BenchmarkIsEmptyIdentityProbe guards that the check added to every raw-block
+// request stays allocation-free for the common case (a CID that is not the
+// probe), where the CID compare short-circuits before the allocating Segments()
+// call.
+func BenchmarkIsEmptyIdentityProbe(b *testing.B) {
+	h, err := mh.Sum([]byte("a typical raw block"), mh.SHA2_256, -1)
+	require.NoError(b, err)
+	rq := &requestData{immutablePath: path.FromCid(cid.NewCidV1(cid.Raw, h))}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if isEmptyIdentityProbe(rq) {
+			b.Fatal("unexpected probe match")
+		}
+	}
+}

--- a/gateway/handler_block_test.go
+++ b/gateway/handler_block_test.go
@@ -64,6 +64,17 @@ func TestEmptyIdentityCIDProbeShortCircuit(t *testing.T) {
 		defer res.Body.Close()
 		require.Equal(t, http.StatusNotFound, res.StatusCode)
 	})
+
+	// The short-circuit matches the bare CID only. A trailing path under the
+	// empty identity CID falls through to the backend, which here cannot
+	// resolve it, so the gateway returns 404 rather than an empty 200.
+	t.Run("identity CID with trailing path is not short-circuited", func(t *testing.T) {
+		req := mustNewRequest(t, http.MethodGet, ts.URL+"/ipfs/"+EmptyIdentityCIDString+"/trailing?format=raw", nil)
+		req.Header.Set("Accept", rawResponseFormat)
+		res := mustDo(t, req)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusNotFound, res.StatusCode)
+	})
 }
 
 // BenchmarkIsEmptyIdentityProbe guards that the check added to every raw-block


### PR DESCRIPTION
This PR is a small fix that ensures people using `boxo/gateway` in their own apps do not expose "dead" endpoints that are ignored by `bitswap/network/httpnet`.

It does not impact Kubo, just third-party implementations that do not wrap blockstore with identity handler.


## Problem

`bafkqaaa` is the empty identity block the [trustless gateway spec](https://specs.ipfs.tech/http-gateways/trustless-gateway/#dedicated-probe-paths) reserves as a probe: boxo's bitswap HTTP client (`bitswap/network/httpnet`) sends `GET`/`HEAD /ipfs/bafkqaaa?format=raw` to decide whether a provider is usable, and a failed probe drops it. Serving that block relied on the backend reconstructing identity CIDs (an idstore-wrapped blockstore), which is implicit assumption and not something `boxo/gateway` test guaranteed .  A `boxo/gateway` backed by something without that support returned `404` and got dropped, even though it could serve real content fine. 

## Fix

- `serveRawBlock` answers a bare `bafkqaaa?format=raw` request (GET and HEAD) with a `200` and empty body before reaching the backend, so any `IPFSBackend` passes the probe.
- The CID is exported as `gateway.EmptyIdentityCID`.
- A cheap CID compare gates the allocating path check, so non-probe raw requests stay allocation-free.

Every boxo-based gateway now passes the probe regardless of its blockstore wiring. Out of scope: only this one CID is short-circuited (other identity CIDs still go to the backend); the client-side drop behavior and the `?format=car` probe path are unchanged.