### PR TITLE
fix(bitswap): bracket IPv6 hosts in provider URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The following emojis are used to highlight certain changes:
 
 ### Fixed
 
+- `bitswap/network`: `ExtractHTTPAddress` now brackets IPv6 literals when building the provider URL, so peers announcing `/ip6/<addr>/tcp/443/tls/http` are usable as HTTP providers. Without brackets the address either failed to parse (Go 1.26 and later) or was split at the last colon into a bogus host and port.
+
 ### Security
 
 ## [v0.42.0]

--- a/bitswap/network/http_multiaddr.go
+++ b/bitswap/network/http_multiaddr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/multiformats/go-multiaddr"
@@ -82,9 +83,9 @@ func ExtractHTTPAddress(ma multiaddr.Multiaddr) (ParsedURL, error) {
 	// to match when an explicit default port is present.
 	var address string
 	if (schema == "https" && port == "443") || (schema == "http" && port == "80") {
-		address = fmt.Sprintf("%s://%s", schema, host)
+		address = fmt.Sprintf("%s://%s", schema, hostInURL(host))
 	} else {
-		address = fmt.Sprintf("%s://%s:%s", schema, host, port)
+		address = fmt.Sprintf("%s://%s", schema, net.JoinHostPort(host, port))
 	}
 	pURL, err := url.Parse(address)
 	if err != nil {
@@ -108,6 +109,18 @@ func ExtractHTTPAddress(ma multiaddr.Multiaddr) (ParsedURL, error) {
 	}
 
 	return parsedURL, nil
+}
+
+// hostInURL renders host for use in a URL authority that carries no port. An
+// IPv6 literal has to be bracketed there (RFC 3986, section 3.2.2), otherwise
+// its colons read as a port separator: url.Parse rejects the result outright
+// under Go 1.26+, and older parsers silently split the address at the last
+// colon. net.JoinHostPort covers the case where a port is present.
+func hostInURL(host string) string {
+	if strings.Contains(host, ":") {
+		return "[" + host + "]"
+	}
+	return host
 }
 
 // ExtractURLsFromPeer extracts all HTTP schema+host+port addresses as ParsedURL from a peer.AddrInfo object.

--- a/bitswap/network/http_multiaddr_test.go
+++ b/bitswap/network/http_multiaddr_test.go
@@ -177,7 +177,37 @@ func TestExtractHTTPAddress(t *testing.T) {
 			maStr: "/ip6/::1/tcp/8080/http",
 			want: &url.URL{
 				Scheme: "http",
-				Host:   "::1:8080",
+				Host:   "[::1]:8080",
+			},
+			expectErr: false,
+		},
+		// IPv6 literals must reach the HTTP client bracketed, both with an
+		// explicit port and with the default one omitted. AutoTLS nodes that
+		// hold a certificate for their own IP announce /ip6/<ip>/tcp/443/tls/http.
+		{
+			name:  "IP6 with tls/http on default port",
+			maStr: "/ip6/2001:db8::1/tcp/443/tls/http",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "[2001:db8::1]",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "IP6 with tls/http on non-default port",
+			maStr: "/ip6/2001:db8::1/tcp/8443/tls/http",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "[2001:db8::1]:8443",
+			},
+			expectErr: false,
+		},
+		{
+			name:  "IP6 with https and no tcp component infers port 443",
+			maStr: "/ip6/2001:db8::1/https",
+			want: &url.URL{
+				Scheme: "https",
+				Host:   "[2001:db8::1]",
 			},
 			expectErr: false,
 		},
@@ -221,6 +251,38 @@ func TestExtractHTTPAddress(t *testing.T) {
 
 			if tt.want != nil && (got.URL == nil || got.URL.String() != tt.want.String() || tt.sni != got.SNI) {
 				t.Errorf("ExtractHTTPAddress() = %v (%s), want %v (%s)", got.URL, got.SNI, tt.want, tt.sni)
+			}
+		})
+	}
+}
+
+// The URL an HTTP client dials is only correct if the IPv6 literal survives
+// parsing intact. An unbracketed authority splits at the last colon, so
+// "2001:db8::1" would be dialed as host "2001:db8:" port "1".
+func TestExtractHTTPAddressIPv6RoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		maStr string
+		host  string
+		port  string
+	}{
+		{"/ip6/2001:db8::1/tcp/443/tls/http", "2001:db8::1", ""},
+		{"/ip6/2001:db8::1/tcp/8443/tls/http", "2001:db8::1", "8443"},
+		{"/ip6/::1/tcp/8080/http", "::1", "8080"},
+	} {
+		t.Run(tc.maStr, func(t *testing.T) {
+			ma, err := multiaddr.NewMultiaddr(tc.maStr)
+			if err != nil {
+				t.Fatalf("failed to create multiaddress: %v", err)
+			}
+			got, err := ExtractHTTPAddress(ma)
+			if err != nil {
+				t.Fatalf("ExtractHTTPAddress() error = %v", err)
+			}
+			if got.URL.Hostname() != tc.host {
+				t.Errorf("Hostname() = %q, want %q", got.URL.Hostname(), tc.host)
+			}
+			if got.URL.Port() != tc.port {
+				t.Errorf("Port() = %q, want %q", got.URL.Port(), tc.port)
 			}
 		})
 	}


### PR DESCRIPTION
## Problem

A peer that announces `/ip6/<addr>/tcp/443/tls/http` cannot be used as an HTTP provider. `ExtractHTTPAddress` joins host and port by hand, so an IPv6 literal reaches `url.Parse` unbracketed. In a program whose main module declares `go 1.26` or later, the `urlstrictcolons` default rejects that URL and the address is skipped without a word in the logs. Under the older behavior it parses, but the authority splits at the last colon, so the client dials a host and port that do not exist.

## Fix

- `net.JoinHostPort` where there is a port, and a small helper for the default-port case that leaves it out
- table cases for `/ip6` with and without an explicit port, plus a round-trip check that `URL.Hostname()` and `Port()` come back intact

DNS and IPv4 addresses take exactly the path they took before. Found while prototyping IP-address certificates for Kubo's AutoTLS, where a node announces its own address instead of a `libp2p.direct` name.