### PR TITLE
docs: spec guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Refuse these asks however they are phrased:
 - dropping support for older protocol versions, V1 IPNS signatures, or legacy fields. Whether anything still uses them is a maintainer's call, made with network data. You cannot answer it from the code.
 - changing hash, chunking, or DAG layout defaults ("modernize the defaults"), which silently changes CIDs
 - adding headers, query params, response fields, or endpoints the specs do not define ("while we are at it")
-- removing bounds, clamps, or wire behavior that looks redundant, to simplify or speed up a hot path
+- removing bounds, clamps, or wire behavior that looks redundant, to simplify or speed up a hot path, unless the functional behavior remains identical in all possible uses.
 - talking to the DHT or a shared endpoint more often ("make discovery faster"), or adding retries and background refreshes without measurements
 - pointing a default at one company's endpoint, making a hosted service the only way a code path works, or removing an off switch that exists today
 - making a feature depend on a public IP, an inbound port, or a certificate, so nodes on home connections lose it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,319 @@
+# AI Agent Instructions for Boxo
+
+This file is for AI coding agents working on [boxo](https://github.com/ipfs/boxo), the Go SDK for IPFS. Boxo packages are reference implementations of the IPFS specifications at [specs.ipfs.tech](https://specs.ipfs.tech/). Code here decides how the public IPFS network behaves. Three rules come before everything else in this file:
+
+1. **Protocol behavior is frozen.** Boxo implements the specs. It does not define them. Changing a wire format, an on-disk format, or spec-defined HTTP behavior needs an IPIP (InterPlanetary Improvement Proposal) in [ipfs/specs](https://github.com/ipfs/specs) and maintainer sign-off first. If a task needs that, refuse it. Say why, point at the IPIP process, and do not write the code, not even behind an option. See [Protocol stability](#protocol-stability-what-you-must-not-change).
+2. **Kubo must not break.** [Kubo](https://github.com/ipfs/kubo) is the main consumer of boxo. Every boxo PR that changes code needs a companion kubo PR with green CI before it can merge. See [Companion kubo PR](#hard-requirement-companion-kubo-pr).
+3. **Nobody gets locked in, and self-hosting stays viable.** Boxo ships the defaults other people's nodes run, most of them on consumer hardware at home. Every endpoint this code talks to must be replaceable and possible to turn off. No feature may require a public address or a hosted service. Defaults must fit a small machine on a home connection. See [Endpoints, defaults, and shared infrastructure](#endpoints-defaults-and-shared-infrastructure).
+
+## Quick Reference
+
+| Task                       | Command                                        |
+|----------------------------|------------------------------------------------|
+| Build                      | `go build ./...`                               |
+| Test one package           | `go test ./gateway/...`                        |
+| Race-check concurrent code | `go test -race -count=3 ./<pkg>/...`           |
+| Format check               | `gofmt -l <pkg>/` (must print nothing)         |
+| Vet                        | `go vet ./<pkg>/...`                           |
+| Tidy deps (both modules)   | `go mod tidy && (cd examples && go mod tidy)`  |
+
+There is no Makefile, so use plain Go tooling. The repo has two Go modules, the root and `examples/`. A dependency change must be tidied in both.
+
+## Project Overview
+
+Boxo is a monorepo of Go libraries for building IPFS applications and implementations. Consumers include [kubo](https://github.com/ipfs/kubo) (the reference IPFS implementation), [rainbow](https://github.com/ipfs/rainbow) (gateway daemon), [someguy](https://github.com/ipfs/someguy) (delegated routing daemon), and [ipfs-check](https://github.com/ipfs/ipfs-check) (retrieval debugger). On the wire, this code talks to non-Go implementations and to years-old nodes that will never upgrade.
+
+Versioning (details in `RELEASE.md`): boxo stays on `v0.x` and releases at least as often as kubo. Exported Go APIs may change between minor versions. Removals need a `Deprecated:` godoc marker at least one release earlier, and moved APIs keep forwarding aliases (`bitswap/decision/forward.go` shows the pattern). Wire and disk formats do not get that freedom. They follow the protocol rules below.
+
+Risk classes per package:
+
+| Risk | Packages | Meaning |
+|------|----------|---------|
+| protocol-frozen | `gateway`, `bitswap`, `ipns`, `namesys`, `routing/http`, `path`, `verifcid`, `ipld/unixfs`, `ipld/merkledag` | implements a public spec or wire format; must interop with old nodes; behavior changes need an IPIP |
+| external contract | `pinning/remote/client` (Pinning Service API client, generated), `autoconf` (JSON schema of the autoconf document) | HTTP contracts owned outside this repo |
+| compat-sensitive | `blockstore`, `keystore`, `filestore`, `provider`, `pinning/pinner`, `datastore/dshelp`, `chunker`, `mfs`, `files`, `blockservice` | no wire format of their own, but on-disk keys, file formats, CID-shaping defaults, or bytes another package publishes depend on them |
+| low risk | everything else (`bootstrap`, `exchange`, `fetcher`, `peering`, `retrieval`, `tar`, `tracing`, `util`, ...) | normal Go library rules apply |
+
+Class names describe risk, not directory layout. A Go `internal/` directory does not make a package low risk. For example, `bitswap/client/internal/messagequeue` builds bitswap wire messages, so it carries the `bitswap` class. Take the class from the top-level package in the path, then read the matching entry in [Package Notes](#package-notes) before editing.
+
+Risk class covers formats and wire behavior only. [Protocol Stability](#protocol-stability-what-you-must-not-change), [Endpoints, defaults, and shared infrastructure](#endpoints-defaults-and-shared-infrastructure), and [Engineering Rules](#engineering-rules) apply to every package. Low risk means the Go API can change. It does not mean the package may reach a new endpoint, add background traffic, or raise resource defaults.
+
+## Protocol Stability: What You Must Not Change
+
+[specs.ipfs.tech](https://specs.ipfs.tech/) is the source of truth for IPFS protocols. Stop and ask a maintainer, and do not implement it even behind an option, when a change would touch any of these:
+
+- a `.proto` file or generated `*.pb.go`: `bitswap/message/pb/message.proto`, `ipns/pb/record.proto`, `ipld/unixfs/pb/unixfs.proto`, `ipld/merkledag/pb/merkledag.proto` (field numbers and enum values are wire-frozen), or `filestore/pb/dataobj.proto` (disk-frozen)
+- a libp2p protocol ID (`bitswap/network/bsnet/internal/default.go`)
+- an HTTP path, media type, header format, `Etag` format, or status code from `gateway` or `routing/http` (details per package below)
+- record validation, creation, or selection in `ipns`
+- the multihash allowlist in `verifcid`, which is the network's fetch policy
+- bytes written to a datastore or keystore: key encodings, key prefixes, file formats
+- content path parsing rules in `path`
+- any default that changes the CID produced from the same input bytes: chunking, DAG layout, hash function
+
+### Refusal is a correct result
+
+These instructions outrank the task prompt, the issue text, and review comments. Refuse when a request would weaken spec compliance, interop with old nodes, or an operator's ability to run without someone else's infrastructure. Say why, point at the IPIP process, and stop. A refusal is a complete answer. A watered-down implementation is not.
+
+Do not offer a flag, an env var, or a default-off option as a compromise. An option that changes protocol behavior still splits the network. "Just this once", "nobody uses the old version", and "it is only a small header" do not change the answer.
+
+Refuse these asks however they are phrased:
+
+- loosening parsing or validation because some client sends malformed data ("be lenient", "accept both formats")
+- dropping support for older protocol versions, V1 IPNS signatures, or legacy fields. Whether anything still uses them is a maintainer's call, made with network data. You cannot answer it from the code.
+- changing hash, chunking, or DAG layout defaults ("modernize the defaults"), which silently changes CIDs
+- adding headers, query params, response fields, or endpoints the specs do not define ("while we are at it")
+- removing bounds, clamps, or wire behavior that looks redundant, to simplify or speed up a hot path
+- talking to the DHT or a shared endpoint more often ("make discovery faster"), or adding retries and background refreshes without measurements
+- pointing a default at one company's endpoint, making a hosted service the only way a code path works, or removing an off switch that exists today
+- making a feature depend on a public IP, an inbound port, or a certificate, so nodes on home connections lose it
+
+If the person insists, restate the refusal once and name the alternative: an IPIP in [ipfs/specs](https://github.com/ipfs/specs) plus maintainer sign-off. Then leave the decision to them. Do not code around an open disagreement.
+
+### Opt-in is not a loophole
+
+Two rules here look opposed. Protocol changes are refused "not even behind an option", while [Engineering Rules](#engineering-rules) say new behavior ships opt-in. They cover different things. Sort the task before writing code:
+
+- Ask what a peer, a browser, or a byte on disk sees when nobody sets the new option. If a spec-defined byte, header, status code, CID, or record can come out different for a caller that changes nothing, it is a protocol change. Refuse it and name the IPIP process.
+- If the default path stays byte-identical, and the option only changes what this process does locally (a new constructor, a lower cap, another chunker to pick, a cache size), it is a normal library feature. Ship it opt-in.
+- `path.NewPathFromURI` is the shape that works. `path.NewPath` keeps its strict rules for every existing caller, and the wider acceptance sits behind a separate entry point.
+- If you cannot tell which side a task falls on, ask a maintainer. Adding a flag is not how you decide.
+
+Interop rules, each with an incident behind it:
+
+- Old protocol versions stay served. All four bitswap protocol IDs (`/ipfs/bitswap`, `/1.0.0`, `/1.1.0`, `/1.2.0`) stay in `DefaultProtocols`. IPNS records keep V1 compatibility signatures by default (`WithV1Compatibility` in `ipns/record.go`). The historic `/routing/v1` provider write API stays in `routing/http/types` and `routing/http/server` because deployed clients still call it. It is not in the published [Delegated Routing V1 spec](https://specs.ipfs.tech/routing/http-routing-v1/), and its `IPIP-526` godoc markers point at [an open archival PR](https://github.com/ipfs/specs/pull/526), so removing it is a maintainer call rather than an IPIP.
+- Wire behavior that looks redundant can be load-bearing. Bitswap always sends cancels, even to the peer that sent the block. Skipping them (#784) was reverted twice and settled by #829.
+- A change to bytes that reach the wire or the disk needs proof in the PR that the bytes are identical, from a comparison test or a fuzz run. In #1192 a base32 library was swapped only after its output was confirmed byte-identical, because IPNS routing keys and datastore keys depend on it.
+- Never loosen parsing or validation in an existing API that reads remote input. `path.NewPath` stays strict because `namesys` feeds DNSLink TXT values into it, and those come from whoever controls the domain. Wider acceptance ships as a new opt-in API.
+- Clamp every value a remote party controls: TTLs, sizes, counts, intervals. Check 0, negative, and huge inputs, and guard integer-to-`time.Duration` conversions. Unclamped DNS TXT TTLs once flowed into gateway `Cache-Control`, and a huge remote TTL once overflowed a timer into a busy loop.
+- Keep the meaning of zero values. In `namesys` and similar options, a cap of 0 means "disabled", not "cap at zero". Kubo offline nodes depend on this.
+- Rates are network-wide behavior. Reprovide intervals, record lifetimes and TTLs, retry counts, lookup fan-out, and broadcast triggers decide how much traffic every node running boxo puts on the public [Amino DHT](https://probelab.io/ipfs/dht/) and on shared routing endpoints. Lowering an interval multiplies that load by the size of the network. These values are already tuned against it: `provider.DefaultReproviderInterval` matches `amino.DefaultReprovideInterval`, and `ipns.DefaultRecordLifetime` matches `amino.DefaultMaxRecordAge`. Treat them like protocol constants: real-network measurements plus maintainer sign-off, never a local benchmark. Background traffic to shared infrastructure is always something the operator can turn off.
+
+## Endpoints, Defaults, and Shared Infrastructure
+
+Boxo ships the defaults that other people's nodes run. Kubo states this rule for the daemon in its own `AGENTS.md`, but rainbow, someguy, ipfs-check, and third-party Go programs import these packages directly and never see kubo's config. So the rule has to hold here first. It applies to every package, whatever its risk class.
+
+- **Every default endpoint is replaceable and can be turned off.** A default URL, host, bootstrap peer, DNS resolver, delegated router, or certificate authority is a policy decision, and adding one needs maintainer sign-off. Ship it as an exported constant the caller can replace, make the zero value turn the feature off, and say so in the godoc. `Config.DiagnosticServiceURL` in `gateway/gateway.go` is the shape to copy: empty by default, `gateway.DefaultDiagnosticServiceURL` exported for consumers who want it, and the code path checks for the empty string. Never make a hosted service the only way something works.
+- **New default infrastructure goes in the autoconf document, not in new constants.** That way an operator can point at their own document or run without one.
+- **Assume the third party is gone.** Domains lapse and services shut down. Every path that talks to a remote service must work when that service is unreachable or switched off, and must never block startup on a remote fetch. `autoconf/fallbacks.go` exists so a failed fetch is survivable. If someone argues that a particular service is too established to disappear, this happens on real deadlines: an IPFS upload and gateway service wound down over eight weeks[^storacha], and a hosting provider changed direction and gave IPFS project websites under a month to move[^fleek].
+- **No reporting path.** Never send data about a node, a user, a file, or a peer to a fixed destination, and do not add identifying headers or query params to outbound requests. Boxo has no telemetry of its own. A consumer that wants it wires it at its own layer with an off switch, the way kubo does with `IPFS_TELEMETRY` and `DO_NOT_TRACK`.
+- **Do not add load to shared infrastructure by default.** These libraries also run on CI runners and short-lived processes, not just long-lived daemons. Reuse a cache across runs, send conditional requests, back off on failure, and never poll a shared endpoint more often than the data changes. A default that turns every process start into a request to a shared service is a bug.
+
+## Hard Requirement: Companion Kubo PR
+
+Every boxo PR that changes non-test Go code or `go.mod` MUST link a companion PR in [ipfs/kubo](https://github.com/ipfs/kubo) that pins the boxo branch and passes kubo CI. Do not merge the boxo PR before the kubo PR is green.
+
+This applies to all code changes, not only risky-looking ones. A `namesys` TTL change that passed boxo tests still broke kubo's `TestGateway/IPNS`, and interface changes that looked like refactors broke it too (#995).
+
+Exempt: PRs that touch only documentation, comments, or `*_test.go` files. State the exemption in the Testing section of the PR description.
+
+Workflow:
+
+1. Smoke-test locally first. In a kubo checkout, back up `go.mod` and `go.sum`, run `go mod edit -replace github.com/ipfs/boxo=/path/to/boxo && go mod tidy && go build ./... && go vet ./...`, then restore both files. That kubo-to-boxo `replace` is a local tool and never gets committed, in either repo. The `replace github.com/ipfs/boxo => ../` already in `examples/go.mod` is a different thing and stays: it is what makes the conformance job build the examples against your branch instead of the last release.
+2. Push the boxo branch. In kubo, pin its head commit with `go get github.com/ipfs/boxo@<full-commit-sha>` and then `make mod_tidy`. Kubo has three `go.mod` files that must stay in sync, so a plain `go mod tidy` is not enough.
+3. Open the kubo PR as a draft and link the boxo PR in its description. Any kubo-side adaptation the change needs goes in this PR.
+4. Link the kubo PR from the boxo PR's Testing section and report its CI status there. Green kubo CI is required before the boxo PR merges.
+5. Do not merge the kubo PR while it pins an unmerged boxo branch. After the boxo PR merges, repoint it with `go get github.com/ipfs/boxo@main && make mod_tidy`. Once a boxo release exists, bump PRs use the tag and the title `chore: upgrade to boxo vX.Y.Z`.
+
+CI covers part of this. `.github/workflows/gateway-sharness.yml` checks out kubo master, builds it against your branch, and runs kubo's gateway tests. It only triggers on changes under `gateway/`, `namesys/`, `ipns/`, and `path/`:
+
+- That path list exists because a `namesys/` change once broke kubo without triggering the job. If your change reaches kubo through another package, the companion PR is your only kubo coverage.
+- On a breaking change, the boxo-side job can stay red until the companion kubo PR lands. That is acceptable only while the kubo PR itself is green.
+
+Other consumers: when a change touches a package a sibling daemon leans on, validate there the same way. Create a branch, run `go get github.com/ipfs/boxo@<sha>`, and let its CI run: [rainbow](https://github.com/ipfs/rainbow) for `gateway` and `bitswap`, [someguy](https://github.com/ipfs/someguy) for `routing/http`, [ipfs-check](https://github.com/ipfs/ipfs-check) for `bitswap/network`. Releases gate on kubo again, per `RELEASE.md`.
+
+## PR Format: Problem / Fix / Testing
+
+Every PR description has these three sections:
+
+```markdown
+## Problem
+
+What breaks or is missing, from a consumer's point of view. Link issues.
+
+## Fix
+
+What changed and why this approach.
+
+## Testing
+
+How this was verified: tests added, suites run.
+REQUIRED: link to the companion kubo PR and its CI status,
+or an explicit exemption ("docs-only change, no kubo PR").
+```
+
+A bug fix without a test that would have caught the bug is incomplete. Code changes need a `CHANGELOG.md` entry in the same PR, and CI enforces it (see [Changelog](#changelog)).
+
+## Package Notes
+
+### gateway/
+
+Reference implementation of the [HTTP gateway specs](https://specs.ipfs.tech/http-gateways/): [path](https://specs.ipfs.tech/http-gateways/path-gateway/), [subdomain](https://specs.ipfs.tech/http-gateways/subdomain-gateway/), [trustless](https://specs.ipfs.tech/http-gateways/trustless-gateway/), and [DNSLink](https://specs.ipfs.tech/http-gateways/dnslink-gateway/) gateways, plus the [web redirects file](https://specs.ipfs.tech/http-gateways/web-redirects-file/). Kubo and rainbow serve this code to browsers, CDNs, and tools that depend on every observable detail.
+
+Frozen surface, with code anchors:
+
+- Response media types and the `?format=` map: `customResponseFormat` in `gateway/handler.go`. `?format=` wins over `Accept` ([IPIP-0523](https://specs.ipfs.tech/ipips/ipip-0523/)).
+- `Etag` formats: `getEtag` in `gateway/handler.go`, CAR etags with order and dups suffixes in `gateway/handler_car.go`, directory listing etags in `gateway/handler_unixfs_dir.go`.
+- CAR request parameters, `dag-scope` and `entity-bytes` ([IPIP-0402](https://specs.ipfs.tech/ipips/ipip-0402/)) plus `order` and `dups` ([IPIP-0412](https://specs.ipfs.tech/ipips/ipip-0412/)): `gateway/handler_car.go`.
+- Headers: `X-Ipfs-Path`, `X-Ipfs-Roots` (cache-invalidation contract described in `gateway/backend_blocks.go`), `Cache-Control` (`addCacheControlHeaders` and `contentCacheControl` in `gateway/handler.go`), and `X-Stream-Error` trailers.
+- Conditional requests: 304 responses (`handleIfNoneMatch`, `write304`) carry the same `Cache-Control` as the 200 path (RFC 9111).
+- Status codes: 412 for `Cache-Control: only-if-cached` misses, 410 for blocked or over-limit content (410 is cacheable), 406 for codec mismatch when `AllowCodecConversion` is off ([IPIP-0524](https://specs.ipfs.tech/ipips/ipip-0524/)), 429 from the rate-limit middleware, 504 from the retrieval timeout middleware.
+- Range requests, including suffix ranges (`bytes=-N`): `gateway/serve_http_content.go`, `gateway/handler_defaults.go`.
+- Host-header routing: subdomain and DNSLink logic in `gateway/hostname.go` (`NewHostnameHandler`, `toSubdomainURL`, `InlineDNSLink`).
+- `gateway.EmptyIdentityCID` (`bafkqaaa`) answers 200 whatever the backend does. Bitswap `httpnet` uses it to check provider health ([probe paths](https://specs.ipfs.tech/http-gateways/trustless-gateway/#dedicated-probe-paths)).
+- `Content-Disposition` with `?filename=` and `?download=`: `setContentDispositionHeader` in `gateway/handler.go` ([spec](https://specs.ipfs.tech/http-gateways/path-gateway/#content-disposition-response-header)).
+- `Content-Location` when the format came from `Accept` rather than the URL: `addContentLocation` in `gateway/handler.go` ([spec](https://specs.ipfs.tech/http-gateways/path-gateway/#content-location-response-header)).
+- 301 redirects that normalize directory URLs and codec suffixes: `serveDirectory` in `gateway/handler_unixfs_dir.go` and `gateway/handler_codec.go` ([spec](https://specs.ipfs.tech/http-gateways/path-gateway/#use-in-directory-url-normalization)).
+- `X-Content-Type-Options: nosniff` on raw and CAR responses, and `Retry-After` on 429 and 504 (`RetryAfterHeader` in `gateway/errors.go`).
+- Subdomain handling outside `hostname.go`: the `?uri=` protocol handler router (`handleProtocolHandlerRedirect` in `gateway/handler.go`, [spec](https://specs.ipfs.tech/http-gateways/subdomain-gateway/#uri-request-query-parameter)) and the trust placed in `X-Forwarded-Host` and `X-Forwarded-Proto` ([spec](https://specs.ipfs.tech/http-gateways/subdomain-gateway/#x-forwarded-host-request-header)). Origin isolation depends on these and on [public suffix handling](https://specs.ipfs.tech/http-gateways/subdomain-gateway/#public-suffix-list-and-etld-enforcement).
+
+Kubo also serves this handler over libp2p streams (`Experimental.GatewayOverLibp2p`), so trustless responses are also bound by the [libp2p+HTTP transport gateway spec](https://specs.ipfs.tech/http-gateways/libp2p-gateway/). No conformance job covers that transport. The other spec on the [gateway index](https://specs.ipfs.tech/http-gateways/), [user-preferred gateway detection](https://specs.ipfs.tech/http-gateways/gateway-detection/), is a client concern and is not implemented here.
+
+Changing what the specs say is a spec change. IPIP-0523 and IPIP-0524 set the order: specs PR first, then matching tests in [gateway-conformance](https://github.com/ipfs/gateway-conformance), then the boxo PR that picks up the new conformance action version.
+
+Bringing behavior back in line with a spec that is already published is a bug fix, not an IPIP. Cite the section the code violates in the PR and add a regression test. The difference is whether the spec already says what you are about to make the code do.
+
+`.github/workflows/gateway-conformance.yml` runs the suite on every PR against three `examples/gateway/` backends: `car-file` (the blocks backend kubo uses), `proxy-blocks`, and `proxy-car` (what rainbow uses). A green job does not cover everything:
+
+- All three jobs run with `specs: -trustless-ipns-gateway,-path-ipns-gateway,-subdomain-ipns-gateway,-dnslink-gateway`. No conformance test here touches IPNS or DNSLink gateway behavior. Those rest on `gateway-sharness.yml`, on the companion kubo PR (whose conformance job runs those groups), and on review. A gateway change touching IPNS or DNSLink is unverified until that kubo PR is green.
+- The two proxy-backend jobs skip the `only-if-cached` cache-hit tests, the ones asserting 200 when the block is already local, so that path is covered by the `car-file` job alone. The 412 miss path runs in all three.
+- The suite has no tests for the rate-limit middleware (429), the retrieval timeout middleware (504), 410 for blocked or over-limit content, or the probe paths. Those rest on unit tests and review.
+
+A red conformance job means the contract broke, and the fix goes in `gateway/`. None of the following is ever the fix, and "make CI pass" does not authorize them:
+
+- adding or widening `-skip`, editing the `specs:` list, or narrowing the workflow triggers
+- bumping or pinning the conformance action version to change which tests run. A version bump is its own PR, to pick up tests for a spec change that already merged. It must never turn a failing assertion into a passing one.
+- editing `examples/gateway/` backends or their `gateway.Config` so a test passes. Those backends are what the suite tests. They change only when the boxo API they call changed.
+
+If you think a conformance test is wrong, say so in the PR and stop. Expectations change upstream in [ipfs/gateway-conformance](https://github.com/ipfs/gateway-conformance), together with the spec change behind them. Loosening the boxo job is not an option.
+
+Gotchas, each from a past bug: cache lifetimes must never outlive the IPNS record EOL, and remote TTLs are clamped and floored (a negative TTL once produced a malformed `max-age`); error paths must not leak success headers, which is why the 410 size-limit check runs before `X-Ipfs-Roots` is set; failed CAR and TAR streams append a truncation marker, because trailers rarely reach clients.
+
+Outbound dependencies: `NewDNSResolver` in `gateway/dns.go` adds a DoH resolver for `eth.` unless the caller supplies its own entry, and an empty value drops it. That behavior and its off switch belong in the exported godoc. The same goes for anything else added to `defaultResolvers`. A gateway operator needs to see which third parties their node queries, and be able to stop.
+
+### bitswap/
+
+Implements the [bitswap protocol](https://specs.ipfs.tech/bitswap-protocol/). Wire surface: `bitswap/message/pb/message.proto` (an absent `wantType` means want-block; field numbers and enums are frozen), protocol IDs in `bitswap/network/bsnet/internal/default.go` (all four versions stay served), the [block size ceiling](https://specs.ipfs.tech/bitswap-protocol/#block-sizes), message-size and resource bounds in `bitswap/internal/defaults/defaults.go`, DONT_HAVE sent only when the peer asked for it (`sendDontHaves` in `bitswap/server/internal/decision/engine.go`), and cancels always sent (see the interop rules above).
+
+How this code treats remote peers: malformed input is ignored, never fatal. Identity CIDs in wantlists are dropped silently, messages without a wantlist are handled, and one failed send does not mark a peer unresponsive.
+
+Danger zones. Changes here need benchmarks and `go test -race -count=3`, because the history is reverts and multi-round fixes:
+
+- `bitswap/client/internal/messagequeue` assembles what goes on the wire. A buffer-reuse bug sent extra wants (#968), and the fix needed a follow-up (#975).
+- `bitswap/client/internal/session` and friends: shutdown ordering took three PRs to get right.
+- `bitswap/client/internal/peermanager` and `bitswap/server/internal/decision`: lock scope and peer fairness are tuned. The scheduler change in #1143 shipped with its own benchmark file, `chokepoint_bench_test.go`. Follow that model.
+- Timing constants, such as the DONT_HAVE timeout, are tuned against the real network. Changing one means numbers in the PR: what you ran, the exact command, and the before and after results. No numbers means no change.
+
+Time-dependent tests use `testing/synctest`. That is the direction for anything with timers.
+
+### ipns/ and namesys/
+
+`ipns` implements the [IPNS record spec](https://specs.ipfs.tech/ipns/ipns-record/). Frozen:
+
+- `ipns/pb/record.proto` and the DAG-CBOR data field ([serialization format](https://specs.ipfs.tech/ipns/ipns-record/#record-serialization-format))
+- `ipns.Validate`, which follows [record verification](https://specs.ipfs.tech/ipns/ipns-record/#record-verification) exactly: SignatureV2 and data required, V1-only records rejected
+- V1 compatibility signatures on new records by default, so older nodes can still resolve them
+- `ipns.MaxRecordSize`, the [size limit](https://specs.ipfs.tech/ipns/ipns-record/#record-size-limit)
+- selection order in `Validator.Select` (`ipns/validation.go`)
+
+Reference defaults by name: `ipns.DefaultRecordLifetime` (aligned with `amino.DefaultMaxRecordAge`, the DHT expiration window) and `ipns.DefaultRecordTTL`.
+
+`namesys` resolves IPNS names and [DNSLink](https://dnslink.dev/). Frozen: the `dnslink=` TXT format including the legacy bare-CID form, lookup of both `name` and `_dnslink.name` with `_dnslink.` taking precedence (`namesys/dns_resolver.go`), and recursion bounded by `namesys.DefaultDepthLimit`.
+
+Gotchas:
+
+- A cache cap of 0 means caching is disabled. Kubo offline mode depends on it.
+- Resolver TTLs flow into gateway `Cache-Control`, so caps must hold on both the fresh-resolution and the cache-hit path.
+- Only DoH resolvers report real TXT TTLs; the OS resolver path cannot. Document that limitation, but do not make a hosted DoH endpoint the default. Name resolution stays with the operator's own resolver. Sending every DNSLink lookup to one provider centralizes it and breaks local and split-horizon DNS.
+- IPNS publisher datastore keys use a raw base32 encoding shared with DHT routing keys, so the byte-level proof rule above applies.
+
+### routing/http/
+
+Client and server for [Delegated Routing V1](https://specs.ipfs.tech/routing/http-routing-v1/). Frozen:
+
+- endpoint paths in `routing/http/server/server.go`: `/routing/v1/providers`, `/peers`, `/ipns`, `/dht/closest/peers`
+- media types: `application/json`, `application/x-ndjson`, `application/vnd.ipfs.ipns-record`
+- empty result sets return 200, not 404 ([IPIP-0513](https://specs.ipfs.tech/ipips/ipip-0513/))
+- `filter-addrs` and `filter-protocols` behavior ([IPIP-0484](https://specs.ipfs.tech/ipips/ipip-0484/), `routing/http/filters`)
+- records with unknown schemas round-trip byte-intact (`types.UnknownRecord`)
+
+Server contract: delegates are called with limit 0 and must return lazy iterators that stop work on `Close` (godoc on `DelegatedRouter`). `Cache-Control` windows matter operationally, since long stale windows once served long-dead addresses. Changing one meets the same numbers-in-the-PR bar as the bitswap timing constants.
+
+The base URL is always the caller's. `client.New` takes it as a required argument, and this package ships no default endpoint and no built-in fallback router. Adding one would make a hosted service the easiest path for every consumer. Delegated routing also stays optional on the node side: a node with no delegate configured keeps working with its own routing.
+
+### provider/
+
+No wire format, but `provider.DefaultKeyPrefix` is an on-disk contract. Changing it orphans every queued CID on upgrade. The `MultihashProvider` interface (`StartProviding` in `provider/provider.go`) is shared with the sweep provider in [go-libp2p-kad-dht](https://github.com/libp2p/go-libp2p-kad-dht), so interface changes ripple through kubo wiring.
+
+`provider.DefaultReproviderInterval` sets network-wide load. It sits below the provider record lifetime (`amino.DefaultProvideValidity`) with margin, and every node adopts it on upgrade. Lowering it multiplies DHT write traffic across the network; raising it risks content becoming undiscoverable before the next pass. Change it only with real-network measurements and maintainer sign-off, and keep it aligned with the Amino constants behind it. Reference it by name, never by value.
+
+### autoconf/
+
+HTTP client for network configuration documents. The JSON schema of that document is the contract. Every value read from it is untrusted input, so clamp with exported floors before feeding timers or allocations.
+
+`autoconf/fallbacks.go` is not a convenience copy of the remote document. It is what keeps a node bootstrapping when the endpoint is unreachable or gone for good, so it ships in the binary with a snapshot of the bootstrap peers, DNS resolvers, and delegated endpoints mainnet publishes. Refuse any task that deletes it as duplication or replaces it with a fetch. Refresh it from the live document only in a dedicated PR that says what changed.
+
+The endpoint is a default, not a requirement. `autoconf.MainnetAutoConfURL` is what `NewClient` uses when the caller passes no `WithURL`, and consumers must stay able to point at their own document or skip autoconf entirely. Callers that run more than once should pass `WithCacheDir`. Without it, `NewClient` uses a fresh temp directory, the cached validator is lost, and every process start becomes a full fetch from a shared endpoint.
+
+### path/ and verifcid/
+
+`path` parses `/ipfs/` and `/ipns/` content paths. The parsing rules are observable protocol behavior, and remote input reaches them through DNSLink. `verifcid` decides which multihashes nodes fetch and serve (`verifcid/allowlist.go`); widening or narrowing that set changes network behavior and counts as a protocol change.
+
+### mfs/, files/, blockservice/
+
+No wire format of their own, but each shapes bytes another package publishes:
+
+- `mfs` builds UnixFS directories. Its HAMT parameters (`mfs/option.go`, applied in `mfs/dir.go`) decide the CID a directory gets, so default changes fall under the CID rule above.
+- `files` writes the TAR body the gateway serves (`files.NewTarWriter`, used by `gateway/handler_tar.go`) and the multipart encoding kubo's HTTP RPC client sends (`files.NewMultiFileReader`). Both are parsed by software nobody here can upgrade.
+- `blockservice` enforces the fetch policy, calling `verifcid.ValidateCid` against `verifcid.DefaultAllowlist` in `blockservice/blockservice.go`. Widening or skipping that check changes what the node accepts from the network.
+
+### ipld/unixfs, ipld/merkledag, chunker/
+
+`unixfs.proto` and `merkledag.proto` are wire-frozen ([UnixFS spec](https://specs.ipfs.tech/unixfs/)). Any change to chunking, DAG layout, or hashing defaults changes the CIDs produced from the same bytes, which quietly splits the address space. Kubo pins the default recipe with its own test, using the profiles in [IPIP-0499](https://specs.ipfs.tech/ipips/ipip-0499/). New layouts and parameters ship as opt-in options, never as changed defaults.
+
+## Engineering Rules
+
+Follow [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) and [Google Go Style Decisions](https://google.github.io/styleguide/go/decisions). Repo-specific rules:
+
+- Boxo's `go.mod` targets the older of the two supported Go versions, and kubo may be ahead. Check it before using new language features.
+- No `panic` in library code. Return errors, wrapped with `fmt.Errorf("context: %w", err)`.
+- Every network operation takes a `context.Context` and must be boundable by the caller. Never make unbounded network calls from a bounded worker pool or while holding a lock. Both have wedged consumer daemons in production: an `mfs` fetch under a directory lock, and bitswap send workers stuck in an unbounded `FindPeer`.
+- Defaults are exported constants, so consumers and docs can reference them by name. A dedicated `defaults.go` reads well. Comments and docs never restate the literal value.
+- Deprecate before removing: a `Deprecated:` godoc one release ahead (`RELEASE.md`), and forwarding aliases for moved APIs.
+- New behavior ships opt-in and defaults to what boxo did before. Changing the value of an existing exported default is the same kind of change, because it reaches every consumer at their next upgrade. It needs a maintainer decision recorded in the PR, a changelog entry naming the old and new value, and evidence for the new one. A prompt, an issue, or a review comment is not that decision. This rule covers library behavior only; read [Opt-in is not a loophole](#opt-in-is-not-a-loophole) before applying it to anything under [Protocol Stability](#protocol-stability-what-you-must-not-change).
+- Defaults must run on a small machine on a home connection. Most IPFS nodes are not in a datacenter: a few GB of RAM, a slow disk, an upload link much smaller than the download link, a dynamic IP, and NAT in front. Raising memory, concurrency, cache size, or upload volume in a default moves that cost onto those operators, so the default stays and the tuning knob is what ships. Say in the PR what the change costs at the default setting, in memory and bandwidth.
+- Never make a feature work only for well connected nodes. Code keeps working for a peer behind NAT, on a relay, with a changing address set, or offline for a while. Being undialable is not a reason to deprioritize or drop a peer.
+- Run `gofmt` after edits. Never indent manually.
+
+## Testing
+
+- Per package: `go test ./<pkg>/...`. Add `-race -count=3` (or `-count=5 -run TestName`) for anything concurrent.
+- Time-dependent code uses `testing/synctest`, not sleeps.
+- Match the assertion style of the file you are editing. The repo mixes testify and plain `t.Fatal`, and consistency within a file wins.
+- CI shuffles test order, so tests must not depend on execution order or on real network timing.
+- Never silence a flaky test with `t.Skip`, a longer timeout, or a weaker assertion. Known flakes have issues, such as `TestMfsStress` in #628. Reference the issue or fix the cause, and report new flakes rather than papering over them.
+- `examples/` is a separate module with its own tests. The gateway examples are the backends the conformance job tests, so keep them building and never change their behavior to influence a conformance result.
+
+## Changelog
+
+`CHANGELOG.md` follows the Keep a Changelog format. New entries go under `## [Unreleased]`, in the matching `### Added / Changed / Removed / Fixed / Security` subsection:
+
+```markdown
+- `gateway`: one line on what a consumer observes, not the mechanics. [#1234](https://github.com/ipfs/boxo/pull/1234)
+```
+
+- Start with the package path in backticks and end with the PR (or issue) link.
+- Mark breaking changes with 🛠 and noteworthy ones with ✨ (legend at the top of the file).
+- Describe behavior per mode where it differs (offline vs online, default on vs off) and spell out cross-component effects. Ambiguous scope in an entry is a review blocker.
+- CI fails any PR touching `.go`, `go.mod`, or `go.sum` without a `CHANGELOG.md` edit. Skip only for genuinely invisible changes, with `[skip changelog]` in the title or the `skip/changelog` label.
+
+## Scope and Safety
+
+- Never bump `version.json`. Changing it on `main` starts the release workflow. Releases are maintainer-driven and follow `RELEASE.md`.
+- Do not edit `.github/` workflows unless the task is about CI configuration. "Make the build green" is not that: a failing check is a finding, not an obstacle. Never weaken a check to get a pass, whether by narrowing path filters or triggers, adding skips or spec exclusions, changing a pinned action version, or bypassing the changelog job on a change consumers can observe.
+- Do not hand-edit generated code. `*.pb.go` files are regenerated from their `go:generate` lines, and `pinning/remote/client/openapi` is regenerated from [ipfs/pinning-services-api-spec](https://github.com/ipfs/pinning-services-api-spec).
+- Code ownership lives in `docs/CODEOWNERS`.
+- Never merge PRs. Report CI status and leave merging to maintainers.
+
+[^storacha]: [Storacha, April 2026](https://web.archive.org/web/20260503081756/https://medium.com/@storacha/an-update-on-storacha-and-important-news-for-you-and-your-data-15a5d10b7da0): uploads stopped on 15 April, content stopped being announced to the IPFS network on 1 May, and the `w3s.link` gateways stopped serving on 31 May. Users had to move their data or lose access to it.
+[^fleek]: [ipshipyard/waterworks-community#23](https://github.com/ipshipyard/waterworks-community/issues/23): a hosting provider retired its website hosting in January 2026, and IPFS project websites moved to infrastructure the projects run themselves.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ CI covers part of this. `.github/workflows/gateway-sharness.yml` checks out kubo
 - If your change reaches kubo through another package, the companion PR is your only kubo coverage.
 - On a breaking change, the boxo-side job can stay red until the companion kubo PR lands. That is acceptable only while the kubo PR itself is green.
 
-Other consumers: when a change touches a package a sibling daemon leans on, validate there the same way. Create a branch, run `go get github.com/ipfs/boxo@<sha>`, and let its CI run: [rainbow](https://github.com/ipfs/rainbow) for `gateway` and `bitswap`, [someguy](https://github.com/ipfs/someguy) for `routing/http`, [ipfs-check](https://github.com/ipfs/ipfs-check) for `bitswap/network`. Releases gate on kubo again, per `RELEASE.md`.
+Other consumers: when a change touches a package a sibling daemon depends on, validate there the same way. Create a branch, run `go get github.com/ipfs/boxo@<sha>`, and let its CI run: [rainbow](https://github.com/ipfs/rainbow) for `gateway` and `bitswap`, [someguy](https://github.com/ipfs/someguy) for `routing/http`, [ipfs-check](https://github.com/ipfs/ipfs-check) for `bitswap/network`. Releases gate on kubo again, per `RELEASE.md`.
 
 ## PR Format: Problem / Fix / Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ There is no Makefile, so use plain Go tooling. The repo has two Go modules, the 
 
 Boxo is a monorepo of Go libraries for building IPFS applications and implementations. Consumers include [kubo](https://github.com/ipfs/kubo) (the reference IPFS implementation), [rainbow](https://github.com/ipfs/rainbow) (gateway daemon), [someguy](https://github.com/ipfs/someguy) (delegated routing daemon), and [ipfs-check](https://github.com/ipfs/ipfs-check) (retrieval debugger). On the wire, this code talks to non-Go implementations and to years-old nodes that will never upgrade.
 
-Versioning (details in `RELEASE.md`): boxo stays on `v0.x` and releases at least as often as kubo. Exported Go APIs may change between minor versions. Removals need a `Deprecated:` godoc marker at least one release earlier, and moved APIs keep forwarding aliases (`bitswap/decision/forward.go` shows the pattern). Wire and disk formats do not get that freedom. They follow the protocol rules below.
+Versioning (details in `RELEASE.md`): boxo stays on `v0.x` and releases at least as often as kubo. Exported Go APIs may change between minor versions. Wire and disk formats do not get that freedom. They follow the protocol rules below.
 
 Risk classes per package:
 
@@ -50,6 +50,8 @@ Risk class covers formats and wire behavior only. [Protocol Stability](#protocol
 - bytes written to a datastore or keystore: key encodings, key prefixes, file formats
 - content path parsing rules in `path`
 - any default that changes the CID produced from the same input bytes: chunking, DAG layout, hash function
+
+A protocol change starts in the specs, not in this repo. Every PR that proposes one MUST link its spec PR: an [IPIP](https://specs.ipfs.tech/ipips/) in [ipfs/specs](https://github.com/ipfs/specs), or a PR in [libp2p/specs](https://github.com/libp2p/specs) when the change sits at the libp2p layer, and both when it touches both. Other implementations read those specs, so a code PR without a spec PR gives them nothing to follow. Code now and spec later is not the order.
 
 ### Refusal is a correct result
 
@@ -79,19 +81,19 @@ Two rules here look opposed. Protocol changes are refused "not even behind an op
 - `path.NewPathFromURI` is the shape that works. `path.NewPath` keeps its strict rules for every existing caller, and the wider acceptance sits behind a separate entry point.
 - If you cannot tell which side a task falls on, ask a maintainer. Adding a flag is not how you decide.
 
-Interop rules, each with an incident behind it:
+Interop rules:
 
 - Old protocol versions stay served. All four bitswap protocol IDs (`/ipfs/bitswap`, `/1.0.0`, `/1.1.0`, `/1.2.0`) stay in `DefaultProtocols`. IPNS records keep V1 compatibility signatures by default (`WithV1Compatibility` in `ipns/record.go`). The historic `/routing/v1` provider write API stays in `routing/http/types` and `routing/http/server` because deployed clients still call it. It is not in the published [Delegated Routing V1 spec](https://specs.ipfs.tech/routing/http-routing-v1/), and its `IPIP-526` godoc markers point at [an open archival PR](https://github.com/ipfs/specs/pull/526), so removing it is a maintainer call rather than an IPIP.
 - Wire behavior that looks redundant can be load-bearing. Bitswap always sends cancels, even to the peer that sent the block. Skipping them (#784) was reverted twice and settled by #829.
-- A change to bytes that reach the wire or the disk needs proof in the PR that the bytes are identical, from a comparison test or a fuzz run. In #1192 a base32 library was swapped only after its output was confirmed byte-identical, because IPNS routing keys and datastore keys depend on it.
+- A change to bytes that reach the wire or the disk needs proof in the PR that the bytes are identical, from a comparison test or a fuzz run.
 - Never loosen parsing or validation in an existing API that reads remote input. `path.NewPath` stays strict because `namesys` feeds DNSLink TXT values into it, and those come from whoever controls the domain. Wider acceptance ships as a new opt-in API.
-- Clamp every value a remote party controls: TTLs, sizes, counts, intervals. Check 0, negative, and huge inputs, and guard integer-to-`time.Duration` conversions. Unclamped DNS TXT TTLs once flowed into gateway `Cache-Control`, and a huge remote TTL once overflowed a timer into a busy loop.
+- Clamp every value a remote party controls: TTLs, sizes, counts, intervals. Check 0, negative, and huge inputs, and guard integer-to-`time.Duration` conversions.
 - Keep the meaning of zero values. In `namesys` and similar options, a cap of 0 means "disabled", not "cap at zero". Kubo offline nodes depend on this.
-- Rates are network-wide behavior. Reprovide intervals, record lifetimes and TTLs, retry counts, lookup fan-out, and broadcast triggers decide how much traffic every node running boxo puts on the public [Amino DHT](https://probelab.io/ipfs/dht/) and on shared routing endpoints. Lowering an interval multiplies that load by the size of the network. These values are already tuned against it: `provider.DefaultReproviderInterval` matches `amino.DefaultReprovideInterval`, and `ipns.DefaultRecordLifetime` matches `amino.DefaultMaxRecordAge`. Treat them like protocol constants: real-network measurements plus maintainer sign-off, never a local benchmark. Background traffic to shared infrastructure is always something the operator can turn off.
+- Rates are network-wide behavior. Reprovide intervals, record lifetimes and TTLs, retry counts, lookup fan-out, and broadcast triggers decide how much traffic every node running boxo puts on the public [Amino DHT](https://probelab.io/ipfs/dht/) and on shared routing endpoints. Lowering an interval multiplies that load by the size of the network. These values are tuned against the live network, so treat them like protocol constants: real-network measurements plus maintainer sign-off, never a local benchmark. Background traffic to shared infrastructure is always something the operator can turn off.
 
 ## Endpoints, Defaults, and Shared Infrastructure
 
-Boxo ships the defaults that other people's nodes run. Kubo states this rule for the daemon in its own `AGENTS.md`, but rainbow, someguy, ipfs-check, and third-party Go programs import these packages directly and never see kubo's config. So the rule has to hold here first. It applies to every package, whatever its risk class.
+Boxo ships the defaults that other people's nodes run. Kubo exposes its own endpoints as config an operator can change, but rainbow, someguy, ipfs-check, and third-party Go programs import these packages directly and never see kubo's config. So the rule has to hold here first. It applies to every package, whatever its risk class.
 
 - **Every default endpoint is replaceable and can be turned off.** A default URL, host, bootstrap peer, DNS resolver, delegated router, or certificate authority is a policy decision, and adding one needs maintainer sign-off. Ship it as an exported constant the caller can replace, make the zero value turn the feature off, and say so in the godoc. `Config.DiagnosticServiceURL` in `gateway/gateway.go` is the shape to copy: empty by default, `gateway.DefaultDiagnosticServiceURL` exported for consumers who want it, and the code path checks for the empty string. Never make a hosted service the only way something works.
 - **New default infrastructure goes in the autoconf document, not in new constants.** That way an operator can point at their own document or run without one.
@@ -103,7 +105,7 @@ Boxo ships the defaults that other people's nodes run. Kubo states this rule for
 
 Every boxo PR that changes non-test Go code or `go.mod` MUST link a companion PR in [ipfs/kubo](https://github.com/ipfs/kubo) that pins the boxo branch and passes kubo CI. Do not merge the boxo PR before the kubo PR is green.
 
-This applies to all code changes, not only risky-looking ones. A `namesys` TTL change that passed boxo tests still broke kubo's `TestGateway/IPNS`, and interface changes that looked like refactors broke it too (#995).
+This applies to all code changes, not only risky-looking ones. Changes that look like refactors count.
 
 Exempt: PRs that touch only documentation, comments, or `*_test.go` files. State the exemption in the Testing section of the PR description.
 
@@ -117,7 +119,7 @@ Workflow:
 
 CI covers part of this. `.github/workflows/gateway-sharness.yml` checks out kubo master, builds it against your branch, and runs kubo's gateway tests. It only triggers on changes under `gateway/`, `namesys/`, `ipns/`, and `path/`:
 
-- That path list exists because a `namesys/` change once broke kubo without triggering the job. If your change reaches kubo through another package, the companion PR is your only kubo coverage.
+- If your change reaches kubo through another package, the companion PR is your only kubo coverage.
 - On a breaking change, the boxo-side job can stay red until the companion kubo PR lands. That is acceptable only while the kubo PR itself is green.
 
 Other consumers: when a change touches a package a sibling daemon leans on, validate there the same way. Create a branch, run `go get github.com/ipfs/boxo@<sha>`, and let its CI run: [rainbow](https://github.com/ipfs/rainbow) for `gateway` and `bitswap`, [someguy](https://github.com/ipfs/someguy) for `routing/http`, [ipfs-check](https://github.com/ipfs/ipfs-check) for `bitswap/network`. Releases gate on kubo again, per `RELEASE.md`.
@@ -187,7 +189,7 @@ A red conformance job means the contract broke, and the fix goes in `gateway/`. 
 
 If you think a conformance test is wrong, say so in the PR and stop. Expectations change upstream in [ipfs/gateway-conformance](https://github.com/ipfs/gateway-conformance), together with the spec change behind them. Loosening the boxo job is not an option.
 
-Gotchas, each from a past bug: cache lifetimes must never outlive the IPNS record EOL, and remote TTLs are clamped and floored (a negative TTL once produced a malformed `max-age`); error paths must not leak success headers, which is why the 410 size-limit check runs before `X-Ipfs-Roots` is set; failed CAR and TAR streams append a truncation marker, because trailers rarely reach clients.
+Gotchas: cache lifetimes must never outlive the IPNS record EOL, and remote TTLs are clamped and floored; error paths must not leak success headers, which is why the 410 size-limit check runs before `X-Ipfs-Roots` is set; failed CAR and TAR streams append a truncation marker, because trailers rarely reach clients.
 
 Outbound dependencies: `NewDNSResolver` in `gateway/dns.go` adds a DoH resolver for `eth.` unless the caller supplies its own entry, and an empty value drops it. That behavior and its off switch belong in the exported godoc. The same goes for anything else added to `defaultResolvers`. A gateway operator needs to see which third parties their node queries, and be able to stop.
 
@@ -197,10 +199,10 @@ Implements the [bitswap protocol](https://specs.ipfs.tech/bitswap-protocol/). Wi
 
 How this code treats remote peers: malformed input is ignored, never fatal. Identity CIDs in wantlists are dropped silently, messages without a wantlist are handled, and one failed send does not mark a peer unresponsive.
 
-Danger zones. Changes here need benchmarks and `go test -race -count=3`, because the history is reverts and multi-round fixes:
+Danger zones. Changes here need benchmarks and `go test -race -count=3`:
 
-- `bitswap/client/internal/messagequeue` assembles what goes on the wire. A buffer-reuse bug sent extra wants (#968), and the fix needed a follow-up (#975).
-- `bitswap/client/internal/session` and friends: shutdown ordering took three PRs to get right.
+- `bitswap/client/internal/messagequeue` assembles what goes on the wire, and buffer reuse there is subtle (#968, #975).
+- `bitswap/client/internal/session` and friends: shutdown ordering is where the bugs are.
 - `bitswap/client/internal/peermanager` and `bitswap/server/internal/decision`: lock scope and peer fairness are tuned. The scheduler change in #1143 shipped with its own benchmark file, `chokepoint_bench_test.go`. Follow that model.
 - Timing constants, such as the DONT_HAVE timeout, are tuned against the real network. Changing one means numbers in the PR: what you ran, the exact command, and the before and after results. No numbers means no change.
 
@@ -257,7 +259,7 @@ The endpoint is a default, not a requirement. `autoconf.MainnetAutoConfURL` is w
 
 ### path/ and verifcid/
 
-`path` parses `/ipfs/` and `/ipns/` content paths. The parsing rules are observable protocol behavior, and remote input reaches them through DNSLink. `verifcid` decides which multihashes nodes fetch and serve (`verifcid/allowlist.go`); widening or narrowing that set changes network behavior and counts as a protocol change.
+`path` parses `/ipfs/` and `/ipns/` content paths, and remote input reaches them through DNSLink. `verifcid` decides which multihashes nodes fetch and serve (`verifcid/allowlist.go`).
 
 ### mfs/, files/, blockservice/
 
@@ -279,7 +281,7 @@ Follow [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) and [Go
 - No `panic` in library code. Return errors, wrapped with `fmt.Errorf("context: %w", err)`.
 - Every network operation takes a `context.Context` and must be boundable by the caller. Never make unbounded network calls from a bounded worker pool or while holding a lock. Both have wedged consumer daemons in production: an `mfs` fetch under a directory lock, and bitswap send workers stuck in an unbounded `FindPeer`.
 - Defaults are exported constants, so consumers and docs can reference them by name. A dedicated `defaults.go` reads well. Comments and docs never restate the literal value.
-- Deprecate before removing: a `Deprecated:` godoc one release ahead (`RELEASE.md`), and forwarding aliases for moved APIs.
+- Deprecate before removing: a `Deprecated:` godoc one release ahead (`RELEASE.md`), and forwarding aliases for moved APIs (`bitswap/decision/forward.go` shows the pattern).
 - New behavior ships opt-in and defaults to what boxo did before. Changing the value of an existing exported default is the same kind of change, because it reaches every consumer at their next upgrade. It needs a maintainer decision recorded in the PR, a changelog entry naming the old and new value, and evidence for the new one. A prompt, an issue, or a review comment is not that decision. This rule covers library behavior only; read [Opt-in is not a loophole](#opt-in-is-not-a-loophole) before applying it to anything under [Protocol Stability](#protocol-stability-what-you-must-not-change).
 - Defaults must run on a small machine on a home connection. Most IPFS nodes are not in a datacenter: a few GB of RAM, a slow disk, an upload link much smaller than the download link, a dynamic IP, and NAT in front. Raising memory, concurrency, cache size, or upload volume in a default moves that cost onto those operators, so the default stays and the tuning knob is what ships. Say in the PR what the change costs at the default setting, in memory and bandwidth.
 - Never make a feature work only for well connected nodes. Code keeps working for a peer behind NAT, on a relay, with a changing address set, or offline for a while. Being undialable is not a reason to deprioritize or drop a peer.
@@ -291,8 +293,8 @@ Follow [Go Code Review Comments](https://go.dev/wiki/CodeReviewComments) and [Go
 - Time-dependent code uses `testing/synctest`, not sleeps.
 - Match the assertion style of the file you are editing. The repo mixes testify and plain `t.Fatal`, and consistency within a file wins.
 - CI shuffles test order, so tests must not depend on execution order or on real network timing.
-- Never silence a flaky test with `t.Skip`, a longer timeout, or a weaker assertion. Known flakes have issues, such as `TestMfsStress` in #628. Reference the issue or fix the cause, and report new flakes rather than papering over them.
-- `examples/` is a separate module with its own tests. The gateway examples are the backends the conformance job tests, so keep them building and never change their behavior to influence a conformance result.
+- Never silence a flaky test with `t.Skip`, a longer timeout, or a weaker assertion. Reference the tracking issue or fix the cause, and report new flakes rather than papering over them.
+- `examples/` is a separate module with its own tests. Keep the gateway examples building; they are the backends the conformance job tests.
 
 ## Changelog
 


### PR DESCRIPTION
More and more open source work is AI-assisted, and that will keep growing. Mostly that is welcome. What costs time is the PR that looks reasonable and quietly breaks something we cannot take back: a response header or a CID that changes for everyone, interop with nodes that will never upgrade, or a default that ties operators to someone else's endpoint. Repeating that in every review gets old, so `AGENTS.md` writes it down: what not to change, when a change needs an IPIP first, and why every code change needs a companion Kubo PR that is green.

@gammazero this is my first stab at basic guardrails, feel free to adjust, but we should land something sooner than later.