### PR TITLE
 fix(bitswap/httpnet): bound probe traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,15 +16,21 @@ The following emojis are used to highlight certain changes:
 
 ### Added
 
+- `bitswap/network/httpnet`: `DefaultConnectFailureBackoff` constant, the wait before `Connect` re-probes an endpoint after a failed probe.
+- `bitswap/network/httpnet`: `CooldownTracker` type with `NewCooldownTracker`, `SharedCooldownTracker` and the `WithCooldownTracker` option, for controlling where per-host backoff state lives.
+
 ### Changed
 
 - ✨ `bitswap/network/httpnet`: removed the background ping loop that probed every connected HTTP peer with `GET/HEAD /ipfs/bafkqaaa` every 5 seconds for the lifetime of the process (old: fixed 5s cadence per peer, results discarded; new: no periodic probes). Idle HTTP peers generate no background traffic.
 - `bitswap/network/httpnet`: latency to HTTP peers is measured from the `Connect` probe and from real retrieval responses instead of periodic pings.
+- `bitswap/network/httpnet`: `Connect` and `Ping` honor per-host cooldowns; after a failed endpoint probe, `Connect` does not re-probe the host until `Retry-After` (when provided) or `DefaultConnectFailureBackoff` elapses (old: no backoff, re-probe on every call).
+- `bitswap/network/httpnet`: per-host cooldowns live in a process-wide registry (`SharedCooldownTracker`) so backoff deadlines survive short-lived `Network` instances (old: per-instance state, forgotten on every restart); `Network.Stop` no longer stops the registry, and `WithCooldownTracker` gives a `Network` a private one.
 
 ### Removed
 
 ### Fixed
 
+- `bitswap/network/httpnet`: message senders created while a host was in cooldown no longer treat that cooldown as permanent; the request path resumes once the cooldown expires.
 - `bitswap/network/bsnet`: peers already connected when Bitswap starts are now recognised. libp2p only reports connections opened after a notifier is registered, so a peer connected during node startup stayed invisible to Bitswap for the life of that connection, and no want was ever sent to it. Nodes with another way to find content usually masked this; nodes relying on an already-connected peer could wait forever.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The following emojis are used to highlight certain changes:
 
 ### Changed
 
+- ✨ `bitswap/network/httpnet`: removed the background ping loop that probed every connected HTTP peer with `GET/HEAD /ipfs/bafkqaaa` every 5 seconds for the lifetime of the process (old: fixed 5s cadence per peer, results discarded; new: no periodic probes). Idle HTTP peers generate no background traffic.
+- `bitswap/network/httpnet`: latency to HTTP peers is measured from the `Connect` probe and from real retrieval responses instead of periodic pings.
+
 ### Removed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The following emojis are used to highlight certain changes:
 
 ### Removed
 
+- `bitswap/network/httpnet`: HTTP 410 is no longer accepted as a successful answer to the connection probe; it was a workaround for a provider that has since shut down. 410 on real block requests still counts as a valid "content unavailable" reply.
+
 ### Fixed
 
 - `bitswap/network/httpnet`: message senders created while a host was in cooldown no longer treat that cooldown as permanent; the request path resumes once the cooldown expires.

--- a/bitswap/network/httpnet/cooldown.go
+++ b/bitswap/network/httpnet/cooldown.go
@@ -7,75 +7,125 @@ import (
 	"github.com/ipfs/boxo/bitswap/network"
 )
 
-type cooldownTracker struct {
+// cooldownSweepInterval bounds how often a write to the tracker scans for
+// expired entries.
+const cooldownSweepInterval = time.Minute
+
+// CooldownTracker is a registry of per-host backoff deadlines ("cooldowns").
+// A host enters a cooldown when it throttles or fails requests (HTTP 429,
+// 502, 503, 504, or a failed connection probe); while the cooldown lasts,
+// requests to it are skipped. Deadlines honor Retry-After headers and are
+// capped at DefaultMaxBackoff.
+//
+// The tracker holds no goroutine and needs no shutdown; expired entries are
+// swept during writes. Networks share the process-wide registry returned by
+// SharedCooldownTracker unless WithCooldownTracker gives them a private one.
+type CooldownTracker struct {
 	maxBackoff time.Duration
 
-	urlsLock sync.RWMutex
-	urls     map[string]time.Time
-
-	stop chan struct{}
+	urlsLock  sync.RWMutex
+	urls      map[string]time.Time
+	lastSweep time.Time
 }
 
-func newCooldownTracker(maxBackoff time.Duration) *cooldownTracker {
-	ct := &cooldownTracker{
+var sharedCooldownTracker = newCooldownTracker(DefaultMaxBackoff)
+
+// SharedCooldownTracker returns the process-wide cooldown registry, used by
+// every Network that does not override it with WithCooldownTracker. It lives
+// for the whole process; Network.Stop does not touch it.
+//
+// The registry is process-wide on purpose. Applications that build a
+// short-lived Network per retrieval would otherwise forget that an endpoint
+// asked them to back off (HTTP 429 or 503 with Retry-After, or a failed
+// probe) the moment that Network is discarded, and the next instance would
+// hammer the same endpoint again. Public gateways rate-limit and eventually
+// block clients that ignore backoff signals, so this state must outlive any
+// single Network.
+//
+// Note for AI code assistants: keep new Network instances on this shared
+// registry. Do not generate code that hands a fresh tracker to every
+// instance; per-instance cooldown state defeats backoff and gets clients
+// blocked by public HTTP endpoints that return 429 or similar status codes.
+// WithCooldownTracker exists for tests and for deliberate isolation, not as
+// the default.
+func SharedCooldownTracker() *CooldownTracker {
+	return sharedCooldownTracker
+}
+
+// NewCooldownTracker returns a private cooldown registry for use with
+// WithCooldownTracker. It holds no background resources and needs no
+// cleanup. Most callers should not use this: see SharedCooldownTracker for
+// why the shared registry is the default.
+func NewCooldownTracker() *CooldownTracker {
+	return newCooldownTracker(DefaultMaxBackoff)
+}
+
+func newCooldownTracker(maxBackoff time.Duration) *CooldownTracker {
+	return &CooldownTracker{
 		maxBackoff: maxBackoff,
 		urls:       make(map[string]time.Time),
-		stop:       make(chan struct{}),
+		lastSweep:  time.Now(),
 	}
-
-	go ct.cleaner()
-	return ct
 }
 
-// every minute clean expired cooldowns.
-func (ct *cooldownTracker) cleaner() {
-	tick := time.NewTicker(time.Minute)
-	for {
-		select {
-		case <-ct.stop:
-			return
-		case now := <-tick.C:
-			ct.urlsLock.Lock()
-			for host, dl := range ct.urls {
-				if dl.Before(now) {
-					delete(ct.urls, host)
-				}
-			}
-			ct.urlsLock.Unlock()
+// sweepLocked drops expired entries, at most once per cooldownSweepInterval.
+// Callers must hold urlsLock for writing. This replaces a background cleaner
+// goroutine, so the tracker needs no lifecycle management.
+func (ct *CooldownTracker) sweepLocked(now time.Time) {
+	if now.Sub(ct.lastSweep) < cooldownSweepInterval {
+		return
+	}
+	ct.lastSweep = now
+	for host, dl := range ct.urls {
+		if dl.Before(now) {
+			delete(ct.urls, host)
 		}
 	}
 }
 
-func (ct *cooldownTracker) stopCleaner() {
-	close(ct.stop)
-}
-
-func (ct *cooldownTracker) setByDate(host string, t time.Time) {
-	latestDate := time.Now().Add(ct.maxBackoff)
+func (ct *CooldownTracker) setByDate(host string, t time.Time) {
+	now := time.Now()
+	latestDate := now.Add(ct.maxBackoff)
 	if t.After(latestDate) {
 		t = latestDate
 	}
 	ct.urlsLock.Lock()
 	ct.urls[host] = t
+	ct.sweepLocked(now)
 	ct.urlsLock.Unlock()
 }
 
-func (ct *cooldownTracker) setByDuration(host string, d time.Duration) {
+func (ct *CooldownTracker) setByDuration(host string, d time.Duration) {
 	if d > ct.maxBackoff {
 		d = ct.maxBackoff
 	}
+	now := time.Now()
 	ct.urlsLock.Lock()
-	ct.urls[host] = time.Now().Add(d)
+	ct.urls[host] = now.Add(d)
+	ct.sweepLocked(now)
 	ct.urlsLock.Unlock()
 }
 
-func (ct *cooldownTracker) remove(host string) {
+// inCooldown returns the cooldown deadline for the host and whether that
+// deadline is still in the future.
+func (ct *CooldownTracker) inCooldown(host string) (time.Time, bool) {
+	ct.urlsLock.RLock()
+	dl, ok := ct.urls[host]
+	ct.urlsLock.RUnlock()
+
+	if !ok || !time.Now().Before(dl) {
+		return time.Time{}, false
+	}
+	return dl, true
+}
+
+func (ct *CooldownTracker) remove(host string) {
 	ct.urlsLock.Lock()
 	delete(ct.urls, host)
 	ct.urlsLock.Unlock()
 }
 
-func (ct *cooldownTracker) fillSenderURLs(urls []network.ParsedURL) []*senderURL {
+func (ct *CooldownTracker) fillSenderURLs(urls []network.ParsedURL) []*senderURL {
 	now := time.Now()
 	surls := make([]*senderURL, len(urls))
 	ct.urlsLock.RLock()

--- a/bitswap/network/httpnet/cooldown_test.go
+++ b/bitswap/network/httpnet/cooldown_test.go
@@ -1,0 +1,78 @@
+package httpnet
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCooldownInCooldown(t *testing.T) {
+	ct := NewCooldownTracker()
+
+	host := "gateway.example.net:443"
+
+	if _, cooling := ct.inCooldown(host); cooling {
+		t.Fatal("unset host should not be cooling")
+	}
+
+	ct.setByDuration(host, time.Second)
+	dl, cooling := ct.inCooldown(host)
+	if !cooling {
+		t.Fatal("host should be cooling")
+	}
+	if until := time.Until(dl); until <= 0 || until > time.Second {
+		t.Errorf("unexpected deadline: %s", dl)
+	}
+
+	// setByDuration caps at maxBackoff.
+	ct.setByDuration(host, time.Hour)
+	dl, _ = ct.inCooldown(host)
+	if time.Until(dl) > DefaultMaxBackoff {
+		t.Errorf("cooldown not capped at maxBackoff: %s", dl)
+	}
+
+	// setByDate caps at maxBackoff too.
+	ct.setByDate(host, time.Now().Add(time.Hour))
+	dl, _ = ct.inCooldown(host)
+	if time.Until(dl) > DefaultMaxBackoff {
+		t.Errorf("cooldown not capped at maxBackoff: %s", dl)
+	}
+
+	// A past date is not an active cooldown.
+	ct.setByDate(host, time.Now().Add(-time.Second))
+	if _, cooling := ct.inCooldown(host); cooling {
+		t.Error("past deadline should not be cooling")
+	}
+
+	ct.setByDuration(host, time.Second)
+	ct.remove(host)
+	if _, cooling := ct.inCooldown(host); cooling {
+		t.Error("removed host should not be cooling")
+	}
+}
+
+func TestCooldownSweepOnWrite(t *testing.T) {
+	ct := NewCooldownTracker()
+
+	expired := "expired.example.net:443"
+	ct.setByDate(expired, time.Now().Add(-time.Second))
+
+	// Sweeps are rate-limited; age the last one to force the next write to
+	// sweep.
+	ct.urlsLock.Lock()
+	ct.lastSweep = time.Now().Add(-2 * cooldownSweepInterval)
+	ct.urlsLock.Unlock()
+
+	ct.setByDuration("other.example.net:443", time.Second)
+
+	ct.urlsLock.RLock()
+	_, stillThere := ct.urls[expired]
+	entries := len(ct.urls)
+	ct.urlsLock.RUnlock()
+
+	if stillThere {
+		t.Error("expired entry should have been swept on write")
+	}
+	if entries != 1 {
+		t.Errorf("only the live entry should remain, have %d", entries)
+	}
+}

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -360,7 +360,7 @@ func New(host host.Host, opts ...Option) network.BitSwapNetwork {
 	}
 	htnet.client = c
 
-	pinger := newPinger(htnet, pingCid)
+	pinger := newPinger(htnet)
 	htnet.pinger = pinger
 
 	et := newErrorTracker(htnet)
@@ -403,12 +403,16 @@ func (ht *Network) Stop() {
 	})
 }
 
-// Ping triggers a ping to the given peer and returns the latency.
+// Ping sends a probe to the peer's endpoints and returns the measured
+// latency. Endpoints in cooldown are not probed; when all of them are cooling
+// down, no request is made and the result carries an error.
 func (ht *Network) Ping(ctx context.Context, p peer.ID) ping.Result {
 	return ht.pinger.ping(ctx, p)
 }
 
-// Latency returns the EWMA latency for the given peer.
+// Latency returns the EWMA latency for the given peer. The estimate is seeded
+// from the Connect probe and updated with response times of real retrieval
+// requests.
 func (ht *Network) Latency(p peer.ID) time.Duration {
 	return ht.pinger.latency(p)
 }
@@ -426,14 +430,15 @@ func (ht *Network) senderURLs(p peer.ID) []*senderURL {
 	return ht.cooldownTracker.fillSenderURLs(urls)
 }
 
-// IsHTTPPeer returns true if the peer is currently being pinged, which means
-// we are connected to it via HTTP.
+// IsConnectedToPeer returns true if the peer is in the connected registry,
+// which means Connect() found a working HTTP endpoint for it and
+// DisconnectFrom() has not been called since.
 func (ht *Network) IsConnectedToPeer(ctx context.Context, p peer.ID) bool {
 	// only answer this question while no one is connecting or
 	// disconnecting.
 	ht.ongoingConnsLock.RLock()
 	defer ht.ongoingConnsLock.RUnlock()
-	return ht.pinger.isPinging(p)
+	return ht.pinger.isConnected(p)
 }
 
 // SendMessage sends the given message to the given peer. It uses
@@ -479,12 +484,11 @@ func (ht *Network) unlockConnectingPeer(p peer.ID) {
 
 // Connect attempts setting up an HTTP connection to the given peer. The given
 // AddrInfo must include at least one HTTP endpoint for the peer. HTTP URLs in
-// AddrInfo will be tried by making an HTTP GET request to
-// "ipfs/bafyqaaa", which is the CID for an empty raw block (inlined).
-// Any completed request, regardless of the HTTP response, is considered a
-// connection success and marks this peer as "connected", setting it up to
-// handle messages and make requests. The peer will be pinged regularly to
-// collect latency measurements until DisconnectFrom() is called.
+// AddrInfo will be tried by making an HTTP request to "/ipfs/bafkqaaa", which
+// is the CID for an empty raw block (inlined). A URL works when the endpoint
+// answers in a way that shows it understood the request. On success the peer
+// is marked as "connected", setting it up to handle messages and make
+// requests, and its latency estimate is seeded from the probe round trip.
 func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	// Connect is called when finding provider records. We should avoid
 	// reconnecting all the time. We should avoid re-testing broken
@@ -536,9 +540,11 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	// that we are about to open next time with the client. We call
 	// peer.Connected() on success.
 	var workingAddrs []multiaddr.Multiaddr
+	var probeRTT time.Duration
 	supportsHead := true
 	for _, u := range urls {
 		// If head works we assume GET works too.
+		start := time.Now()
 		status, err := ht.connectToURL(ctx, pi.ID, u, "HEAD")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
@@ -551,6 +557,9 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 				continue // do not try GET, just move on.
 			}
 		} else {
+			if probeRTT == 0 {
+				probeRTT = time.Since(start)
+			}
 			workingAddrs = append(workingAddrs, u.Multiaddress)
 			continue
 		}
@@ -558,6 +567,7 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		// HEAD did not work. Try GET.
 		supportsHead = false
 
+		start = time.Now()
 		_, err = ht.connectToURL(ctx, pi.ID, u, "GET")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
@@ -565,6 +575,9 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 				return errors.Join(errs...)
 			}
 			continue
+		}
+		if probeRTT == 0 {
+			probeRTT = time.Since(start)
 		}
 		workingAddrs = append(workingAddrs, u.Multiaddress)
 	}
@@ -584,7 +597,13 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	// Record whether HEAD test passed for all urls - ignoring error
 	_ = ps.Put(pi.ID, peerstoreSupportsHeadKey, supportsHead)
 
-	ht.pinger.startPinging(p)
+	ht.pinger.markConnected(p)
+	// Seed the latency estimate from the probe, so consumers see a real
+	// value without any extra request. Real retrieval responses update it
+	// from here on.
+	if probeRTT > 0 {
+		ht.pinger.recordLatencyIfConnected(p, probeRTT)
+	}
 	ht.connEvtMgr.Connected(p)
 
 	log.Debugf("connect success to %s (supports HEAD: %t)", p, supportsHead)
@@ -650,8 +669,8 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 }
 
 // DisconnectFrom marks this peer as Disconnected in the connection event
-// manager, stops pinging for latency measurements and removes it from the
-// peerstore.
+// manager, removes it from the connected registry and forgets its recorded
+// latency.
 func (ht *Network) DisconnectFrom(ctx context.Context, p peer.ID) error {
 	ht.lockConnectingPeer(p)
 	defer ht.unlockConnectingPeer(p)
@@ -659,7 +678,7 @@ func (ht *Network) DisconnectFrom(ctx context.Context, p peer.ID) error {
 	log.Debugf("disconnecting from %s", p)
 	ht.connEvtMgr.Disconnected(p) // notify everywhere that we are going offline
 
-	ht.pinger.stopPinging(p)
+	ht.pinger.markDisconnected(p)
 	ht.errorTracker.stopTracking(p)
 
 	// coolDownTracker: we leave untouched. We want to keep

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -54,6 +54,10 @@ const (
 	DefaultMaxHTTPAddressesPerPeer       = 10
 	DefaultMaxDontHaveErrors             = 100
 	DefaultHTTPWorkers                   = 64
+	// DefaultConnectFailureBackoff is how long Connect waits before
+	// re-probing an HTTP endpoint after a failed probe, unless the endpoint
+	// requested a different wait with a Retry-After header.
+	DefaultConnectFailureBackoff = time.Minute
 )
 
 var pingCid = "bafkqaaa" // identity CID
@@ -218,6 +222,19 @@ func WithConnectEventManager(evm *network.ConnectEventManager) Option {
 	}
 }
 
+// WithCooldownTracker replaces the process-wide cooldown registry with a
+// private one made with NewCooldownTracker. Without this option, the Network
+// uses SharedCooldownTracker, and it should stay that way for anything that
+// talks to endpoints it does not operate: the shared registry is what keeps
+// backoff deadlines (Retry-After, HTTP 429 and similar) working across
+// short-lived Network instances. Use a private registry only in tests or
+// when isolating traffic on purpose.
+func WithCooldownTracker(ct *CooldownTracker) Option {
+	return func(net *Network) {
+		net.cooldownTracker = ct
+	}
+}
+
 type Network struct {
 	// NOTE: Stats must be at the top of the heap allocation to ensure 64bit
 	// alignment.
@@ -233,7 +250,7 @@ type Network struct {
 	pinger          *pinger
 	errorTracker    *errorTracker
 	requestTracker  *requestTracker
-	cooldownTracker *cooldownTracker
+	cooldownTracker *CooldownTracker
 
 	ongoingConnsLock sync.RWMutex
 	ongoingConns     map[peer.ID]struct{}
@@ -299,8 +316,11 @@ func New(host host.Host, opts ...Option) network.BitSwapNetwork {
 	reqTracker := newRequestTracker()
 	htnet.requestTracker = reqTracker
 
-	cooldownTracker := newCooldownTracker(DefaultMaxBackoff)
-	htnet.cooldownTracker = cooldownTracker
+	// Default to the process-wide registry so backoff deadlines survive
+	// this Network instance. See SharedCooldownTracker.
+	if htnet.cooldownTracker == nil {
+		htnet.cooldownTracker = SharedCooldownTracker()
+	}
 
 	netdialer := &net.Dialer{
 		// Timeout for connects to complete.
@@ -395,10 +415,14 @@ func (ht *Network) Start(receivers ...network.Receiver) {
 
 // Stop stops the connect event manager associated with this network.
 // Other methods should no longer be used after calling Stop().
+//
+// The cooldown registry is deliberately left alone: by default it is the
+// process-wide SharedCooldownTracker, which must outlive this instance so
+// backoff deadlines survive Network churn. It holds no resources that need
+// shutting down.
 func (ht *Network) Stop() {
 	ht.connEvtMgr.Stop()
 	ht.closeOnce.Do(func() {
-		ht.cooldownTracker.stopCleaner()
 		close(ht.closing)
 	})
 }
@@ -489,6 +513,9 @@ func (ht *Network) unlockConnectingPeer(p peer.ID) {
 // answers in a way that shows it understood the request. On success the peer
 // is marked as "connected", setting it up to handle messages and make
 // requests, and its latency estimate is seeded from the probe round trip.
+// Endpoints whose probe failed are not probed again until their cooldown
+// expires: the Retry-After deadline when the endpoint sent one, otherwise
+// DefaultConnectFailureBackoff.
 func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	// Connect is called when finding provider records. We should avoid
 	// reconnecting all the time. We should avoid re-testing broken
@@ -540,12 +567,24 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	// that we are about to open next time with the client. We call
 	// peer.Connected() on success.
 	var workingAddrs []multiaddr.Multiaddr
+	var cooledAddrs []multiaddr.Multiaddr
 	var probeRTT time.Duration
 	supportsHead := true
 	for _, u := range urls {
+		// Respect an ongoing cooldown for this host without making any
+		// request. The address is kept as a failover target below:
+		// senders skip it while the cooldown lasts and use it again
+		// once it lapses, instead of losing it for the lifetime of the
+		// connection.
+		if dl, cooling := ht.cooldownTracker.inCooldown(u.URL.Host); cooling {
+			errs = append(errs, fmt.Errorf("%s: host in cooldown until %s", u.Multiaddress.String(), dl))
+			cooledAddrs = append(cooledAddrs, u.Multiaddress)
+			continue
+		}
+
 		// If head works we assume GET works too.
 		start := time.Now()
-		status, err := ht.connectToURL(ctx, pi.ID, u, "HEAD")
+		status, retryAfter, err := ht.connectToURL(ctx, pi.ID, u, "HEAD")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
 			// abort if context cancelled
@@ -554,7 +593,10 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 			}
 
 			if status == http.StatusTooManyRequests {
-				continue // do not try GET, just move on.
+				// The endpoint is throttling the probe itself:
+				// back off from the host, do not try GET.
+				ht.startCooldown(u.URL.Host, retryAfter)
+				continue
 			}
 		} else {
 			if probeRTT == 0 {
@@ -568,12 +610,14 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		supportsHead = false
 
 		start = time.Now()
-		_, err = ht.connectToURL(ctx, pi.ID, u, "GET")
+		_, retryAfter, err = ht.connectToURL(ctx, pi.ID, u, "GET")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return errors.Join(errs...)
 			}
+			// Both methods failed: back off from the host.
+			ht.startCooldown(u.URL.Host, retryAfter)
 			continue
 		}
 		if probeRTT == 0 {
@@ -589,11 +633,18 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		return err
 	}
 
+	// Cooled addresses were never probed, so HEAD support cannot be
+	// assumed for the peer.
+	if len(cooledAddrs) > 0 {
+		supportsHead = false
+	}
+
 	// We have some working urls, keep the bitswap providers in case we fail over.
-	// Add the working addresses to the peerstore. Clean the others.
+	// Add the working and the cooled-but-untested addresses to the
+	// peerstore. Clean the others.
 	ps := ht.host.Peerstore()
 	ps.ClearAddrs(p)
-	ps.AddAddrs(p, workingAddrs, peerstore.PermanentAddrTTL)
+	ps.AddAddrs(p, append(workingAddrs, cooledAddrs...), peerstore.PermanentAddrTTL)
 	// Record whether HEAD test passed for all urls - ignoring error
 	_ = ps.Put(pi.ID, peerstoreSupportsHeadKey, supportsHead)
 
@@ -611,18 +662,28 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	return nil
 }
 
-// connectToURL perform a pingCid request  against the given URL using the given method. An error is returned if we interprete that the server does not understand the request (not a valid IPFS gateway that we can use for HTTP requests).  That happens if the client.Do fails, if the remote endpoint does not support HTTP/2, or if the remote endpoint errors in a way that suggests it is not a gateway. Some requests are considered successful even if they return an http error code if we can assume that the server has understood the request. The response status code is returned in any case.
-func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.ParsedURL, method string) (int, error) {
+// startCooldown registers a failed-probe cooldown for the host, honoring the
+// Retry-After deadline when the endpoint provided one.
+func (ht *Network) startCooldown(host string, retryAfter time.Time) {
+	if retryAfter.IsZero() {
+		ht.cooldownTracker.setByDuration(host, DefaultConnectFailureBackoff)
+		return
+	}
+	ht.cooldownTracker.setByDate(host, retryAfter)
+}
+
+// connectToURL perform a pingCid request  against the given URL using the given method. An error is returned if we interprete that the server does not understand the request (not a valid IPFS gateway that we can use for HTTP requests).  That happens if the client.Do fails, if the remote endpoint does not support HTTP/2, or if the remote endpoint errors in a way that suggests it is not a gateway. Some requests are considered successful even if they return an http error code if we can assume that the server has understood the request. The response status code is returned in any case, along with the Retry-After deadline when a throttling response carried one.
+func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.ParsedURL, method string) (int, time.Time, error) {
 	req, err := buildRequest(ctx, u, method, pingCid, ht.userAgent)
 	if err != nil {
 		log.Debug(err)
-		return 0, err
+		return 0, time.Time{}, err
 	}
 
 	log.Debugf("connect/ping request to %s %s %q", p, method, req.URL)
 	resp, err := ht.client.Do(req)
 	if err != nil {
-		return 0, err
+		return 0, time.Time{}, err
 	}
 	defer resp.Body.Close()
 
@@ -633,7 +694,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	if u.URL.Scheme == "https" && resp.Proto != http2proto {
 		err = fmt.Errorf("%s://%q is not using HTTP/2 (%s)", req.URL.Scheme, req.URL.Host, resp.Proto)
 		log.Warn(err)
-		return resp.StatusCode, err
+		return resp.StatusCode, time.Time{}, err
 	}
 
 	// probe success.
@@ -641,7 +702,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusGone {
 		log.Debugf("connect/ping request to %s %s succeeded: %d", p, req.URL, resp.StatusCode)
 		io.Copy(io.Discard, resp.Body) // read all body data so that connection can be reused
-		return resp.StatusCode, nil
+		return resp.StatusCode, time.Time{}, nil
 	}
 
 	if resp.StatusCode == http.StatusInternalServerError {
@@ -652,20 +713,33 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 
 		body, err := io.ReadAll(limReader)
 		if err != nil {
-			return resp.StatusCode, err
+			return resp.StatusCode, time.Time{}, err
 		}
 
 		// The endpoint understands ipld.
 		if isKnownNotFoundError(string(body)) {
 			log.Debugf("connect/ping request to %s %s succeeded despite status code (known error): %d / %s", p, req.URL, resp.StatusCode, string(body))
-			return resp.StatusCode, nil
+			return resp.StatusCode, time.Time{}, nil
+		}
+	}
+
+	// Per the path-gateway spec, throttling responses should carry
+	// Retry-After. Surface it so the caller can size the cooldown.
+	var retryAfter time.Time
+	switch resp.StatusCode {
+	case http.StatusTooManyRequests,
+		http.StatusServiceUnavailable,
+		http.StatusBadGateway,
+		http.StatusGatewayTimeout:
+		if ra, ok := parseRetryAfter(resp.Header.Get("Retry-After")); ok {
+			retryAfter = ra
 		}
 	}
 
 	log.Debugf("connect error: %d <- %q (%s)", resp.StatusCode, req.URL, p)
 	// We made a proper request and got a 5xx back.
 	// We cannot consider this a working connection.
-	return resp.StatusCode, errors.New("testCid request not understood by the server")
+	return resp.StatusCode, retryAfter, errors.New("testCid request not understood by the server")
 }
 
 // DisconnectFrom marks this peer as Disconnected in the connection event

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -651,10 +651,10 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 	ht.pinger.markConnected(p)
 	// Seed the latency estimate from the probe, so consumers see a real
 	// value without any extra request. Real retrieval responses update it
-	// from here on.
-	if probeRTT > 0 {
-		ht.pinger.recordLatencyIfConnected(p, probeRTT)
-	}
+	// from here on. Recorded unconditionally: this point is only reached
+	// after a probe succeeded, and a coarse clock may have measured that
+	// probe as zero; the recording floor turns it into a valid sample.
+	ht.pinger.recordLatencyIfConnected(p, probeRTT)
 	ht.connEvtMgr.Connected(p)
 
 	log.Debugf("connect success to %s (supports HEAD: %t)", p, supportsHead)

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -613,7 +613,7 @@ func (ht *Network) Connect(ctx context.Context, pi peer.AddrInfo) error {
 		_, retryAfter, err = ht.connectToURL(ctx, pi.ID, u, "GET")
 		if err != nil {
 			errs = append(errs, fmt.Errorf("%s: %s", u.Multiaddress.String(), err))
-			if ctxErr := ctx.Err(); ctxErr != nil {
+			if ctx.Err() != nil {
 				return errors.Join(errs...)
 			}
 			// Both methods failed: back off from the host.

--- a/bitswap/network/httpnet/httpnet.go
+++ b/bitswap/network/httpnet/httpnet.go
@@ -698,8 +698,7 @@ func (ht *Network) connectToURL(ctx context.Context, p peer.ID, u network.Parsed
 	}
 
 	// probe success.
-	// FIXME: Storacha returns 410 for our probe.
-	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusGone {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
 		log.Debugf("connect/ping request to %s %s succeeded: %d", p, req.URL, resp.StatusCode)
 		io.Copy(io.Discard, resp.Body) // read all body data so that connection can be reused
 		return resp.StatusCode, time.Time{}, nil

--- a/bitswap/network/httpnet/httpnet_test.go
+++ b/bitswap/network/httpnet/httpnet_test.go
@@ -807,6 +807,157 @@ func TestPassiveLatencySkipsThrottleStatuses(t *testing.T) {
 	}
 }
 
+func TestConnectCooldownRetryAfter(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	handler.probeStatus.Store(http.StatusTooManyRequests)
+	handler.probeRetryAfter.Store("1")
+
+	if err := connectToPeer(t, ctx, htnet, peer, srv); err == nil {
+		t.Fatal("expected connect to fail while throttled")
+	}
+	if got := handler.probes.Load(); got != 1 {
+		t.Fatalf("429 on HEAD should not be followed by GET: %d probes", got)
+	}
+
+	// A second connect within the Retry-After window makes no request.
+	err = connectToPeer(t, ctx, htnet, peer, srv)
+	if err == nil {
+		t.Fatal("expected connect to fail during cooldown")
+	}
+	if !strings.Contains(err.Error(), "cooldown") {
+		t.Errorf("expected a cooldown error, got: %s", err)
+	}
+	if got := handler.probes.Load(); got != 1 {
+		t.Errorf("connect during cooldown should not probe: %d probes", got)
+	}
+
+	// After the Retry-After deadline, connect probes again.
+	handler.probeStatus.Store(0)
+	time.Sleep(1100 * time.Millisecond)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+	if got := handler.probes.Load(); got != 2 {
+		t.Errorf("connect after cooldown should probe again: %d probes", got)
+	}
+}
+
+func TestConnectCooldownDefaultBackoff(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	handler.probeStatus.Store(http.StatusInternalServerError)
+
+	if err := connectToPeer(t, ctx, htnet, peer, srv); err == nil {
+		t.Fatal("expected connect to fail")
+	}
+	if got := handler.probes.Load(); got != 2 {
+		t.Fatalf("expected HEAD and GET probes: %d", got)
+	}
+
+	// The host is cooling down for DefaultConnectFailureBackoff: a second
+	// connect makes no request.
+	if err := connectToPeer(t, ctx, htnet, peer, srv); err == nil {
+		t.Fatal("expected connect to fail during cooldown")
+	}
+	if got := handler.probes.Load(); got != 2 {
+		t.Errorf("connect during cooldown should not probe: %d probes", got)
+	}
+
+	host := srv.Listener.Addr().String()
+	dl, cooling := htnet.cooldownTracker.inCooldown(host)
+	if !cooling {
+		t.Fatal("expected an active cooldown for the host")
+	}
+	if until := time.Until(dl); until < DefaultConnectFailureBackoff-10*time.Second || until > DefaultConnectFailureBackoff {
+		t.Errorf("cooldown should be about DefaultConnectFailureBackoff away: %s", until)
+	}
+}
+
+// A Retry-After date in the past (cached response, clock skew) must not
+// disable the backoff: the default applies instead.
+func TestConnectCooldownPastRetryAfterDate(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	handler.probeStatus.Store(http.StatusTooManyRequests)
+	handler.probeRetryAfter.Store(time.Now().Add(-time.Hour).UTC().Format(time.RFC1123))
+
+	if err := connectToPeer(t, ctx, htnet, peer, srv); err == nil {
+		t.Fatal("expected connect to fail while throttled")
+	}
+
+	dl, cooling := htnet.cooldownTracker.inCooldown(srv.Listener.Addr().String())
+	if !cooling {
+		t.Fatal("expected an active cooldown despite the past Retry-After date")
+	}
+	if until := time.Until(dl); until < DefaultConnectFailureBackoff-10*time.Second || until > DefaultConnectFailureBackoff {
+		t.Errorf("expected the default backoff, got a deadline %s away", until)
+	}
+}
+
+// An endpoint skipped only because its host was cooling stays in the
+// peerstore as a failover target for the connection's lifetime; since it was
+// never probed, HEAD support is not assumed for the peer.
+func TestConnectKeepsCooledEndpoints(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cooled := makeServer(t, 0, 0)
+	healthy := makeServer(t, 0, 0)
+
+	htnet.cooldownTracker.setByDuration(cooled.Listener.Addr().String(), time.Minute)
+
+	mustConnectToPeer(t, ctx, htnet, peer, cooled, healthy)
+
+	if addrs := htnet.host.Peerstore().Addrs(peer.ID()); len(addrs) != 2 {
+		t.Errorf("cooled endpoint should stay in the peerstore: %d addrs", len(addrs))
+	}
+	if supportsHave(htnet.host.Peerstore(), peer.ID()) {
+		t.Error("HEAD support must not be assumed for an unprobed endpoint")
+	}
+}
+
+func TestConnectHeadFallbackNotSelfGated(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	handler.probeHeadStatus.Store(http.StatusMethodNotAllowed)
+
+	// HEAD fails, the GET fallback within the same Connect must still run
+	// and succeed, and no cooldown may be written for the host.
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	if got := handler.probes.Load(); got != 2 {
+		t.Errorf("expected HEAD and GET probes: %d", got)
+	}
+	if _, cooling := htnet.cooldownTracker.inCooldown(srv.Listener.Addr().String()); cooling {
+		t.Error("no cooldown should be set when the GET fallback succeeded")
+	}
+	if supportsHave(htnet.host.Peerstore(), peer.ID()) {
+		t.Error("HEAD support should have been recorded as false")
+	}
+}
+
 func TestDisconnectFreezesProbes(t *testing.T) {
 	ctx := context.Background()
 	htnet, mn := mockNetwork(t, mockReceiver(t))
@@ -839,5 +990,126 @@ func TestDisconnectFreezesProbes(t *testing.T) {
 	}
 	if htnet.Latency(peer.ID()) <= 0 {
 		t.Error("latency should be re-seeded on reconnect")
+	}
+}
+
+func TestPingAllHostsCooling(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	probes := handler.probes.Load()
+
+	htnet.cooldownTracker.setByDuration(srv.Listener.Addr().String(), time.Minute)
+
+	res := htnet.Ping(ctx, peer.ID())
+	if !errors.Is(res.Error, errProbesInCooldown) {
+		t.Errorf("expected errProbesInCooldown, got: %v", res.Error)
+	}
+	if got := handler.probes.Load(); got != probes {
+		t.Errorf("ping during cooldown should not probe: %d -> %d", probes, got)
+	}
+}
+
+// TestCooldownSharedAcrossNetworks covers the reason the cooldown registry is
+// process-wide: an application that builds a Network per retrieval must not
+// re-probe a host that just failed, even from a brand-new instance, and
+// Network.Stop must not tear the shared registry down.
+func TestCooldownSharedAcrossNetworks(t *testing.T) {
+	ctx := context.Background()
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	handler.probeStatus.Store(http.StatusInternalServerError)
+
+	htnet1, mn1 := mockNetwork(t, mockReceiver(t))
+	peer1, err := mn1.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := connectToPeer(t, ctx, htnet1, peer1, srv); err == nil {
+		t.Fatal("expected connect to fail")
+	}
+	if got := handler.probes.Load(); got != 2 {
+		t.Fatalf("expected HEAD and GET probes: %d", got)
+	}
+
+	// Stopping the first Network must leave the shared registry running.
+	htnet1.Stop()
+
+	// A different Network in the same process inherits the cooldown: an
+	// ephemeral node must not re-probe a host that just failed.
+	htnet2, mn2 := mockNetwork(t, mockReceiver(t))
+	peer2, err := mn2.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = connectToPeer(t, ctx, htnet2, peer2, srv)
+	if err == nil {
+		t.Fatal("expected connect to fail during shared cooldown")
+	}
+	if !strings.Contains(err.Error(), "cooldown") {
+		t.Errorf("expected a cooldown error, got: %s", err)
+	}
+	if got := handler.probes.Load(); got != 2 {
+		t.Errorf("second Network should not probe during shared cooldown: %d probes", got)
+	}
+
+	// A Network with a private registry is isolated and probes again.
+	htnet3, mn3 := mockNetwork(t, mockReceiver(t), WithCooldownTracker(NewCooldownTracker()))
+	peer3, err := mn3.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := connectToPeer(t, ctx, htnet3, peer3, srv); err == nil {
+		t.Fatal("expected connect to fail")
+	}
+	if got := handler.probes.Load(); got != 4 {
+		t.Errorf("a private registry should probe independently: %d probes", got)
+	}
+}
+
+func TestSenderCooldownExpires(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := makeServer(t, 0, 1)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	nms, err := htnet.NewMessageSender(ctx, peer.ID(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ms := nms.(*httpMsgSender)
+	u := ms.urls[0]
+
+	entry := makeWantsMessage(makeCids(t, 0, 1)).Wantlist()[0]
+
+	// A pending cooldown short-circuits without a request.
+	u.cooldown.Store(time.Now().Add(time.Minute))
+	_, serr := ms.tryURL(ctx, u, entry)
+	if serr == nil || serr.Type != typeRetryLater {
+		t.Fatal("pending cooldown should return retry-later")
+	}
+
+	// An expired cooldown is cleared and the request proceeds. This is
+	// what keeps a sender created during a cooldown from treating it as
+	// permanent.
+	u.cooldown.Store(time.Now().Add(-time.Second))
+	b, serr := ms.tryURL(ctx, u, entry)
+	if serr != nil {
+		t.Fatalf("expired cooldown should not block the request: %s", serr)
+	}
+	if b == nil {
+		t.Fatal("expected a block")
+	}
+	if !u.cooldown.Load().(time.Time).IsZero() {
+		t.Error("expired cooldown snapshot should have been cleared")
 	}
 }

--- a/bitswap/network/httpnet/httpnet_test.go
+++ b/bitswap/network/httpnet/httpnet_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -200,6 +201,16 @@ func makeBlockstore(t *testing.T, start, end int) blockstore.Blockstore {
 
 type Handler struct {
 	bstore blockstore.Blockstore
+
+	// Probe instrumentation. probes counts requests for pingCid.
+	// probeStatus, when non-zero, overrides the 200 a probe answers by
+	// default; probeHeadStatus, when non-zero, overrides it for HEAD
+	// probes only. probeRetryAfter, when set, is sent as a Retry-After
+	// header on non-200 probe responses.
+	probes          atomic.Int64
+	probeStatus     atomic.Int64
+	probeHeadStatus atomic.Int64
+	probeRetryAfter atomic.Value // string
 }
 
 func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
@@ -217,7 +228,22 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	if cidstr == pingCid {
-		rw.WriteHeader(http.StatusOK)
+		h.probes.Add(1)
+		status := int(h.probeStatus.Load())
+		if r.Method == http.MethodHead {
+			if s := int(h.probeHeadStatus.Load()); s != 0 {
+				status = s
+			}
+		}
+		if status == 0 {
+			status = http.StatusOK
+		}
+		if status != http.StatusOK {
+			if ra, _ := h.probeRetryAfter.Load().(string); ra != "" {
+				rw.Header().Set("Retry-After", ra)
+			}
+		}
+		rw.WriteHeader(status)
 		return
 	}
 
@@ -254,7 +280,7 @@ func (h *Handler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	rw.Write(b.RawData())
 }
 
-func makeServer(t *testing.T, bstart, bend int) *httptest.Server {
+func makeServerAndHandler(t *testing.T, bstart, bend int) (*httptest.Server, *Handler) {
 	t.Helper()
 
 	handler := &Handler{
@@ -264,6 +290,13 @@ func makeServer(t *testing.T, bstart, bend int) *httptest.Server {
 	srv := httptest.NewUnstartedServer(handler)
 	srv.EnableHTTP2 = true
 	srv.StartTLS()
+	return srv, handler
+}
+
+func makeServer(t *testing.T, bstart, bend int) *httptest.Server {
+	t.Helper()
+
+	srv, _ := makeServerAndHandler(t, bstart, bend)
 	return srv
 }
 
@@ -674,5 +707,137 @@ func TestErrorTracking(t *testing.T) {
 	err = recv.waitDisconnected(1)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestNoBackgroundProbes is the regression guard for the removed periodic
+// ping loop: an idle connected peer must not generate any request. The sleep
+// is deliberately longer than the old 5s ping cadence.
+func TestNoBackgroundProbes(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	probes := handler.probes.Load()
+	if probes == 0 {
+		t.Fatal("Connect should have probed the endpoint")
+	}
+
+	time.Sleep(6 * time.Second)
+
+	if got := handler.probes.Load(); got != probes {
+		t.Errorf("idle connected peer generated background probes: %d -> %d", probes, got)
+	}
+}
+
+func TestConnectSeedsLatency(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := makeServer(t, 0, 0)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	if htnet.Latency(peer.ID()) <= 0 {
+		t.Error("latency should be seeded by the Connect probe")
+	}
+}
+
+func TestPassiveLatencyUpdate(t *testing.T) {
+	ctx := context.Background()
+	recv := mockReceiver(t)
+	htnet, mn := mockNetwork(t, recv)
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := makeServer(t, 0, 0)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	seed := htnet.Latency(peer.ID())
+
+	// slowCid answers with a ~2s delay, far above the probe seed, so the
+	// EWMA must move up once the response is recorded.
+	msg := makeWantsMessage([]cid.Cid{slowCid})
+	if err := htnet.SendMessage(ctx, peer.ID(), msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := recv.wait(5); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := htnet.Latency(peer.ID()); got <= seed {
+		t.Errorf("latency should grow after a slow response: seed %s, got %s", seed, got)
+	}
+}
+
+func TestPassiveLatencySkipsThrottleStatuses(t *testing.T) {
+	ctx := context.Background()
+	recv := mockReceiver(t)
+	htnet, mn := mockNetwork(t, recv)
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := makeServer(t, 0, 0)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	seed := htnet.Latency(peer.ID())
+
+	// backoffCid answers 429: a throttled response must not move the
+	// latency estimate, or short rejections would shrink DONT_HAVE
+	// timeouts.
+	msg := makeWantsMessage([]cid.Cid{backoffCid})
+	if err := htnet.SendMessage(ctx, peer.ID(), msg); err != nil {
+		t.Fatal(err)
+	}
+	if err := recv.wait(5); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := htnet.Latency(peer.ID()); got != seed {
+		t.Errorf("latency should not move on 429: seed %s, got %s", seed, got)
+	}
+}
+
+func TestDisconnectFreezesProbes(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+
+	probes := handler.probes.Load()
+
+	if err := htnet.DisconnectFrom(ctx, peer.ID()); err != nil {
+		t.Fatal(err)
+	}
+	if htnet.IsConnectedToPeer(ctx, peer.ID()) {
+		t.Error("peer should not be connected after DisconnectFrom")
+	}
+	if htnet.Latency(peer.ID()) != 0 {
+		t.Error("latency should be wiped on disconnect")
+	}
+	if got := handler.probes.Load(); got != probes {
+		t.Errorf("disconnect should not generate probes: %d -> %d", probes, got)
+	}
+
+	// Reconnecting probes again and re-seeds latency.
+	mustConnectToPeer(t, ctx, htnet, peer, srv)
+	if got := handler.probes.Load(); got != probes+1 {
+		t.Errorf("reconnect should probe again: %d -> %d", probes, got)
+	}
+	if htnet.Latency(peer.ID()) <= 0 {
+		t.Error("latency should be re-seeded on reconnect")
 	}
 }

--- a/bitswap/network/httpnet/httpnet_test.go
+++ b/bitswap/network/httpnet/httpnet_test.go
@@ -933,6 +933,29 @@ func TestConnectKeepsCooledEndpoints(t *testing.T) {
 	}
 }
 
+// A 410 on the probe is an endpoint that does not serve the probe path, not a
+// working gateway.
+func TestConnectProbe410Fails(t *testing.T) {
+	ctx := context.Background()
+	htnet, mn := mockNetwork(t, mockReceiver(t))
+	peer, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv, handler := makeServerAndHandler(t, 0, 0)
+	handler.probeStatus.Store(http.StatusGone)
+
+	if err := connectToPeer(t, ctx, htnet, peer, srv); err == nil {
+		t.Fatal("expected connect to fail on a 410 probe")
+	}
+	if got := handler.probes.Load(); got != 2 {
+		t.Errorf("expected HEAD and GET probes: %d", got)
+	}
+	if _, cooling := htnet.cooldownTracker.inCooldown(srv.Listener.Addr().String()); !cooling {
+		t.Error("failed probe should have started a cooldown")
+	}
+}
+
 func TestConnectHeadFallbackNotSelfGated(t *testing.T) {
 	ctx := context.Background()
 	htnet, mn := mockNetwork(t, mockReceiver(t))

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -192,12 +192,21 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	}
 
 	if dl := u.cooldown.Load().(time.Time); !dl.IsZero() {
-		err := fmt.Errorf("cooldown (%s): %s %q ", dl, method, u.URL)
-		log.Debug(err)
-		return nil, &senderError{
-			Type: typeRetryLater,
-			Err:  err,
+		if time.Now().Before(dl) {
+			err := fmt.Errorf("cooldown (%s): %s %q ", dl, method, u.URL)
+			log.Debug(err)
+			return nil, &senderError{
+				Type: typeRetryLater,
+				Err:  err,
+			}
 		}
+		// The deadline passed while this sender was alive. Clear the
+		// snapshot and proceed, otherwise a sender created during a
+		// cooldown treats it as permanent. CompareAndSwap, so a fresh
+		// deadline stored by a concurrent worker survives; losing the
+		// swap only lets this one request through, same as any request
+		// already in flight when a cooldown starts.
+		u.cooldown.CompareAndSwap(dl, time.Time{})
 	}
 
 	// We do not abort ongoing requests. This is known to cause "http2: server
@@ -647,6 +656,11 @@ func parseRetryAfter(ra string) (time.Time, bool) {
 	if err != nil {
 		date, err := time.Parse(time.RFC1123, ra)
 		if err != nil {
+			return time.Time{}, false
+		}
+		// A date at or before now (cached response, clock skew) is not
+		// a usable deadline; callers fall back to their own backoff.
+		if !date.After(time.Now()) {
 			return time.Time{}, false
 		}
 		return date, true

--- a/bitswap/network/httpnet/msg_sender.go
+++ b/bitswap/network/httpnet/msg_sender.go
@@ -225,6 +225,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 	log.Debugf("%d/%d %s %q", u.serverErrors.Load(), sender.opts.MaxRetries, method, req.URL)
 	atomic.AddUint64(&sender.ht.stats.MessagesSent, 1)
 	sender.ht.metrics.RequestsInFlight.Inc()
+	reqStart := time.Now()
 	resp, err := sender.ht.client.Do(req)
 	if err != nil {
 		err = fmt.Errorf("error making request to %q: %w", req.URL, err)
@@ -248,6 +249,12 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 		return nil, serr
 	}
 	defer resp.Body.Close()
+
+	// Time to response headers, comparable to the connect-probe round trip
+	// that seeds the latency estimate. Only recorded below for responses
+	// the server understood, so throttling and server errors cannot skew
+	// the estimate.
+	respLatency := time.Since(reqStart)
 
 	// Record request size
 	var buf bytes.Buffer
@@ -315,6 +322,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 			sender.ht.cooldownTracker.remove(req.URL.Host)
 			u.cooldown.Store(time.Time{})
 		}
+		sender.ht.pinger.recordLatencyIfConnected(sender.peer, respLatency)
 
 		return nil, &senderError{
 			Type: typeClient,
@@ -326,6 +334,7 @@ func (sender *httpMsgSender) tryURL(ctx context.Context, u *senderURL, entry bsm
 			sender.ht.cooldownTracker.remove(req.URL.Host)
 			u.cooldown.Store(time.Time{})
 		}
+		sender.ht.pinger.recordLatencyIfConnected(sender.peer, respLatency)
 		log.Debugf("%s %q -> %d (%d bytes)", req.Method, req.URL, statusCode, len(body))
 
 		if req.Method == http.MethodHead {

--- a/bitswap/network/httpnet/pinger.go
+++ b/bitswap/network/httpnet/pinger.go
@@ -144,6 +144,14 @@ func (pngr *pinger) recordLatency(p peer.ID, next time.Duration) {
 // the connected registry, so a sample from an in-flight request cannot
 // resurrect latency state for a peer that just disconnected.
 func (pngr *pinger) recordLatencyIfConnected(p peer.ID, next time.Duration) {
+	// Coarse monotonic clocks (Windows ticks at ~0.5ms) measure a fast
+	// round-trip over a pooled connection as zero, which downstream reads
+	// as "no latency data". Floor the sample so a measured peer never
+	// looks unmeasured.
+	if next <= 0 {
+		next = time.Millisecond
+	}
+
 	pngr.connectedLock.RLock()
 	defer pngr.connectedLock.RUnlock()
 

--- a/bitswap/network/httpnet/pinger.go
+++ b/bitswap/network/httpnet/pinger.go
@@ -11,29 +11,30 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
-// pinger pings connected hosts on regular intervals
-// and tracks their latency.
+// pinger is the registry of connected HTTP peers and their latency estimate.
+// The latency EWMA is seeded from the Connect probe and updated with response
+// times of real retrieval requests. ping sends an on-demand probe only when
+// asked.
 type pinger struct {
 	ht *Network
 
 	latenciesLock sync.RWMutex
 	latencies     map[peer.ID]time.Duration
 
-	pingsLock sync.RWMutex
-	pings     map[peer.ID]context.CancelFunc
+	connectedLock sync.RWMutex
+	connected     map[peer.ID]struct{}
 }
 
-func newPinger(ht *Network, pingCid string) *pinger {
+func newPinger(ht *Network) *pinger {
 	return &pinger{
 		ht:        ht,
 		latencies: make(map[peer.ID]time.Duration),
-		pings:     make(map[peer.ID]context.CancelFunc),
+		connected: make(map[peer.ID]struct{}),
 	}
 }
 
-// ping sends a ping packet to the first known url of the given peer and
-// returns the result with the latency for this peer. The result is also
-// recorded.
+// ping sends a probe to the known urls of the given peer and returns the
+// result with the latency for this peer. The result is also recorded.
 func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 	pi := pngr.ht.host.Peerstore().PeerInfo(p)
 	urls := network.ExtractURLsFromPeer(pi)
@@ -85,8 +86,7 @@ func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 	}
 	result.RTT = result.RTT / time.Duration(len(urls)-lenErrors)
 
-	// log.Debugf("ping latency %s %s", p, result.RTT)
-	pngr.recordLatency(p, result.RTT)
+	pngr.recordLatencyIfConnected(p, result.RTT)
 	return result
 }
 
@@ -121,54 +121,56 @@ func (pngr *pinger) recordLatency(p peer.ID, next time.Duration) {
 	pngr.latenciesLock.Unlock()
 }
 
-func (pngr *pinger) startPinging(p peer.ID) {
-	pngr.pingsLock.Lock()
-	defer pngr.pingsLock.Unlock()
+// recordLatencyIfConnected records the measurement only while the peer is in
+// the connected registry, so a sample from an in-flight request cannot
+// resurrect latency state for a peer that just disconnected.
+func (pngr *pinger) recordLatencyIfConnected(p peer.ID, next time.Duration) {
+	pngr.connectedLock.RLock()
+	defer pngr.connectedLock.RUnlock()
 
-	_, ok := pngr.pings[p]
-	if ok {
-		log.Debugf("already pinging %s", p)
+	if _, ok := pngr.connected[p]; !ok {
+		return
+	}
+	pngr.recordLatency(p, next)
+}
+
+// markConnected adds the peer to the connected registry. It is idempotent.
+func (pngr *pinger) markConnected(p peer.ID) {
+	pngr.connectedLock.Lock()
+	defer pngr.connectedLock.Unlock()
+
+	if _, ok := pngr.connected[p]; ok {
+		log.Debugf("already connected to %s", p)
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	pngr.pings[p] = cancel
-
-	log.Debugf("starting pings to %s", p)
-
-	go func(ctx context.Context, p peer.ID) {
-		ticker := time.NewTicker(5 * time.Second)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				pngr.ping(ctx, p)
-			}
-		}
-	}(ctx, p)
+	log.Debugf("marking %s as connected", p)
+	pngr.connected[p] = struct{}{}
 }
 
-func (pngr *pinger) stopPinging(p peer.ID) {
-	log.Debugf("stopping pings to %s", p)
-	pngr.pingsLock.Lock()
+// markDisconnected removes the peer from the connected registry and wipes its
+// recorded latency, so a later reconnection starts from a fresh measurement.
+// Lock order: connectedLock, then latenciesLock. recordLatencyIfConnected
+// nests the same way, so no recording path can repopulate the latency of a
+// peer once this returns.
+func (pngr *pinger) markDisconnected(p peer.ID) {
+	log.Debugf("marking %s as disconnected", p)
+	pngr.connectedLock.Lock()
 	{
-		cancel, ok := pngr.pings[p]
-		if ok {
-			cancel()
-		}
-		delete(pngr.pings, p)
+		delete(pngr.connected, p)
+
+		pngr.latenciesLock.Lock()
+		delete(pngr.latencies, p)
+		pngr.latenciesLock.Unlock()
 	}
-	pngr.pingsLock.Unlock()
-	pngr.latenciesLock.Lock()
-	delete(pngr.latencies, p)
-	pngr.latenciesLock.Unlock()
+	pngr.connectedLock.Unlock()
 }
 
-func (pngr *pinger) isPinging(p peer.ID) bool {
-	pngr.pingsLock.RLock()
-	defer pngr.pingsLock.RUnlock()
+// isConnected reports whether the peer is in the connected registry.
+func (pngr *pinger) isConnected(p peer.ID) bool {
+	pngr.connectedLock.RLock()
+	defer pngr.connectedLock.RUnlock()
 
-	_, ok := pngr.pings[p]
+	_, ok := pngr.connected[p]
 	return ok
 }

--- a/bitswap/network/httpnet/pinger.go
+++ b/bitswap/network/httpnet/pinger.go
@@ -11,6 +11,10 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 )
 
+// errProbesInCooldown is returned by ping when every endpoint of the peer is
+// in cooldown, so no probe was sent.
+var errProbesInCooldown = errors.New("all peer endpoints are in cooldown, no probe sent")
+
 // pinger is the registry of connected HTTP peers and their latency estimate.
 // The latency EWMA is seeded from the Connect probe and updated with response
 // times of real retrieval requests. ping sends an on-demand probe only when
@@ -34,7 +38,9 @@ func newPinger(ht *Network) *pinger {
 }
 
 // ping sends a probe to the known urls of the given peer and returns the
-// result with the latency for this peer. The result is also recorded.
+// result with the latency for this peer. The result is also recorded. URLs
+// whose host is in cooldown are skipped; when every url is cooling down no
+// request is made at all and the result carries errProbesInCooldown.
 func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 	pi := pngr.ht.host.Peerstore().PeerInfo(p)
 	urls := network.ExtractURLsFromPeer(pi)
@@ -44,16 +50,29 @@ func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 		}
 	}
 
+	// Do not probe hosts that asked us to back off.
+	probeURLs := make([]network.ParsedURL, 0, len(urls))
+	for _, u := range urls {
+		if _, cooling := pngr.ht.cooldownTracker.inCooldown(u.URL.Host); !cooling {
+			probeURLs = append(probeURLs, u)
+		}
+	}
+	if len(probeURLs) == 0 {
+		return ping.Result{
+			Error: errProbesInCooldown,
+		}
+	}
+
 	method := "GET"
 	if supportsHave(pngr.ht.host.Peerstore(), p) {
 		method = "HEAD"
 	}
 
-	results := make(chan ping.Result, len(urls))
-	for _, u := range urls {
+	results := make(chan ping.Result, len(probeURLs))
+	for _, u := range probeURLs {
 		go func(u network.ParsedURL) {
 			start := time.Now()
-			_, err := pngr.ht.connectToURL(ctx, p, u, method)
+			_, _, err := pngr.ht.connectToURL(ctx, p, u, method)
 			if err != nil {
 				log.Debug(err)
 				results <- ping.Result{Error: err}
@@ -67,7 +86,7 @@ func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 
 	var result ping.Result
 	var errs []error
-	for range urls {
+	for range probeURLs {
 		r := <-results
 		if r.Error != nil {
 			errs = append(errs, r.Error)
@@ -79,12 +98,12 @@ func (pngr *pinger) ping(ctx context.Context, p peer.ID) ping.Result {
 
 	lenErrors := len(errs)
 	// if all urls failed return that, otherwise ignore.
-	if lenErrors == len(urls) {
+	if lenErrors == len(probeURLs) {
 		return ping.Result{
 			Error: errors.Join(errs...),
 		}
 	}
-	result.RTT = result.RTT / time.Duration(len(urls)-lenErrors)
+	result.RTT = result.RTT / time.Duration(len(probeURLs)-lenErrors)
 
 	pngr.recordLatencyIfConnected(p, result.RTT)
 	return result

--- a/bitswap/network/httpnet/pinger_test.go
+++ b/bitswap/network/httpnet/pinger_test.go
@@ -63,6 +63,15 @@ func TestRecordLatencyIfConnected(t *testing.T) {
 	if pngr.latency(p) != time.Second {
 		t.Fatal("sample for a connected peer should be recorded")
 	}
+
+	// A zero measurement from a coarse clock is floored, not dropped: a
+	// measured peer must never look unmeasured.
+	other := peer.ID("zero-sample-peer")
+	pngr.markConnected(other)
+	pngr.recordLatencyIfConnected(other, 0)
+	if pngr.latency(other) <= 0 {
+		t.Fatal("zero sample should be floored to a positive latency")
+	}
 }
 
 func TestPingerConcurrentHammer(t *testing.T) {

--- a/bitswap/network/httpnet/pinger_test.go
+++ b/bitswap/network/httpnet/pinger_test.go
@@ -1,0 +1,128 @@
+package httpnet
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+func TestConnectionRegistry(t *testing.T) {
+	pngr := newPinger(nil)
+	p := peer.ID("test-peer")
+
+	if pngr.isConnected(p) {
+		t.Fatal("new registry should be empty")
+	}
+
+	pngr.markConnected(p)
+	pngr.markConnected(p) // idempotent
+	if !pngr.isConnected(p) {
+		t.Fatal("peer should be connected")
+	}
+
+	pngr.recordLatency(p, time.Second)
+
+	pngr.markDisconnected(p)
+	if pngr.isConnected(p) {
+		t.Error("peer should be disconnected")
+	}
+	if pngr.latency(p) != 0 {
+		t.Error("latency should be wiped on disconnect")
+	}
+}
+
+func TestRecordLatencyEWMA(t *testing.T) {
+	pngr := newPinger(nil)
+	p := peer.ID("test-peer")
+
+	pngr.recordLatency(p, time.Second)
+	if got := pngr.latency(p); got != time.Second {
+		t.Fatalf("first sample should be taken as-is: %s", got)
+	}
+
+	pngr.recordLatency(p, 2*time.Second)
+	want := time.Duration(0.9*float64(time.Second) + 0.1*float64(2*time.Second))
+	if got := pngr.latency(p); got != want {
+		t.Errorf("EWMA blend: want %s, got %s", want, got)
+	}
+}
+
+func TestRecordLatencyIfConnected(t *testing.T) {
+	pngr := newPinger(nil)
+	p := peer.ID("test-peer")
+
+	pngr.recordLatencyIfConnected(p, time.Second)
+	if pngr.latency(p) != 0 {
+		t.Fatal("sample for a non-connected peer should be dropped")
+	}
+
+	pngr.markConnected(p)
+	pngr.recordLatencyIfConnected(p, time.Second)
+	if pngr.latency(p) != time.Second {
+		t.Fatal("sample for a connected peer should be recorded")
+	}
+}
+
+func TestPingerConcurrentHammer(t *testing.T) {
+	pngr := newPinger(nil)
+	peers := []peer.ID{"a", "b", "c"}
+
+	var wg sync.WaitGroup
+	for i := range 8 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := range 500 {
+				p := peers[(i+j)%len(peers)]
+				switch j % 4 {
+				case 0:
+					pngr.markConnected(p)
+				case 1:
+					pngr.recordLatencyIfConnected(p, time.Duration(j)*time.Millisecond)
+				case 2:
+					pngr.latency(p)
+				case 3:
+					pngr.markDisconnected(p)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Whatever the interleaving, a disconnected peer keeps no latency.
+	for _, p := range peers {
+		pngr.markDisconnected(p)
+		if pngr.latency(p) != 0 {
+			t.Errorf("disconnected peer %s kept latency", p)
+		}
+	}
+}
+
+func BenchmarkRecordLatencyIfConnected(b *testing.B) {
+	pngr := newPinger(nil)
+	p := peer.ID("bench-peer")
+	pngr.markConnected(p)
+
+	stop := make(chan struct{})
+	go func() {
+		other := peer.ID("churn-peer")
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				pngr.markConnected(other)
+				pngr.markDisconnected(other)
+			}
+		}
+	}()
+	defer close(stop)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			pngr.recordLatencyIfConnected(p, time.Millisecond)
+		}
+	})
+}


### PR DESCRIPTION

## Problem

For legacy reasons, every connected HTTP peer gets probed with `GET/HEAD /ipfs/bafkqaaa` every 5 seconds for the lifetime of the process. Results are discarded, failures never slow the loop, and `Connect` re-probes failing endpoints with no memory. A single idle daemon emits ~17k requests per day per HTTP provider. The probe target and wire format are spec-defined and unchanged[^1]; the defect is frequency and lifecycle, which the spec does not constrain.

## Fix

- delete the ping loop; latency for the DONT_HAVE timeout manager is seeded from the `Connect` probe round trip and updated from time-to-headers of server-understood retrieval responses; on-demand `Ping` stays, matching bsnet
- `Connect` and `Ping` honor per-host cooldowns; a failed probe starts one from `Retry-After`[^2][^3] (past dates rejected) or the new `DefaultConnectFailureBackoff`; endpoints skipped for an active cooldown stay in the peerstore as failover targets
- cooldowns move to a process-wide `SharedCooldownTracker` so backoff survives applications that build a short-lived `Network` per retrieval; `WithCooldownTracker` opts a Network out; the tracker holds no goroutine and needs no shutdown
- expired sender cooldown snapshots no longer poison a sender for its lifetime, and the 410 probe workaround for a provider that shut down is gone

Historic conxtex: the 5s interval landed in #747 without a stated rationale, nothing consumes it on a schedule, and #918 already records that idle peers should not be pinged. An opt-in periodic pinger can come back later without API breakage, but i'm unsure we need it..

## Testing

New synctest and integration suites cover the behavior changes; `TestNoBackgroundProbes` is the regression guard for the removed loop. `go test -race -count=3 ./bitswap/network/httpnet/...` and `go test -race ./bitswap/...` pass. Companion kubo PR (branch pinned, green CI) plus ipfs-check and rainbow validation branches: to follow, linked here before merge.


Before this ships as a patch release, we need to make sure success rate remains the same: 
- [ ] staging test: https://github.com/ipshipyard/waterworks-infra/pull/1037

[^1]: [Trustless Gateway spec, dedicated probe paths](https://specs.ipfs.tech/http-gateways/trustless-gateway/#dedicated-probe-paths): defines the probe target and response; says nothing about client request frequency.
[^2]: [Path Gateway spec, Retry-After response header](https://specs.ipfs.tech/http-gateways/path-gateway/#retry-after-response-header): gateways SHOULD return Retry-After with 429, 503 and 504.
[^3]: [RFC 9110, section 10.2.3](https://httpwg.org/specs/rfc9110.html#field.retry-after): Retry-After indicates how long the user agent ought to wait before making a follow-up request.
