### PR TITLE
fix(blockstore): don't activate bloom cache if build incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,19 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `blockstore`: the Bloom filter cache no longer activates after an incomplete
+build. Previously, if `AllKeysChan` enumeration was truncated by a
+mid-iteration datastore error (which was only logged, never propagated) or by a
+cancelled context, the cache treated the closed channel as a complete build and
+activated a Bloom filter holding only a subset of the stored CIDs. It then
+answered "not present" conclusively for blocks that exist but were never
+indexed, reporting present blocks as missing (`Has` returns false,
+`Get`/`GetSize`/`View` return not-found, `DeleteBlock` becomes a silent no-op).
+The build now activates the filter only when enumeration is known to have
+completed; otherwise the cache degrades to correct pass-through. This also
+fixes a race where a cancelled build could still mark the filter active.
+[#NNNN](https://github.com/ipfs/boxo/pull/NNNN)
+
 ### Security
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ indexed, reporting present blocks as missing (`Has` returns false,
 The build now activates the filter only when enumeration is known to have
 completed; otherwise the cache degrades to correct pass-through. This also
 fixes a race where a cancelled build could still mark the filter active.
-[#NNNN](https://github.com/ipfs/boxo/pull/NNNN)
+[#1183](https://github.com/ipfs/boxo/pull/1183)
 
 ### Security
 

--- a/blockstore/allkeyschanwitherr_test.go
+++ b/blockstore/allkeyschanwitherr_test.go
@@ -1,0 +1,527 @@
+package blockstore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	blocks "github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
+	ds "github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+	syncds "github.com/ipfs/go-datastore/sync"
+	ipld "github.com/ipfs/go-ipld-format"
+)
+
+var errInjected = errors.New("simulated mid-iteration datastore error")
+
+// errAfterDS wraps a datastore and injects a mid-iteration query error after
+// `after` entries have been streamed, simulating an I/O or iterator error
+// partway through enumeration (a documented possibility: see dsq.Result.Error).
+type errAfterDS struct {
+	ds.Batching
+	after int
+}
+
+func (d *errAfterDS) Query(ctx context.Context, q dsq.Query) (dsq.Results, error) {
+	res, err := d.Batching.Query(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	return dsq.ResultsWithContext(q, func(ctx context.Context, out chan<- dsq.Result) {
+		defer res.Close()
+		n := 0
+		for {
+			r, ok := res.NextSync()
+			if !ok {
+				return
+			}
+			if r.Error != nil {
+				out <- r
+				return
+			}
+			if n >= d.after {
+				out <- dsq.Result{Error: errInjected}
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case out <- r:
+			}
+			n++
+		}
+	}), nil
+}
+
+// cleanChanErrFnBS is a Blockstore whose allKeysChanWithErr returns a channel
+// that closes normally, yet reports a non-nil enumeration error. It isolates
+// the core invariant: the Bloom build must trust the reported error, not the
+// fact that the channel closed.
+type cleanChanErrFnBS struct {
+	Blockstore
+	enumErr error
+}
+
+func (f *cleanChanErrFnBS) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
+	ch, err := f.AllKeysChan(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ch, func() error { return f.enumErr }, nil
+}
+
+func TestAllKeysChanWithErrClean(t *testing.T) {
+	bs, keys := newBlockStoreWithKeys(t, nil, 100)
+
+	e := bs.(allKeysChanWithErrer)
+	ch, errFn, err := e.allKeysChanWithErr(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(ch)
+	if err := errFn(); err != nil {
+		t.Fatalf("errFn returned error on clean enumeration: %v", err)
+	}
+	expectMatches(t, keys, got)
+}
+
+func TestAllKeysChanWithErrMidIteration(t *testing.T) {
+	const total = 100
+	const after = 10
+
+	under := syncds.MutexWrap(ds.NewMapDatastore())
+	bs := NewBlockstore(&errAfterDS{Batching: under, after: after})
+	for i := range total {
+		if err := bs.Put(t.Context(), blocks.NewBlock(fmt.Appendf(nil, "data %d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	e := bs.(allKeysChanWithErrer)
+	ch, errFn, err := e.allKeysChanWithErr(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(ch)
+
+	iterErr := errFn()
+	if iterErr == nil {
+		t.Fatal("expected errFn to report the mid-iteration error, got nil")
+	}
+	if !errors.Is(iterErr, errInjected) {
+		t.Fatalf("expected wrapped errInjected, got: %v", iterErr)
+	}
+	if len(got) >= total {
+		t.Fatalf("expected partial enumeration (< %d keys), got %d", total, len(got))
+	}
+}
+
+func TestAllKeysChanWithErrContextCancel(t *testing.T) {
+	// More keys than the channel buffer so the producer is forced to block on
+	// a send once we stop draining, making the cancellation deterministic.
+	n := 2*dsq.KeysOnlyBufSize + 10
+	bs, _ := newBlockStoreWithKeys(t, nil, n)
+
+	e := bs.(allKeysChanWithErrer)
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	ch, errFn, err := e.allKeysChanWithErr(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	<-ch // ensure enumeration started, then stop draining
+	cancel()
+
+	if iterErr := errFn(); !errors.Is(iterErr, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", iterErr)
+	}
+}
+
+func TestBloomBuildDoesNotActivateOnIncompleteEnumeration(t *testing.T) {
+	under, keys := newBlockStoreWithKeys(t, nil, 100)
+	enumErr := errors.New("incomplete enumeration")
+	fake := &cleanChanErrFnBS{Blockstore: under, enumErr: enumErr}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cachedbs, err := testBloomCached(ctx, fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitErr := cachedbs.Wait(ctx)
+	if waitErr == nil {
+		t.Fatal("expected Wait to return the build error, got nil")
+	}
+	if !errors.Is(waitErr, enumErr) {
+		t.Fatalf("expected wrapped enumErr, got: %v", waitErr)
+	}
+	if cachedbs.BloomActive() {
+		t.Fatal("bloom must not be active after an incomplete build")
+	}
+
+	// Despite the failed build, the cache must answer correctly by falling
+	// through to the underlying store.
+	for _, k := range keys {
+		has, err := cachedbs.Has(t.Context(), k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !has {
+			t.Fatalf("present block %s reported missing after incomplete build", k)
+		}
+	}
+	absent := blocks.NewBlock([]byte("definitely-absent")).Cid()
+	if has, err := cachedbs.Has(t.Context(), absent); err != nil || has {
+		t.Fatalf("absent block reported present (has=%v err=%v)", has, err)
+	}
+
+	// Get / GetSize must also pass through to the underlying store, and
+	// DeleteBlock must actually reach it (not be skipped as a no-op).
+	if blk, err := cachedbs.Get(t.Context(), keys[0]); err != nil || blk == nil {
+		t.Fatalf("Get of present block failed under inactive bloom (blk=%v err=%v)", blk, err)
+	}
+	if sz, err := cachedbs.GetSize(t.Context(), keys[0]); err != nil || sz < 0 {
+		t.Fatalf("GetSize of present block failed under inactive bloom (sz=%d err=%v)", sz, err)
+	}
+	delKey := keys[len(keys)-1]
+	if err := cachedbs.DeleteBlock(t.Context(), delKey); err != nil {
+		t.Fatal(err)
+	}
+	if has, err := cachedbs.Has(t.Context(), delKey); err != nil || has {
+		t.Fatalf("DeleteBlock under inactive bloom did not delete (has=%v err=%v)", has, err)
+	}
+}
+
+func TestBloomBuildMidIterationErrorEndToEnd(t *testing.T) {
+	const total = 1000
+	const after = 100
+
+	under := syncds.MutexWrap(ds.NewMapDatastore())
+	bs := NewBlockstore(&errAfterDS{Batching: under, after: after})
+	keys := make([]cid.Cid, 0, total)
+	for i := range total {
+		b := blocks.NewBlock(fmt.Appendf(nil, "data %d", i))
+		if err := bs.Put(t.Context(), b); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, b.Cid())
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cachedbs, err := testBloomCached(ctx, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	waitErr := cachedbs.Wait(ctx)
+	if waitErr == nil {
+		t.Fatal("expected Wait to return the incomplete-build error, got nil")
+	}
+	if !errors.Is(waitErr, errInjected) {
+		t.Fatalf("expected wrapped errInjected, got: %v", waitErr)
+	}
+	if cachedbs.BloomActive() {
+		t.Fatal("bloom must not be active after a mid-iteration enumeration error")
+	}
+
+	// All present blocks must still be reported present (pass-through).
+	for _, k := range keys {
+		has, err := cachedbs.Has(t.Context(), k)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !has {
+			t.Fatalf("present block %s reported missing", k)
+		}
+	}
+}
+
+func TestBloomBuildCleanPathActivates(t *testing.T) {
+	under, keys := newBlockStoreWithKeys(t, nil, 200)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cachedbs, err := testBloomCached(ctx, under)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := cachedbs.Wait(ctx); err != nil {
+		t.Fatalf("clean build returned error: %v", err)
+	}
+	if !cachedbs.BloomActive() {
+		t.Fatal("bloom should be active after a clean build")
+	}
+
+	for _, k := range keys {
+		if has, err := cachedbs.Has(t.Context(), k); err != nil || !has {
+			t.Fatalf("present block reported missing (has=%v err=%v)", has, err)
+		}
+	}
+	absent := blocks.NewBlock([]byte("nope-not-here")).Cid()
+	if has, err := cachedbs.Has(t.Context(), absent); err != nil || has {
+		t.Fatalf("absent block reported present (has=%v err=%v)", has, err)
+	}
+}
+
+func TestAllKeysChanWithErrForwardsThroughCacheStack(t *testing.T) {
+	const total = 100
+	const after = 10
+
+	under := syncds.MutexWrap(ds.NewMapDatastore())
+	bs := NewBlockstore(&errAfterDS{Batching: under, after: after})
+	for i := range total {
+		if err := bs.Put(t.Context(), blocks.NewBlock(fmt.Appendf(nil, "data %d", i))); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	// Default opts wrap in BOTH a two-queue cache and a Bloom filter, so the
+	// capability must traverse bloomcache -> tqcache -> base blockstore.
+	cbs, err := CachedBlockstore(ctx, bs, DefaultCacheOpts())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	e, ok := cbs.(allKeysChanWithErrer)
+	if !ok {
+		t.Fatal("CachedBlockstore result does not implement allKeysChanWithErrer")
+	}
+	ch, errFn, err := e.allKeysChanWithErr(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = collect(ch)
+	if iterErr := errFn(); !errors.Is(iterErr, errInjected) {
+		t.Fatalf("expected errInjected to propagate through the cache stack, got: %v", iterErr)
+	}
+}
+
+// legacyBS implements only the Blockstore interface (no allKeysChanWithErrer),
+// to exercise the best-effort fallback in allKeysChanWithErrFor. It must NOT
+// embed *blockstore, or the capability method would be promoted and the
+// fallback branch would never run.
+type legacyBS struct{ inner Blockstore }
+
+func (b *legacyBS) DeleteBlock(ctx context.Context, k cid.Cid) error {
+	return b.inner.DeleteBlock(ctx, k)
+}
+func (b *legacyBS) Has(ctx context.Context, k cid.Cid) (bool, error) { return b.inner.Has(ctx, k) }
+func (b *legacyBS) Get(ctx context.Context, k cid.Cid) (blocks.Block, error) {
+	return b.inner.Get(ctx, k)
+}
+
+func (b *legacyBS) GetSize(ctx context.Context, k cid.Cid) (int, error) {
+	return b.inner.GetSize(ctx, k)
+}
+func (b *legacyBS) Put(ctx context.Context, bl blocks.Block) error { return b.inner.Put(ctx, bl) }
+func (b *legacyBS) PutMany(ctx context.Context, bls []blocks.Block) error {
+	return b.inner.PutMany(ctx, bls)
+}
+
+func (b *legacyBS) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	return b.inner.AllKeysChan(ctx)
+}
+
+func TestAllKeysChanWithErrFallbackForLegacyBlockstore(t *testing.T) {
+	under, keys := newBlockStoreWithKeys(t, nil, 100)
+	legacy := &legacyBS{inner: under}
+
+	// Guard the premise: legacyBS must NOT advertise the capability, else the
+	// fallback branch is not exercised.
+	if _, ok := Blockstore(legacy).(allKeysChanWithErrer); ok {
+		t.Fatal("legacyBS unexpectedly implements allKeysChanWithErrer")
+	}
+
+	// The fallback yields a no-op errFn and a full enumeration.
+	ch, errFn, err := allKeysChanWithErrFor(t.Context(), legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(ch)
+	if err := errFn(); err != nil {
+		t.Fatalf("fallback errFn must return nil, got: %v", err)
+	}
+	expectMatches(t, keys, got)
+
+	// Over a fully-enumerable legacy store, the bloom still activates.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cachedbs, err := testBloomCached(ctx, legacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cachedbs.Wait(ctx); err != nil {
+		t.Fatalf("clean build over legacy store returned error: %v", err)
+	}
+	if !cachedbs.BloomActive() {
+		t.Fatal("bloom should activate over a fully-enumerable legacy store")
+	}
+	for _, k := range keys {
+		if has, err := cachedbs.Has(t.Context(), k); err != nil || !has {
+			t.Fatalf("present block reported missing (has=%v err=%v)", has, err)
+		}
+	}
+}
+
+func TestAllKeysChanWithErrForwardingWrappers(t *testing.T) {
+	const total = 100
+	const after = 10
+
+	newBaseWithErr := func() Blockstore {
+		under := syncds.MutexWrap(ds.NewMapDatastore())
+		bs := NewBlockstore(&errAfterDS{Batching: under, after: after})
+		for i := range total {
+			if err := bs.Put(t.Context(), blocks.NewBlock(fmt.Appendf(nil, "data %d", i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+		return bs
+	}
+
+	wrappers := map[string]func(Blockstore) Blockstore{
+		"idstore":              func(bs Blockstore) Blockstore { return NewIdStore(bs) },
+		"ValidatingBlockstore": func(bs Blockstore) Blockstore { return &ValidatingBlockstore{Blockstore: bs} },
+	}
+
+	for name, wrap := range wrappers {
+		t.Run(name, func(t *testing.T) {
+			w := wrap(newBaseWithErr())
+			e, ok := w.(allKeysChanWithErrer)
+			if !ok {
+				t.Fatalf("%s does not implement allKeysChanWithErrer", name)
+			}
+			ch, errFn, err := e.allKeysChanWithErr(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			_ = collect(ch)
+			if iterErr := errFn(); !errors.Is(iterErr, errInjected) {
+				t.Fatalf("%s did not propagate enumeration error, got: %v", name, iterErr)
+			}
+		})
+	}
+}
+
+func TestAllKeysChanWithErrSkipsUnparseableKey(t *testing.T) {
+	raw := syncds.MutexWrap(ds.NewMapDatastore())
+	bs := NewBlockstore(raw)
+
+	const total = 50
+	keys := make([]cid.Cid, 0, total)
+	for i := range total {
+		b := blocks.NewBlock(fmt.Appendf(nil, "data %d", i))
+		if err := bs.Put(t.Context(), b); err != nil {
+			t.Fatal(err)
+		}
+		keys = append(keys, b.Cid())
+	}
+
+	// Inject a datastore key under the block prefix that is not valid base32,
+	// so BinaryFromDsKey fails to parse it during enumeration.
+	badKey := BlockPrefix.ChildString("this-is-not-base32")
+	if err := raw.Put(t.Context(), badKey, []byte("garbage")); err != nil {
+		t.Fatal(err)
+	}
+
+	e := bs.(allKeysChanWithErrer)
+	ch, errFn, err := e.allKeysChanWithErr(t.Context())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := collect(ch)
+
+	// The unparseable key is skipped, NOT treated as a truncating error: it
+	// cannot correspond to a retrievable block, so it must not disable the
+	// completeness signal.
+	if err := errFn(); err != nil {
+		t.Fatalf("unparseable key must not be reported as an enumeration error, got: %v", err)
+	}
+	expectMatches(t, keys, got)
+
+	// The bloom filter still activates over such a store.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cachedbs, err := testBloomCached(ctx, bs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cachedbs.Wait(ctx); err != nil {
+		t.Fatalf("build over store with an unparseable key returned error: %v", err)
+	}
+	if !cachedbs.BloomActive() {
+		t.Fatal("bloom should activate despite an unparseable datastore key")
+	}
+}
+
+// incompleteViewerBS reports an enumeration error (so the bloom build stays
+// inactive) AND implements Viewer (so bloomcache wires up its viewer path),
+// exercising bloomcache.View's pass-through gating while inactive.
+type incompleteViewerBS struct {
+	Blockstore
+	enumErr error
+}
+
+func (f *incompleteViewerBS) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
+	ch, err := f.AllKeysChan(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ch, func() error { return f.enumErr }, nil
+}
+
+func (f *incompleteViewerBS) View(ctx context.Context, k cid.Cid, callback func([]byte) error) error {
+	blk, err := f.Get(ctx, k)
+	if err != nil {
+		return err
+	}
+	return callback(blk.RawData())
+}
+
+func TestBloomViewPassThroughWhenInactive(t *testing.T) {
+	under, keys := newBlockStoreWithKeys(t, nil, 50)
+	fake := &incompleteViewerBS{Blockstore: under, enumErr: errors.New("incomplete enumeration")}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	cachedbs, err := testBloomCached(ctx, fake)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cachedbs.Wait(ctx); err == nil {
+		t.Fatal("expected incomplete-build error")
+	}
+	if cachedbs.BloomActive() {
+		t.Fatal("bloom must be inactive")
+	}
+
+	// View passes through to the underlying viewer for a present block.
+	var got []byte
+	if err := cachedbs.View(t.Context(), keys[0], func(b []byte) error { got = append(got, b...); return nil }); err != nil {
+		t.Fatalf("View of present block failed under inactive bloom: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatal("View returned empty data for a present block")
+	}
+
+	// View of an absent block returns not-found.
+	absent := blocks.NewBlock([]byte("absent-view")).Cid()
+	if err := cachedbs.View(t.Context(), absent, func(b []byte) error { return nil }); !ipld.IsNotFound(err) {
+		t.Fatalf("View of absent block: expected not-found, got %v", err)
+	}
+}

--- a/blockstore/blockstore.go
+++ b/blockstore/blockstore.go
@@ -5,6 +5,7 @@ package blockstore
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -59,6 +60,13 @@ type Blockstore interface {
 	//
 	// When underlying blockstore is operating on Multihash and codec information
 	// is not preserved, returned CIDs will use Raw (0x55) codec.
+	//
+	// If enumeration fails partway (for example an I/O error mid-iteration or a
+	// cancelled context), the channel may be closed early without warning.
+	// Callers MUST NOT assume the returned error reflects enumeration
+	// completeness: it is only guaranteed to cover query setup, not
+	// mid-iteration failures. A consumer that requires a complete enumeration
+	// (such as building a Bloom filter) cannot rely on this method alone.
 	AllKeysChan(ctx context.Context) (<-chan cid.Cid, error)
 }
 
@@ -284,18 +292,52 @@ func (bs *blockstore) DeleteBlock(ctx context.Context, k cid.Cid) error {
 //
 // AllKeysChan respects context.
 func (bs *blockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
+	ch, _, err := bs.allKeysChanWithErr(ctx)
+	return ch, err
+}
+
+// allKeysChanWithErrer is an optional capability a Blockstore may implement
+// alongside AllKeysChan. allKeysChanWithErr behaves like AllKeysChan, but
+// additionally returns a function that, once the returned channel has been
+// fully drained, reports any error that terminated enumeration early.
+//
+// The reported error is nil if enumeration ran to completion without a
+// mid-iteration error or cancellation; a non-nil error means enumeration was
+// truncated and the delivered keys must not be treated as the complete set.
+// Datastore keys that cannot be parsed as a block key are skipped without being
+// treated as an error: such a key cannot correspond to a retrievable block, so
+// omitting it cannot cause a Bloom-filter false negative.
+//
+// The function blocks until enumeration finishes, so it must be called only
+// after the channel has been drained; calling it earlier deadlocks the caller
+// once the producer fills the channel buffer.
+type allKeysChanWithErrer interface {
+	allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error)
+}
+
+var _ allKeysChanWithErrer = (*blockstore)(nil)
+
+// allKeysChanWithErr implements [allKeysChanWithErrer]. The returned function
+// reports any error that ended key enumeration early (nil if every key was
+// delivered) and must be called only after the channel has been drained.
+func (bs *blockstore) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
 	// KeysOnly, because that would be _a lot_ of data.
 	q := dsq.Query{KeysOnly: true}
 	res, err := bs.datastore.Query(ctx, q)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	output := make(chan cid.Cid, dsq.KeysOnlyBufSize)
+	var iterErr error
+	done := make(chan struct{})
 	go func() {
 		defer func() {
 			res.Close() // ensure exit (signals early exit, too)
 			close(output)
+			// done is closed after output so a reader that drains output and
+			// then calls the returned func observes the fully-written iterErr.
+			close(done)
 		}()
 
 		for {
@@ -304,26 +346,43 @@ func (bs *blockstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 				return
 			}
 			if e.Error != nil {
-				logger.Errorf("blockstore.AllKeysChan got err: %s", e.Error)
+				iterErr = fmt.Errorf("blockstore.AllKeysChan iteration error: %w", e.Error)
+				logger.Error(iterErr)
 				return
 			}
 
 			// need to convert to key.Key using key.KeyFromDsKey.
 			bk, err := dshelp.BinaryFromDsKey(ds.RawKey(e.Key))
 			if err != nil {
+				// A key that cannot be parsed as a block key cannot correspond
+				// to a retrievable block, so skipping it (rather than treating
+				// it as a truncating error) cannot cause a Bloom false negative.
 				logger.Warnf("error parsing key from binary: %s", err)
 				continue
 			}
 			k := cid.NewCidV1(cid.Raw, bk)
 			select {
 			case <-ctx.Done():
+				iterErr = ctx.Err()
 				return
 			case output <- k:
 			}
 		}
 	}()
 
-	return output, nil
+	return output, func() error { <-done; return iterErr }, nil
+}
+
+// allKeysChanWithErrFor returns bs.allKeysChanWithErr when bs implements
+// [allKeysChanWithErrer]. Otherwise it falls back to [Blockstore.AllKeysChan]
+// with a no-op error function, preserving best-effort behavior for blockstores
+// that cannot report enumeration errors.
+func allKeysChanWithErrFor(ctx context.Context, bs Blockstore) (<-chan cid.Cid, func() error, error) {
+	if e, ok := bs.(allKeysChanWithErrer); ok {
+		return e.allKeysChanWithErr(ctx)
+	}
+	ch, err := bs.AllKeysChan(ctx)
+	return ch, func() error { return nil }, err
 }
 
 // NewGCLocker returns a default implementation of

--- a/blockstore/bloom_cache.go
+++ b/blockstore/bloom_cache.go
@@ -79,8 +79,9 @@ type bloomcache struct {
 }
 
 var (
-	_ Blockstore = (*bloomcache)(nil)
-	_ Viewer     = (*bloomcache)(nil)
+	_ Blockstore           = (*bloomcache)(nil)
+	_ Viewer               = (*bloomcache)(nil)
+	_ allKeysChanWithErrer = (*bloomcache)(nil)
 )
 
 func (b *bloomcache) BloomActive() bool {
@@ -104,15 +105,30 @@ func (b *bloomcache) build(ctx context.Context) error {
 	}()
 	defer close(b.buildChan)
 
-	ch, err := b.blockstore.AllKeysChan(ctx)
+	ch, errFn, err := allKeysChanWithErrFor(ctx, b.blockstore)
 	if err != nil {
-		b.buildErr = fmt.Errorf("AllKeysChan failed in bloomcache rebuild with: %v", err)
+		b.buildErr = fmt.Errorf("AllKeysChan failed in bloomcache build with: %w", err)
 		return b.buildErr
 	}
 	for {
 		select {
 		case key, ok := <-ch:
 			if !ok {
+				// A closed channel alone does not prove the enumeration was
+				// complete: it could have been truncated by a mid-iteration
+				// error or a cancelled context. Trust the filter only if every
+				// key was delivered, otherwise the "not in bloom" answer would
+				// be a false negative for blocks that exist but were never
+				// indexed.
+				//
+				// If the wrapped store does not implement allKeysChanWithErrer,
+				// errFn is a no-op returning nil (see allKeysChanWithErrFor) and
+				// the filter is treated as complete, preserving the pre-existing
+				// best-effort behavior for such stores.
+				if err := errFn(); err != nil {
+					b.buildErr = fmt.Errorf("bloomcache build incomplete, not activating filter: %w", err)
+					return b.buildErr
+				}
 				atomic.StoreInt32(&b.active, 1)
 				return nil
 			}
@@ -122,6 +138,12 @@ func (b *bloomcache) build(ctx context.Context) error {
 			return b.buildErr
 		}
 	}
+}
+
+// allKeysChanWithErr forwards the error-reporting enumeration to the wrapped
+// blockstore, so the completeness signal survives the cache stack.
+func (b *bloomcache) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
+	return allKeysChanWithErrFor(ctx, b.blockstore)
 }
 
 func (b *bloomcache) DeleteBlock(ctx context.Context, k cid.Cid) error {

--- a/blockstore/idstore.go
+++ b/blockstore/idstore.go
@@ -16,9 +16,10 @@ type idstore struct {
 }
 
 var (
-	_ Blockstore = (*idstore)(nil)
-	_ Viewer     = (*idstore)(nil)
-	_ io.Closer  = (*idstore)(nil)
+	_ Blockstore           = (*idstore)(nil)
+	_ Viewer               = (*idstore)(nil)
+	_ io.Closer            = (*idstore)(nil)
+	_ allKeysChanWithErrer = (*idstore)(nil)
 )
 
 func NewIdStore(bs Blockstore) Blockstore {
@@ -111,6 +112,10 @@ func (b *idstore) PutMany(ctx context.Context, bs []blocks.Block) error {
 
 func (b *idstore) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return b.bs.AllKeysChan(ctx)
+}
+
+func (b *idstore) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
+	return allKeysChanWithErrFor(ctx, b.bs)
 }
 
 func (b *idstore) Close() error {

--- a/blockstore/twoqueue_cache.go
+++ b/blockstore/twoqueue_cache.go
@@ -42,8 +42,9 @@ type tqcache struct {
 }
 
 var (
-	_ Blockstore = (*tqcache)(nil)
-	_ Viewer     = (*tqcache)(nil)
+	_ Blockstore           = (*tqcache)(nil)
+	_ Viewer               = (*tqcache)(nil)
+	_ allKeysChanWithErrer = (*tqcache)(nil)
 )
 
 func newTwoQueueCachedBS(ctx context.Context, bs Blockstore, lruSize int) (*tqcache, error) {
@@ -396,6 +397,10 @@ func (b *tqcache) queryCache(k string) (exists bool, size int, ok bool) {
 
 func (b *tqcache) AllKeysChan(ctx context.Context) (<-chan cid.Cid, error) {
 	return b.blockstore.AllKeysChan(ctx)
+}
+
+func (b *tqcache) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
+	return allKeysChanWithErrFor(ctx, b.blockstore)
 }
 
 func (b *tqcache) GCLock(ctx context.Context) Unlocker {

--- a/blockstore/validating_blockstore.go
+++ b/blockstore/validating_blockstore.go
@@ -12,6 +12,12 @@ type ValidatingBlockstore struct {
 	Blockstore
 }
 
+var _ allKeysChanWithErrer = (*ValidatingBlockstore)(nil)
+
+func (bs *ValidatingBlockstore) allKeysChanWithErr(ctx context.Context) (<-chan cid.Cid, func() error, error) {
+	return allKeysChanWithErrFor(ctx, bs.Blockstore)
+}
+
 func (bs *ValidatingBlockstore) Get(ctx context.Context, c cid.Cid) (blocks.Block, error) {
 	block, err := bs.Blockstore.Get(ctx, c)
 	if err != nil {


### PR DESCRIPTION
## Problem

The blockstore's Bloom filter cache relies on one invariant: every stored CID must be present in the filter, so a filter miss can be trusted as a conclusive "not present" answer.

The initial filter build populates itself by enumerating the datastore via `AllKeysChan`. That enumeration had two ways to end early without anyone noticing:

- **A mid-iteration datastore error.** `AllKeysChan` only logged errors returned by the underlying query (`dsq.Result.Error`) and then closed its output channel — indistinguishable from a normal, complete enumeration.
- **A cancelled context.** Cancelling the build's context could still race with the channel closing "cleanly," letting the build finish and mark the filter active anyway.

In both cases the build could not tell a truncated enumeration from a complete one, so it activated a Bloom filter that only covered a subset of the actual stored CIDs. Once active, the cache started giving **wrong, conclusive answers for blocks that really exist but were never indexed**:

- `Has` → `false`
- `Get` / `GetSize` / `View` → not-found
- `DeleteBlock` → silent no-op (doesn't reach the underlying store)

This is a correctness bug, not a performance one — it can make present data appear to have vanished.

## Fix

Add a way for the enumeration to report, after the fact, whether it actually completed:

- New internal capability interface `allKeysChanWithErrer` (`allKeysChanWithErr`) alongside `AllKeysChan`. It returns the same key channel plus a `func() error` that — once the channel is fully drained — reports whether enumeration was truncated (mid-iteration datastore error or context cancellation) or completed cleanly.
- Implemented on the base blockstore, and forwarded through every layer that can sit between the base store and the Bloom cache: `tqcache`, `idstore`, `ValidatingBlockstore`. A `allKeysChanWithErrFor` helper falls back to a no-op (always-nil) error function for any blockstore that doesn't implement the capability, preserving today's best-effort behavior for those.
- `bloomcache.build()` now checks that error function after the channel closes, and only flips the filter to active if it's nil. On a truncated or cancelled build, the filter stays inactive and the cache correctly degrades to pass-through (queries fall through to the real store) instead of serving false negatives.
- This also removes the cancellation race described above: activation now depends on the enumeration's actual terminal state rather than which branch of a `select` happens to fire when the channel closes and the context is cancelled at the same time.

Unparseable datastore keys are still skipped (not treated as a truncating error) — they can't correspond to a retrievable block, so omitting one can't cause a false negative.
