### PR TITLE
fix(bootstrap): skip backup peer list when no bootstrap peers configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,7 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `gateway`: `X-Ipfs-Path` values no longer carry bytes that are invalid in an HTTP field value (Section 5.5 of RFC 9110). The header used to echo raw UnixFS file names, so non-ASCII paths arrived garbled or broke strict clients; when the header is enabled, it is now omitted for such paths, which only the percent-encoded `Ipfs-Uri` can carry. [#1209](https://github.com/ipfs/boxo/pull/1209)
-- ✨ `bootstrap`: `bootstrapRound` no longer consults the backup peer list when no bootstrap peers are configured. The backup list exists only as a recovery mechanism for when configured bootstrap peers are down (see #8856); with no configured peers there is nothing to recover from, so dialing stale backup peers persisted from previous runs is skipped. This lets a caller fully disable bootstrap dialing by setting an empty peer list (for example a local-only/offline node with `Routing.Type=none`), and works with runtime overrides such as `ipfs daemon --routing=none` that do not change the config file. Nodes that configure explicit `Bootstrap` peers are unaffected. [#1213](https://github.com/ipfs/boxo/pull/1213)
-
+- `bootstrap`: the saved backup peer list is no longer dialed when no bootstrap peers are configured. [#1213](https://github.com/ipfs/boxo/pull/1213)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ The following emojis are used to highlight certain changes:
 ### Fixed
 
 - `gateway`: `X-Ipfs-Path` values no longer carry bytes that are invalid in an HTTP field value (Section 5.5 of RFC 9110). The header used to echo raw UnixFS file names, so non-ASCII paths arrived garbled or broke strict clients; when the header is enabled, it is now omitted for such paths, which only the percent-encoded `Ipfs-Uri` can carry. [#1209](https://github.com/ipfs/boxo/pull/1209)
+- ✨ `bootstrap`: `bootstrapRound` no longer consults the backup peer list when no bootstrap peers are configured. The backup list exists only as a recovery mechanism for when configured bootstrap peers are down (see #8856); with no configured peers there is nothing to recover from, so dialing stale backup peers persisted from previous runs is skipped. This lets a caller fully disable bootstrap dialing by setting an empty peer list (for example a local-only/offline node with `Routing.Type=none`), and works with runtime overrides such as `ipfs daemon --routing=none` that do not change the config file. Nodes that configure explicit `Bootstrap` peers are unaffected. [#1213](https://github.com/ipfs/boxo/pull/1213)
+
 
 ### Security
 

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -299,11 +299,21 @@ func bootstrapRound(ctx context.Context, host host.Host, cfg BootstrapConfig) er
 	// Retrieving them here makes sure we remain observant of changes to client configuration.
 	peers := cfg.BootstrapPeers()
 
-	if len(peers) > 0 {
-		numToDial -= int(peersConnect(ctx, host, peers, numToDial, true))
-		if numToDial <= 0 {
-			return nil
-		}
+	if len(peers) == 0 {
+		// No bootstrap peers are configured. The backup peer list exists only as
+		// a recovery mechanism for when configured bootstrap peers are down
+		// (see #8856). With no configured peers there is nothing to recover
+		// from, so we skip the backup list entirely. This lets a caller fully
+		// disable bootstrap dialing by setting an empty peer list (for example
+		// a local-only/offline node with Routing.Type=none), and avoids dialing
+		// stale backup peers persisted from previous runs.
+		log.Debugf("%s bootstrap skipped -- no bootstrap peers configured", id)
+		return nil
+	}
+
+	numToDial -= int(peersConnect(ctx, host, peers, numToDial, true))
+	if numToDial <= 0 {
+		return nil
 	}
 
 	if cfg.loadBackupBootstrapPeers == nil {

--- a/bootstrap/bootstrap.go
+++ b/bootstrap/bootstrap.go
@@ -300,13 +300,9 @@ func bootstrapRound(ctx context.Context, host host.Host, cfg BootstrapConfig) er
 	peers := cfg.BootstrapPeers()
 
 	if len(peers) == 0 {
-		// No bootstrap peers are configured. The backup peer list exists only as
-		// a recovery mechanism for when configured bootstrap peers are down
-		// (see #8856). With no configured peers there is nothing to recover
-		// from, so we skip the backup list entirely. This lets a caller fully
-		// disable bootstrap dialing by setting an empty peer list (for example
-		// a local-only/offline node with Routing.Type=none), and avoids dialing
-		// stale backup peers persisted from previous runs.
+		// The backup list is a fallback for when configured bootstrap peers
+		// are unreachable (ipfs/kubo#8856). With no configured peers there is
+		// nothing to fall back from.
 		log.Debugf("%s bootstrap skipped -- no bootstrap peers configured", id)
 		return nil
 	}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -260,7 +260,7 @@ func TestHasCircuitProtocol(t *testing.T) {
 // The backup list exists only as a recovery mechanism for when configured
 // bootstrap peers are down; with no configured peers there is nothing to
 // recover from, so dialing stale backup peers from previous runs would be
-// unwanted network traffic. See kubo issue #11452.
+// unwanted network traffic. See ipfs/kubo#11452.
 func TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers(t *testing.T) {
 	backupCalled := false
 	loadFunc := func(_ context.Context) []peer.AddrInfo {
@@ -272,11 +272,7 @@ func TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers(t *testing.T) {
 	bootCfg := BootstrapConfigWithPeers(nil, WithBackupPeers(loadFunc, saveFunc))
 	bootCfg.MinPeerThreshold = 2
 
-	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	peerID, err := peer.IDFromPublicKey(pub)
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -286,8 +282,7 @@ func TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = p2pHost.Close() })
 
-	_ = peerID
-	if err := bootstrapRound(context.Background(), p2pHost, bootCfg); err != nil {
+	if err := bootstrapRound(t.Context(), p2pHost, bootCfg); err != nil {
 		t.Fatalf("bootstrapRound returned error: %v", err)
 	}
 	if backupCalled {
@@ -297,7 +292,7 @@ func TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers(t *testing.T) {
 
 // TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent confirms the backup
 // list is still consulted when configured bootstrap peers fail to connect,
-// preserving the recovery mechanism from #8856.
+// preserving the recovery mechanism from ipfs/kubo#8856.
 func TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent(t *testing.T) {
 	backupCalled := false
 	loadFunc := func(_ context.Context) []peer.AddrInfo {
@@ -318,11 +313,7 @@ func TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent(t *testing.T) {
 	// Keep the round snappy: the dial will fail fast against a random peer ID.
 	bootCfg.ConnectionTimeout = 500 * time.Millisecond
 
-	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	peerID, err := peer.IDFromPublicKey(pub)
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -332,8 +323,7 @@ func TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = p2pHost.Close() })
 
-	_ = peerID
-	_ = bootstrapRound(context.Background(), p2pHost, bootCfg)
+	_ = bootstrapRound(t.Context(), p2pHost, bootCfg)
 	if !backupCalled {
 		t.Fatal("bootstrapRound did not consult the backup peer list despite configured bootstrap peers failing to connect")
 	}

--- a/bootstrap/bootstrap_test.go
+++ b/bootstrap/bootstrap_test.go
@@ -254,3 +254,87 @@ func TestHasCircuitProtocol(t *testing.T) {
 		})
 	}
 }
+
+// TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers verifies that bootstrapRound
+// does not consult the backup peer list when no bootstrap peers are configured.
+// The backup list exists only as a recovery mechanism for when configured
+// bootstrap peers are down; with no configured peers there is nothing to
+// recover from, so dialing stale backup peers from previous runs would be
+// unwanted network traffic. See kubo issue #11452.
+func TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers(t *testing.T) {
+	backupCalled := false
+	loadFunc := func(_ context.Context) []peer.AddrInfo {
+		backupCalled = true
+		return nil
+	}
+	saveFunc := func(_ context.Context, _ []peer.AddrInfo) {}
+
+	bootCfg := BootstrapConfigWithPeers(nil, WithBackupPeers(loadFunc, saveFunc))
+	bootCfg.MinPeerThreshold = 2
+
+	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerID, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2pHost, err := libp2p.New(libp2p.Identity(priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = p2pHost.Close() })
+
+	_ = peerID
+	if err := bootstrapRound(context.Background(), p2pHost, bootCfg); err != nil {
+		t.Fatalf("bootstrapRound returned error: %v", err)
+	}
+	if backupCalled {
+		t.Fatal("bootstrapRound consulted the backup peer list despite no bootstrap peers being configured")
+	}
+}
+
+// TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent confirms the backup
+// list is still consulted when configured bootstrap peers fail to connect,
+// preserving the recovery mechanism from #8856.
+func TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent(t *testing.T) {
+	backupCalled := false
+	loadFunc := func(_ context.Context) []peer.AddrInfo {
+		backupCalled = true
+		return nil
+	}
+	saveFunc := func(_ context.Context, _ []peer.AddrInfo) {}
+
+	// A fake, undialable bootstrap peer so peersConnect attempts and fails
+	// rather than short-circuiting on an empty list.
+	fakeID, err := test.RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	fakePeer := peer.AddrInfo{ID: fakeID}
+	bootCfg := BootstrapConfigWithPeers([]peer.AddrInfo{fakePeer}, WithBackupPeers(loadFunc, saveFunc))
+	bootCfg.MinPeerThreshold = 2
+	// Keep the round snappy: the dial will fail fast against a random peer ID.
+	bootCfg.ConnectionTimeout = 500 * time.Millisecond
+
+	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peerID, err := peer.IDFromPublicKey(pub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2pHost, err := libp2p.New(libp2p.Identity(priv))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = p2pHost.Close() })
+
+	_ = peerID
+	_ = bootstrapRound(context.Background(), p2pHost, bootCfg)
+	if !backupCalled {
+		t.Fatal("bootstrapRound did not consult the backup peer list despite configured bootstrap peers failing to connect")
+	}
+}


### PR DESCRIPTION
## Problem

When a node has no bootstrap peers configured (for example `Routing.Type=none` with an empty `Bootstrap` list, or `ipfs daemon --routing=none`), `bootstrapRound` still loads and dials backup peers persisted from previous runs (stored under `TempBootstrapPeersKey` in the datastore). This causes unwanted external DNS resolution and connection attempts to stale addresses every 30 seconds, even though the operator explicitly disabled routing/bootstrap. Reported in [kubo#11452](https://github.com/ipfs/kubo/issues/11452).

The backup peer list exists as a recovery mechanism for when configured bootstrap peers are down ([#8856](https://github.com/ipfs/boxo/pull/8856)). With no configured bootstrap peers, there is nothing to recover from, so consulting the backup list is the wrong behavior.

## Fix

In `bootstrapRound`, return early when `cfg.BootstrapPeers()` returns an empty list, before consulting the backup peer list. This:

- Covers `Bootstrap: null` / empty list (becomes an empty `[]peer.AddrInfo`)
- Works with `ipfs daemon --routing=none` (runtime override that does not change the config file)
- Keeps `Routing.Type=none` + explicit `Bootstrap` peers working (those nodes still dial their configured peers)
- Needs no new config option

Nodes that configure explicit `Bootstrap` peers are unaffected: the backup-list fallback still runs when those peers fail to connect.

### Behavior change

Previously, a node with default routing and an empty `Bootstrap` list would still dial backup peers. After this change it does not. This aligns behavior with operator intent: an empty `Bootstrap` list now means "no bootstrap dialing at all, including saved backup peers." This is a fix, directed by @lidel in [kubo#11453 (review)](https://github.com/ipfs/kubo/pull/11453#pullrequestreview-5127196673): *"The simplest fix is in boxo, in `bootstrap.bootstrapRound`: when `cfg.BootstrapPeers()` returns nothing, stop there instead of trying the backup list."*

## Testing

- `go build ./bootstrap/...` passes
- `go test ./bootstrap/... -count=1` passes (all existing tests green)
- `go vet ./bootstrap/...` passes
- `gofmt -l bootstrap/` clean
- Added `TestBootstrapRoundSkipsBackupWhenNoBootstrapPeers`: verifies `bootstrapRound` does not call `loadBackupBootstrapPeers` when `BootstrapPeers()` is empty
- Added `TestBootstrapRoundDialsBackupWhenBootstrapPeersPresent`: verifies the backup list is still consulted when configured bootstrap peers fail to connect, preserving the #8856 recovery mechanism

### Companion kubo PR

REQUIRED companion kubo PR: [ipfs/kubo#11453](https://github.com/ipfs/kubo/pull/11453) (reworked to pin this boxo branch, fix docs, and add a kubo-level regression test). It is a draft while this boxo PR is unmerged; kubo CI status will be reported there.

Generated with [Devin](https://devin.ai)
