### PR TITLE
fix(gateway): renew cache freshness on 304

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ enumeration. [#1184](https://github.com/ipfs/boxo/pull/1184)
 
 ### Fixed
 
+- `gateway`: `304 Not Modified` responses to `If-None-Match` and `If-Modified-Since` now carry `Etag` and the `Cache-Control` their `200` counterpart sends, so a client cache renews its freshness window when it revalidates. A bare 304 left the stored response expired, forcing a revalidation round-trip on every request after the first expiry even when the gateway had just confirmed the content is unchanged. Together with the DNSLink TTL work above, this addresses [#329](https://github.com/ipfs/boxo/issues/329) for web content; CAR and IPNS-record downloads keep their format-specific `Etag` handling.
 - `gateway`: fixed a data race in the remote blockstore, CAR fetcher, and value store. Each picked a gateway URL out of its list using a per-instance `*rand.Rand`, which is not safe to use from more than one goroutine, so a gateway serving requests in parallel was racing on every request. They now use the top-level `math/rand/v2` functions, which are safe to share. [#1187](https://github.com/ipfs/boxo/pull/1187)
 - `blockstore`: the Bloom filter cache no longer activates after an incomplete
 build. Previously, if `AllKeysChan` enumeration was truncated by a

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -602,6 +602,94 @@ func TestHeaders(t *testing.T) {
 	})
 }
 
+func TestNotModifiedHeaders(t *testing.T) {
+	t.Parallel()
+
+	ts, backend, root := newTestServerAndNode(t, "headers-test.car")
+
+	const ttl = 42 * time.Minute
+	backend.namesys["/ipns/ttl.example.com"] = newMockNamesysItem(path.FromCid(root), ttl)
+
+	revalidate := func(t *testing.T, urlPath, accept string) (etag200, cacheControl200 string, res304 *http.Response) {
+		t.Helper()
+
+		req := mustNewRequest(t, http.MethodGet, ts.URL+urlPath, nil)
+		if accept != "" {
+			req.Header.Add("Accept", accept)
+		}
+		res := mustDoWithoutRedirect(t, req)
+		_, err := io.Copy(io.Discard, res.Body)
+		require.NoError(t, err)
+		defer res.Body.Close()
+		require.Equal(t, http.StatusOK, res.StatusCode)
+		etag200 = res.Header.Get("Etag")
+		require.NotEmpty(t, etag200)
+		cacheControl200 = res.Header.Get("Cache-Control")
+
+		req = mustNewRequest(t, http.MethodGet, ts.URL+urlPath, nil)
+		if accept != "" {
+			req.Header.Add("Accept", accept)
+		}
+		req.Header.Add("If-None-Match", etag200)
+		res304 = mustDoWithoutRedirect(t, req)
+		_, err = io.Copy(io.Discard, res304.Body)
+		require.NoError(t, err)
+		defer res304.Body.Close()
+		require.Equal(t, http.StatusNotModified, res304.StatusCode)
+		return etag200, cacheControl200, res304
+	}
+
+	// A 304 must echo the validator the client matched and the Cache-Control
+	// its 200 counterpart sends (RFC 9110, section 15.4.5), so a client cache
+	// renews its stored response (RFC 9111, section 4.3.4) instead of
+	// revalidating every subsequent request.
+
+	t.Run("304 for immutable /ipfs/ file carries Etag and Cache-Control", func(t *testing.T) {
+		t.Parallel()
+		etag, cc200, res := revalidate(t, "/ipfs/"+root.String()+"/subdir/fnord", "")
+		assert.Equal(t, etag, res.Header.Get("Etag"))
+		assert.Equal(t, immutableCacheControl, res.Header.Get("Cache-Control"))
+		assert.Equal(t, cc200, res.Header.Get("Cache-Control"))
+	})
+
+	t.Run("304 for /ipfs/ dir listing keeps the bounded dir policy", func(t *testing.T) {
+		t.Parallel()
+		// generated HTML changes between boxo versions, so its 304 must not
+		// upgrade the listing to the immutable profile
+		etag, cc200, res := revalidate(t, "/ipfs/"+root.String()+"/subdir/", "")
+		assert.Contains(t, etag, "DirIndex")
+		assert.Equal(t, etag, res.Header.Get("Etag"))
+		assert.Equal(t, "public, max-age=604800, stale-while-revalidate=2678400", res.Header.Get("Cache-Control"))
+		assert.Equal(t, cc200, res.Header.Get("Cache-Control"))
+	})
+
+	t.Run("304 for dag index HTML omits Cache-Control like its 200", func(t *testing.T) {
+		t.Parallel()
+		etag, cc200, res := revalidate(t, "/ipfs/"+root.String()+"/subdir/dag-cbor-document/", "text/html")
+		assert.Contains(t, etag, "DagIndex")
+		assert.Equal(t, etag, res.Header.Get("Etag"))
+		assert.Empty(t, cc200)
+		assert.Empty(t, res.Header.Get("Cache-Control"))
+	})
+
+	t.Run("304 for mutable /ipns/ file carries max-age from the TTL", func(t *testing.T) {
+		t.Parallel()
+		etag, cc200, res := revalidate(t, "/ipns/ttl.example.com/subdir/fnord", "")
+		assert.Equal(t, etag, res.Header.Get("Etag"))
+		assert.Equal(t, fmt.Sprintf("public, max-age=%d", int(ttl.Seconds())), res.Header.Get("Cache-Control"))
+		assert.Equal(t, cc200, res.Header.Get("Cache-Control"))
+	})
+
+	t.Run("304 for mutable /ipns/ dir listing keeps stale-while-revalidate", func(t *testing.T) {
+		t.Parallel()
+		etag, cc200, res := revalidate(t, "/ipns/ttl.example.com/subdir/", "")
+		assert.Contains(t, etag, "DirIndex")
+		assert.Equal(t, etag, res.Header.Get("Etag"))
+		assert.Equal(t, fmt.Sprintf("public, max-age=%d, stale-while-revalidate=2678400", int(ttl.Seconds())), res.Header.Get("Cache-Control"))
+		assert.Equal(t, cc200, res.Header.Get("Cache-Control"))
+	})
+}
+
 // Testing a DAG with (optional) UnixFS1.5 modification time
 func TestHeadersUnixFSModeModTime(t *testing.T) {
 	t.Parallel()
@@ -650,8 +738,14 @@ func TestHeadersUnixFSModeModTime(t *testing.T) {
 				require.NoError(t, err)
 				defer res.Body.Close()
 				if supported {
-					// 304 on exact match, can skip body
+					// 304 on exact match, can skip body. The 304 carries the
+					// validator and freshness a cache needs to renew its
+					// stored response; Last-Modified is omitted because the
+					// Etag is the stronger validator (stdlib behavior).
 					assert.Equal(t, http.StatusNotModified, res.StatusCode)
+					assert.NotEmpty(t, res.Header.Get("Etag"))
+					assert.Empty(t, res.Header.Get("Last-Modified"))
+					assert.Equal(t, immutableCacheControl, res.Header.Get("Cache-Control"))
 				} else {
 					assert.Equal(t, http.StatusOK, res.StatusCode)
 				}

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -439,12 +439,10 @@ func addCacheControlHeaders(w http.ResponseWriter, r *http.Request, contentPath 
 	}
 
 	// Set Cache-Control and Last-Modified based on contentPath properties
+	if cc := contentCacheControl(contentPath.Mutable(), ttl); cc != "" {
+		w.Header().Set("Cache-Control", cc)
+	}
 	if contentPath.Mutable() {
-		if ttl > 0 {
-			// When we know the TTL, set the Cache-Control header and disable Last-Modified.
-			w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d", int(ttl.Seconds())))
-		}
-
 		if lastMod.IsZero() {
 			// If no lastMod, set Last-Modified to the current time to leverage caching heuristics
 			// built into modern browsers: https://github.com/ipfs/kubo/pull/8074#pullrequestreview-645196768
@@ -456,8 +454,6 @@ func addCacheControlHeaders(w http.ResponseWriter, r *http.Request, contentPath 
 		}
 
 	} else {
-		w.Header().Set("Cache-Control", immutableCacheControl)
-
 		if lastMod.IsZero() {
 			// (noop) skip Last-Modified on immutable response
 			modtime = noModtime
@@ -818,10 +814,20 @@ func (i *handler) handleIfNoneMatch(w http.ResponseWriter, r *http.Request, rq *
 		dirEtag := getDirListingEtag(pathCid)
 		dagEtag := getDagIndexEtag(pathCid)
 
-		if etagMatch(ifNoneMatch, cidEtag, dirEtag, dagEtag) {
-			// Finish early if client already has a matching Etag
-			w.WriteHeader(http.StatusNotModified)
-			return true
+		// Finish early if the client already has a matching Etag. The 304
+		// echoes the validator the client matched, paired with the
+		// Cache-Control its 200 counterpart sends: plain content, generated
+		// dir listing, or dag index HTML (which sends none).
+		mutable, ttl := rq.contentPath.Mutable(), rq.ttl
+		for _, c := range []struct{ etag, cacheControl string }{
+			{cidEtag, contentCacheControl(mutable, ttl)},
+			{dirEtag, dirListingCacheControl(mutable, ttl)},
+			{dagEtag, ""},
+		} {
+			if etagMatch(ifNoneMatch, c.etag) {
+				i.write304(w, c.etag, c.cacheControl)
+				return true
+			}
 		}
 
 		// Check if the resolvedPath is an immutable path.
@@ -867,7 +873,16 @@ func (i *handler) handleIfModifiedSince(w http.ResponseWriter, r *http.Request, 
 	// but other sources of this metadata could be added in the future
 	lastModified := pathMetadata.ModTime
 	if lastModifiedMatch(ifModifiedSince, lastModified) {
-		w.WriteHeader(http.StatusNotModified)
+		// Only files carry a Last-Modified (from UnixFS mtime), so only files
+		// reach this branch. Dir listings and dag-index HTML never set
+		// Last-Modified, so clients revalidate those through If-None-Match
+		// above, where each gets its own policy. That is why the plain-content
+		// Cache-Control is the right one to echo here.
+		//
+		// Omit Last-Modified on the 304, like http.ServeContent: the Etag is
+		// the stronger validator.
+		etag := getEtag(r, pathMetadata.LastSegment.RootCid(), rq.responseFormat)
+		i.write304(w, etag, contentCacheControl(rq.contentPath.Mutable(), rq.ttl))
 		return true
 	}
 
@@ -880,6 +895,52 @@ func (i *handler) handleIfModifiedSince(w http.ResponseWriter, r *http.Request, 
 
 	rq.pathMetadata = &pathMetadata
 	return false
+}
+
+// contentCacheControl returns the Cache-Control that a 200 response carrying
+// plain content sends (see addCacheControlHeaders). Empty means the header is
+// omitted: an unknown TTL (0) on a mutable path leaves freshness to client
+// heuristics.
+func contentCacheControl(mutable bool, ttl time.Duration) string {
+	if mutable {
+		if ttl > 0 {
+			return fmt.Sprintf("public, max-age=%d", int(ttl.Seconds()))
+		}
+		return ""
+	}
+	return immutableCacheControl
+}
+
+// dirListingCacheControl returns the Cache-Control that a 200 response with a
+// generated HTML dir listing sends (see serveDirectory). The generated HTML
+// changes between boxo versions, so even immutable paths get a bounded
+// lifetime instead of the immutable profile.
+func dirListingCacheControl(mutable bool, ttl time.Duration) string {
+	if ttl > 0 {
+		// Use known TTL from IPNS Record or DNSLink TXT Record
+		return fmt.Sprintf("public, max-age=%d, stale-while-revalidate=2678400", int(ttl.Seconds()))
+	}
+	if !mutable {
+		// Cache for 1 week, serve stale cache for up to a month
+		return "public, max-age=604800, stale-while-revalidate=2678400"
+	}
+	return ""
+}
+
+// write304 replies 304 Not Modified carrying the current validator and the
+// Cache-Control a 200 for the same representation would send (RFC 9110,
+// section 15.4.5), so a client cache can update its stored response
+// (RFC 9111, section 4.3.4). A bare 304 would leave the stored copy expired,
+// and the client would revalidate on every subsequent request even though the
+// resolution was just confirmed valid for another TTL.
+func (i *handler) write304(w http.ResponseWriter, etag, cacheControl string) {
+	if etag != "" {
+		w.Header().Set("Etag", etag)
+	}
+	if cacheControl != "" {
+		w.Header().Set("Cache-Control", cacheControl)
+	}
+	w.WriteHeader(http.StatusNotModified)
 }
 
 // check if request was for one of known explicit formats,

--- a/gateway/handler_unixfs_dir.go
+++ b/gateway/handler_unixfs_dir.go
@@ -142,13 +142,8 @@ func (i *handler) serveDirectory(ctx context.Context, w http.ResponseWriter, r *
 	w.Header().Set("Etag", dirEtag)
 
 	// Set Cache-Control
-	if rq.ttl > 0 {
-		// Use known TTL from IPNS Record or DNSLink TXT Record
-		w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, stale-while-revalidate=2678400", int(rq.ttl.Seconds())))
-	} else if !rq.contentPath.Mutable() {
-		// Cache for 1 week, serve stale cache for up to a month
-		// (style of generated HTML may change, should not be cached forever)
-		w.Header().Set("Cache-Control", "public, max-age=604800, stale-while-revalidate=2678400")
+	if cc := dirListingCacheControl(rq.contentPath.Mutable(), rq.ttl); cc != "" {
+		w.Header().Set("Cache-Control", cc)
 	}
 
 	if r.Method == http.MethodHead {


### PR DESCRIPTION
## Problem

Revalidation was cheap but pointless: `304 Not Modified` responses carried no headers, so a client cache stayed expired and revalidated on every request, even right after the gateway confirmed the content is unchanged.

## Fix

- 304s echo the validator the client matched plus the `Cache-Control` its 200 counterpart sends[^1]: TTL-derived or immutable for content, the bounded dir-listing policy for generated listings, none for dag index HTML. Caches use these headers to freshen the stored response[^2].
- The policies live in helpers shared by the 200 and 304 paths, so they cannot drift apart.

CAR and IPNS-record downloads keep their format-specific `Etag` handling.

Closes #329

[^1]: [RFC 9110, section 15.4.5](https://httpwg.org/specs/rfc9110.html#status.304): a 304 SHOULD carry the headers that would have been sent in a 200.
[^2]: [RFC 9111, section 4.3.4](https://httpwg.org/specs/rfc9111.html#freshening.responses): a cache updates its stored response with the 304's header fields.