### PR TITLE
do not use dedup cache for reprovide queue

### DIFF
--- a/provider/reprovider.go
+++ b/provider/reprovider.go
@@ -42,7 +42,7 @@ const (
 
 	// dedupCacheSize is the number of CIDs which deduplication is done across.
 	// Set to 0 is disable deduplication.
-	dedupCacheSize = 2048
+	dedupCacheSize = 0
 )
 
 var log = logging.Logger("provider")


### PR DESCRIPTION
The legacy reprovide is not the default, and the sweeping provide provides its own deduplication. People should use new sweeping provider, and additional resources should not be devoted to the legacy provider.

Closes #1180
